### PR TITLE
Drop import_args variable and let import_pool build its own arguments

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-exec.sh
+++ b/90zfsbootmenu/zfsbootmenu-exec.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-export import_args
 export spl_hostid
 export force_import
 export read_write
@@ -8,4 +7,4 @@ export menu_timeout
 export root
 
 # https://busybox.net/FAQ.html#job_control
-exec setsid sh -c 'exec /bin/zfsbootmenu </dev/tty1 >/dev/tty1 2>&1'
+exec setsid bash -c 'exec /bin/zfsbootmenu </dev/tty1 >/dev/tty1 2>&1'

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -554,11 +554,27 @@ find_online_pools() {
 # returns: 0 on success, 1 on failure
 
 import_pool() {
-  local pool
+  local pool import_args
+
   pool="${1}"
 
+  # Import /never/ mounts filesystems
+  import_args=( "-N" )
+
+  # shellcheck disable=SC2154
+  if [ "${force_import}" ]; then
+    import_args+=( "-f" )
+  fi
+
+  # shellcheck disable=SC2154
+  if [ "${read_write}" ]; then
+    import_args+=( "-o" "readonly=on" )
+  else
+    import_args+=( "-o" "readonly=off" )
+  fi
+
   # shellcheck disable=SC2086
-  status="$( zpool import ${import_args} ${pool} )"
+  status="$( zpool import "${import_args[@]}" ${pool} )"
   ret=$?
 
   return ${ret}
@@ -641,9 +657,8 @@ set_rw_pool() {
     fi
   fi
 
-  import_args="${import_args/readonly=on/readonly=off}"
   if export_pool "${pool}" ; then
-    import_pool "${pool}"
+    read_write=yes import_pool "${pool}"
     return $?
   fi
 

--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -18,16 +18,16 @@ fi
 
 # Force import pools only when explicitly told to do so
 if getargbool 0 force_import ; then
+  # shellcheck disable=SC2034
+  force_import="yes"
   info "ZFSBootMenu: Enabling force import of ZFS pools"
-  import_args="-o readonly=on -f -N"
-else
-  import_args="-o readonly=on -N"
 fi
 
 # Import pools by default in read-write mode
 if getargbool 0 read_write ; then
+  # shellcheck disable=SC2034
+  read_write="yes"
   info "ZFSBootMenu: Enabling read-write ZFS pool import"
-  import_args="${import_args/readonly=on/readonly=off}"
 fi
 
 # Set a menu timeout, to allow immediate booting


### PR DESCRIPTION
Rather than define `import_args` in `zfsbootmenu-parse-commandline.sh`
based on the value of `force_import` and `read_write` on the ZBM kernel
command line, the parser just defines `force_import` and `read_write`
variables based on these arguments. The `import_pool` function uses
these variables directly to determine the right command-line arguments
to pass to `zpool import`.

This is a bit cleaner and allows for a construct like

    read_write=yes import_pool zpool

to force rw imports rathern than rewriting `import_args`. Note that
passing `read_write=yes` in that call does not override the value in the
environment, so other calls to `import_pool` will fall back to expected
behavior.