### PR TITLE
support sk, an fzf workalike, for menu presentation

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -129,8 +129,9 @@ install() {
   inst_simple "${moddir}/zfsbootmenu-lib.sh" "/lib/zfsbootmenu-lib.sh" || _ret=$?
   inst_simple "${moddir}/zfsbootmenu-preview.sh" "/bin/zfsbootmenu-preview.sh" || _ret=$?
   inst_simple "${moddir}/zfs-chroot" "/bin/zfs-chroot" || _ret=$?
+  inst_simple "${moddir}/zfsbootmenu.sh" "/bin/zfsbootmenu" || _ret=$?
   inst_hook cmdline 95 "${moddir}/zfsbootmenu-parse-commandline.sh" || _ret=$?
-  inst_hook pre-mount 90 "${moddir}/zfsbootmenu.sh" || _ret=$?
+  inst_hook pre-mount 90 "${moddir}/zfsbootmenu-exec.sh" || _ret=$?
 
   if [ ${_ret} -ne 0 ]; then
     dfatal "Unable to install core ZFSBootMenu functions"

--- a/90zfsbootmenu/zfsbootmenu-exec.sh
+++ b/90zfsbootmenu/zfsbootmenu-exec.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export import_args
+export spl_hostid
+export force_import
+export read_write
+export menu_timeout
+export root
+
+# https://busybox.net/FAQ.html#job_control
+exec setsid sh -c 'exec /bin/zfsbootmenu </dev/tty1 >/dev/tty1 2>&1'

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -56,9 +56,9 @@ draw_be() {
 
   test -f "${env}" || return 130
 
-  selected="$( fzf -0 --prompt "BE > " \
+  selected="$( ${FUZZYSEL} -0 --prompt "BE > " \
     --expect=alt-k,alt-d,alt-s,alt-c,alt-r \
-    --preview-window=up:2 \
+    --preview-window="up:${PREVIEW_HEIGHT}" \
     --header="[ENTER] boot [ALT+K] kernel [ALT+D] set bootfs [ALT+S] snapshots [ALT+C] cmdline" \
     --preview="zfsbootmenu-preview.sh ${BASE} {} ${BOOTFS}" < "${env}" )"
   ret=$?
@@ -76,9 +76,9 @@ draw_kernel() {
 
   benv="${1}"
 
-  selected="$( fzf --prompt "${benv} > " --tac --expect=alt-d \
+  selected="$( ${FUZZYSEL} --prompt "${benv} > " --tac --expect=alt-d \
     --with-nth=2 --header="[ENTER] boot [ALT+D] set default [ESC] back" \
-    --preview-window=up:2 \
+    --preview-window="up:${PREVIEW_HEIGHT}" \
     --preview="zfsbootmenu-preview.sh ${BASE} ${benv} ${BOOTFS}" < "${BASE}/${benv}/kernels" )"
   ret=$?
   # shellcheck disable=SC2119
@@ -96,9 +96,9 @@ draw_snapshots() {
   benv="${1}"
 
   selected="$( zfs list -t snapshot -H -o name "${benv}" |
-    fzf --prompt "Snapshot > " --tac --expect=alt-x,alt-c,alt-d \
+    ${FUZZYSEL} --prompt "Snapshot > " --tac --expect=alt-x,alt-c,alt-d \
       --preview="zfsbootmenu-preview.sh ${BASE} ${benv} ${BOOTFS}" \
-      --preview-window=up:2 \
+      --preview-window="up:${PREVIEW_HEIGHT}" \
       --header="[ENTER] duplicate [ALT+X] clone and promote [ALT+C] clone only [ALT+D] show diff [ESC] back" )"
   ret=$?
   # shellcheck disable=SC2119
@@ -133,9 +133,9 @@ draw_diff() {
   # shellcheck disable=SC2016
   ( zfs diff -H "${snapshot}" "${diff_target}" & echo $! >&3 ) 3>/tmp/diff.pid | \
     sed "s,${mnt},," | \
-    fzf --prompt "Files > " \
+    ${FUZZYSEL} --prompt "Files > " \
       --preview="zfsbootmenu-preview.sh ${BASE} ${diff_target} ${BOOTFS}" \
-      --preview-window=up:2 \
+      --preview-window="up:${PREVIEW_HEIGHT}" \
       --bind 'esc:execute-silent( kill $( cat /tmp/diff.pid ) )+abort'
 
   test -f /tmp/diff.pid  && rm /tmp/diff.pid

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -21,8 +21,15 @@ tput reset
 
 OLDIFS="$IFS"
 
-export FZF_DEFAULT_OPTS="--layout=reverse-list --cycle \
-  --inline-info --tac"
+if command -v fzf >/dev/null 2>&1; then
+  export FUZZYSEL=fzf
+  export FZF_DEFAULT_OPTS="--layout=reverse-list --cycle --inline-info --tac"
+  export PREVIEW_HEIGHT=2
+elif command -v sk >/dev/null 2>&1; then
+  export FUZZYSEL=sk
+  export SKIM_DEFAULT_OPTIONS="--layout=reverse-list --inline-info --tac --color=16"
+  export PREVIEW_HEIGHT=3
+fi
 
 BASE="$( mktemp -d /tmp/zfs.XXXX )"
 
@@ -158,6 +165,12 @@ fi
 
 # Clear screen before a possible password prompt
 tput clear
+
+# The menu will not work if a fuzzy menu isn't available
+if [ -z "${FUZZYSEL}" ]; then
+  emergency_shell "no fuzzy menu available"
+  exit
+fi
 
 BE_SELECTED=0
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ zfsbootmenu is implemented as a Dracut module to provide an experience similar t
 At this point, you'll be booting into your OS-managed kernel and initramfs, along with any arguments needed to correctly boot your system.
 
 This tool makes uses of the following additional software:
- * [fzf](https://github.com/junegunn/fzf)
+ * [fzf](https://github.com/junegunn/fzf) or [skim](https://github.com/lotabout/skim)
  * [kexec-tools](https://github.com/horms/kexec-tools)
  * [mbuffer](http://www.maier-komor.de/mbuffer.html)
  * [Linux Kernel](https://www.kernel.org)
@@ -158,7 +158,7 @@ The [zfsbootmenu(7)](pod/zfsbootmenu.7.pod#zfs-properties) manual page describes
 
 `bin/generate-zbm` can be used to create an initramfs on your system. It ships with void-specific defaults in [etc/zfsbootmenu/config.yaml](etc/zfsbootmenu/config.yaml). To create an initramfs, the following additional tools/libraries will need to be available on your system:
 
- * [fzf](https://github.com/junegunn/fzf)
+ * [fzf](https://github.com/junegunn/fzf) or [skim](https://github.com/lotabout/skim)
  * [kexec-tools](https://github.com/horms/kexec-tools)
  * [mbuffer](http://www.maier-komor.de/mbuffer.html)
  * [perl Config::IniFiles](https://metacpan.org/pod/Config::IniFiles)


### PR DESCRIPTION
fzf, while excellent, has limited support for older architectures due to
Go. skim is flag-compatible with fzf and supports more architectures.
Supporting this in ZFSBootMenu required the following changes:

- Setup a proper TTY; this is done by creating a stub pre-mount hook
  that is sourced into the Dracut master shell. Required variables are
  exported and then a new shell is exec'd that launches the master
  bootmenu script.

- Export defaults for skim and fzf depending on which is found

- Work around a bug in skim where the preview height is off by -1