### PR TITLE
Further compartmentalize testing

### DIFF
--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -30,6 +30,8 @@ use boolean;
 
 use Storable qw( dclone );
 
+use constant REFARRAY => ref [];
+
 sub versionedKernel;
 sub latestKernel;
 sub createInitramfs;
@@ -472,8 +474,17 @@ sub createInitramfs {
 
   my $output_file = join( '/', $temp, "zfsbootmenu" );
   my @cmd         = ( qw(dracut -q -f --confdir), $runConf{confd}, $output_file, qw(--kver), $kver, );
-  my @output      = execute(@cmd);
-  my $status      = pop(@output);
+
+  if ( defined $config{Global}{DracutFlags} and ref $config{Global}{DracutFlags} eq REFARRAY ) {
+    foreach my $flag ( @{ $config{Global}{DracutFlags} } ) {
+      push( @cmd, $flag );
+    }
+  } else {
+    push( @cmd, $config{Global}{DracutFlags} );
+  }
+
+  my @output = execute(@cmd);
+  my $status = pop(@output);
   if ( $status eq 0 ) {
     return $output_file;
   } else {

--- a/pod/generate-zbm.5.pod
+++ b/pod/generate-zbm.5.pod
@@ -34,6 +34,10 @@ In general, this should be the location of your EFI System Partition. B<generate
 
 A specific ZFSBootMenu version string to use in producing images. In the string, the value I<%{current}> will be replaced with the release version of ZFSBootMenu. The default value is simply I<%{current}>.
 
+=item B<DracutFlags>
+
+An array of additional arguments that will be passed to B<dracut> when generating an initramfs.
+
 =back
 
 =head2 Kernel

--- a/testing/.gitignore
+++ b/testing/.gitignore
@@ -5,3 +5,4 @@ vmlinuz*
 vmlinux*
 local.yaml
 .config
+modules.d

--- a/testing/.gitignore
+++ b/testing/.gitignore
@@ -6,3 +6,4 @@ vmlinux*
 local.yaml
 .config
 modules.d
+dracut.conf.d

--- a/testing/README.md
+++ b/testing/README.md
@@ -26,7 +26,7 @@ Then run as your local user `./setup.sh -ymc` to:
 * Create a local dracut.conf.d configuration directory (`dracut.conf.d`) with a default configuration file
 * Create a local dracut modules directory (`modules.d`) with symlinks to all of the system modules, and a symlink to the `90zfsbootmenu` directory in the current git checkout.
 
-These options can be individually executed if you need to re:qset any single portion of your testing environment.
+These options can be individually executed if you need to reset any single portion of your testing environment.
 
 The root password in the test installation will be set to `zfsbootmenu`.
 

--- a/testing/README.md
+++ b/testing/README.md
@@ -10,7 +10,7 @@ The testing environment setup and runtime depends on the following tools:
 
 # Creating a ZFSBootMenu Test Pool for QEMU
 
-First, run (as root) `./setup.sh -i` to:
+First, run `./setup.sh -a` to:
 
 * Create a test pool
   1. Create a 1GB RAW image file,
@@ -19,14 +19,15 @@ First, run (as root) `./setup.sh -i` to:
   4. Install Void base-minimal onto the pool,
   5. Configure the installation, and
   6. Set the `bootfs` property of `ztest`.
-
-Then run as your local user `./setup.sh -ymc` to:
-
 * Create a local generate-zbm configuration file (`local.yaml`)
-* Create a local dracut.conf.d configuration directory (`dracut.conf.d`) with a default configuration file
-* Create a local dracut modules directory (`modules.d`) with symlinks to all of the system modules, and a symlink to the `90zfsbootmenu` directory in the current git checkout.
+* Create a local dracut.conf.d configuration directory (`dracut.conf.d`) with a
+  default configuration file
+* Create a local dracut modules directory (`modules.d`) with symlinks to all of
+  the system modules, and a symlink to the `90zfsbootmenu` directory in the
+  current git checkout.
 
-These options can be individually executed if you need to reset any single portion of your testing environment.
+These options can be individually executed if you need to reset any single
+portion of your testing environment.
 
 The root password in the test installation will be set to `zfsbootmenu`.
 
@@ -37,6 +38,7 @@ user, but make sure your user is a member of the `kvm` group if you wish to
 leverate `KVM`.
 
 The following defaults can be set to a local default in the `.config`:
+
 ```
 DRIVE="format=raw,file=zfsbootmenu-pool.img"
 INITRD="initramfs-bootmenu.img"
@@ -47,4 +49,6 @@ APPEND="loglevel=7 timeout=5 zfsbotmenu:POOL=ztest"
 ```
 
 The ZFSBootMenu kernel command line (specified in the `APPEND` variable) can be
-overridden per run by passing an optional `-a` argument to `./run.sh`. The `-n` argument can be used to skip image regeneration, allowing you to boot the existing initramfs.
+overridden per run by passing an optional `-a` argument to `./run.sh`. The `-n`
+argument can be used to skip image regeneration, allowing you to boot the
+existing initramfs.

--- a/testing/README.md
+++ b/testing/README.md
@@ -10,13 +10,23 @@ The testing environment setup and runtime depends on the following tools:
 
 # Creating a ZFSBootMenu Test Pool for QEMU
 
-First, run (as root) `./setup.sh` to:
-1. Create a 1GB RAW image file,
-2. Attach it to the `loop0` loopback device,
-3. Create a GPT label and a ZFS pool `ztest`,
-4. Install Void base-minimal onto the pool,
-5. Configure the installation, and
-6. Set the `bootfs` property of `ztest`.
+First, run (as root) `./setup.sh -i` to:
+
+* Create a test pool
+  1. Create a 1GB RAW image file,
+  2. Attach it to the `loop0` loopback device,
+  3. Create a GPT label and a ZFS pool `ztest`,
+  4. Install Void base-minimal onto the pool,
+  5. Configure the installation, and
+  6. Set the `bootfs` property of `ztest`.
+
+Then run as your local user `./setup.sh -ymc` to:
+
+* Create a local generate-zbm configuration file (`local.yaml`)
+* Create a local dracut.conf.d configuration directory (`dracut.conf.d`) with a default configuration file
+* Create a local dracut modules directory (`modules.d`) with symlinks to all of the system modules, and a symlink to the `90zfsbootmenu` directory in the current git checkout.
+
+These options can be individually executed if you need to re:qset any single portion of your testing environment.
 
 The root password in the test installation will be set to `zfsbootmenu`.
 

--- a/testing/run.sh
+++ b/testing/run.sh
@@ -47,7 +47,9 @@ else
   # Create our initramfs
   [ -f "${KERNEL}" ] && rm "${KERNEL}"
   [ -f "${INITRD}" ] && rm "${INITRD}"
-  ../bin/generate-zbm -c local.yaml
+  #shellcheck disable=SC2164
+  cd modules.d
+  ../../bin/generate-zbm -c ../local.yaml
 fi
 
 # Boot it up

--- a/testing/run.sh
+++ b/testing/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+TESTING_DIR="$( pwd )"
 
 # Support x86_64 and ppc64(le)
 case "$(uname -m)" in
@@ -41,15 +42,23 @@ done
 
 if ((NOCREATE)) ; then
   # Don't create anything
-  [ -f "${KERNEL}" ] || echo "Missing kernel: ${KERNEL}" && exit
-  [ -f "${INITRD}" ] || echo "Missing initramfs: ${INITRD}" && exit
+  if [ ! -f "${KERNEL}" ] ; then
+    echo "Missing kernel: ${KERNEL}"
+    exit
+  fi
+  if [ ! -f "${INITRD}" ] ; then
+    echo "Missing initramfs: ${INITRD}"
+    exit
+  fi
 else
   # Create our initramfs
   [ -f "${KERNEL}" ] && rm "${KERNEL}"
   [ -f "${INITRD}" ] && rm "${INITRD}"
   #shellcheck disable=SC2164
-  cd modules.d
+  cd "${TESTING_DIR}/modules.d"
   ../../bin/generate-zbm -c ../local.yaml
+  #shellcheck disable=SC2164
+  cd "${TESTING_DIR}"
 fi
 
 # Boot it up

--- a/testing/setup.sh
+++ b/testing/setup.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Setup our dracut directory
+test -d modules.d || mkdir modules.d
+for mod in $( find /usr/lib/dracut/modules.d/ -type d | grep -v zfsbootmenu ); do
+  TARGET="modules.d/$( basename "${mod}" )"
+  test -L "${TARGET}" || ln -s "${mod}" "${TARGET}"
+done
+
+test -L "modules.d/90zfsbootmenu" || ln -s "../../90zfsbootmenu" "modules.d/90zfsbootmenu"
+
 MNT="$( mktemp -d )"
 LOOP="$( losetup -f )"
 
@@ -81,4 +90,5 @@ if [ ! -f local.yaml ]; then
   yq-go w -i local.yaml Components.Versions false
   yq-go w -i local.yaml Global.ManageImages true
   yq-go d -i local.yaml Global.BootMountPoint
+  yq-go w -i local.yaml Global.DracutFlags[+] -- "--local"
 fi

--- a/testing/setup.sh
+++ b/testing/setup.sh
@@ -3,7 +3,22 @@ YAML=0
 MODULES=0
 IMAGE=0
 
-while getopts "ymi" opt; do
+usage() {
+  cat <<EOF
+Usage: $0 [options]
+  -y  Create local.yaml
+  -m  Create modules.d
+  -i  Create a test VM image
+  -a  Perform all setup options
+EOF
+}
+
+if [ $# -eq 0 ]; then
+  usage
+  exit
+fi
+
+while getopts "ymia" opt; do
   case "${opt}" in
     y)
       YAML=1
@@ -14,6 +29,14 @@ while getopts "ymi" opt; do
     i)
       IMAGE=1
       ;;
+    a)
+      YAML=1
+      MODULES=1
+      IMAGE=1
+      ;;
+    \?)
+      usage
+      exit
   esac
 done
 

--- a/testing/setup.sh
+++ b/testing/setup.sh
@@ -78,6 +78,8 @@ fi
 
 # Create an image
 if ((IMAGE)) ; then
+  SHELL=/bin/bash sudo -s <<"EOF"
+
 	MNT="$( mktemp -d )"
 	LOOP="$( losetup -f )"
 
@@ -151,4 +153,5 @@ if ((IMAGE)) ; then
 	losetup -d "${LOOP}"
 
 	chown "$( stat -c %U . ):$( stat -c %G . )" zfsbootmenu-pool.img
+EOF
 fi

--- a/testing/setup.sh
+++ b/testing/setup.sh
@@ -1,94 +1,122 @@
 #!/bin/bash
+YAML=0
+MODULES=0
+IMAGE=0
 
-# Setup our dracut directory
-test -d modules.d || mkdir modules.d
-for mod in $( find /usr/lib/dracut/modules.d/ -type d | grep -v zfsbootmenu ); do
-  TARGET="modules.d/$( basename "${mod}" )"
-  test -L "${TARGET}" || ln -s "${mod}" "${TARGET}"
+while getopts "ymi" opt; do
+  case "${opt}" in
+    y)
+      YAML=1
+      ;;
+    m)
+      MODULES=1
+      ;;
+    i)
+      IMAGE=1
+      ;;
+  esac
 done
 
-test -L "modules.d/90zfsbootmenu" || ln -s "../../90zfsbootmenu" "modules.d/90zfsbootmenu"
+if ((MODULES)) ; then
+# Setup our dracut directory
+  echo "Creating local modules.d/"
+  test -d modules.d || mkdir modules.d
+  for mod in $( find /usr/lib/dracut/modules.d/ -type d | grep -v zfsbootmenu ); do
+    TARGET="modules.d/$( basename "${mod}" )"
+    test -L "${TARGET}" || ln -s "${mod}" "${TARGET}"
+  done
 
-MNT="$( mktemp -d )"
-LOOP="$( losetup -f )"
+  test -L "modules.d/90zfsbootmenu" || ln -s "../../90zfsbootmenu" "modules.d/90zfsbootmenu"
 
-qemu-img create zfsbootmenu-pool.img 1G
-
-losetup "${LOOP}" zfsbootmenu-pool.img
-kpartx -u "${LOOP}"
-
-echo 'label: gpt' | sfdisk "${LOOP}"
-zpool create -f \
- -O compression=lz4 \
- -O acltype=posixacl \
- -O xattr=sa \
- -O relatime=on \
- -o autotrim=on \
- -o cachefile=none \
- -m none ztest "${LOOP}"
-
-zfs snapshot -r ztest@barepool
-
-zfs create -o mountpoint=none ztest/ROOT
-zfs create -o mountpoint=/ -o canmount=noauto ztest/ROOT/void
-
-zfs snapshot -r ztest@barebe
-
-zfs set org.zfsbootmenu:commandline="spl_hostid=$( hostid ) ro quiet" ztest/ROOT
-zpool set bootfs=ztest/ROOT/void ztest
-
-zpool export ztest
-zpool import -R "${MNT}" ztest
-zfs mount ztest/ROOT/void
-
-case "$(uname -m)" in
-  ppc64le)
-    URL="https://mirrors.servercentral.com/void-ppc/current"
-    ;;
-  x86_64)
-    URL="https://mirrors.servercentral.com/voidlinux/current"
-    ;;
-esac
-
-# https://github.com/project-trident/trident-installer/blob/master/src-sh/void-install-zfs.sh#L541
-mkdir -p "${MNT}/var/db/xbps/keys"
-cp /var/db/xbps/keys/*.plist "${MNT}/var/db/xbps/keys/."
-
-mkdir -p "${MNT}/etc/xbps.d"
-cp /etc/xbps.d/*.conf "${MNT}/etc/xbps.d/."
-
-# /etc/runit/core-services/03-console-setup.sh depends on loadkeys from kbd
-# /etc/runit/core-services/05-misc.sh depends on ip from iproute2
-xbps-install -y -S -M -r "${MNT}" --repository="${URL}" \
-  base-minimal dracut ncurses-base kbd iproute2
-
-cp /etc/hostid "${MNT}/etc/"
-cp /etc/resolv.conf "${MNT}/etc/"
-cp /etc/rc.conf "${MNT}/etc/"
-
-mount -t proc proc "${MNT}/proc"
-mount -t sysfs sys "${MNT}/sys"
-mount -B /dev "${MNT}/dev"
-mount -t devpts pts "${MNT}/dev/pts"
-
-zfs snapshot -r ztest@pre-chroot
-
-cp chroot.sh "${MNT}/root"
-chroot "${MNT}" /root/chroot.sh
-
-umount -R "${MNT}" && rmdir "${MNT}"
-
-zpool export ztest
-losetup -d "${LOOP}"
-
-chown "$( stat -c %U . ):$( stat -c %G . )" zfsbootmenu-pool.img
+  test -d "dracut.conf.d" || cp -Rp ../etc/zfsbootmenu/dracut.conf.d .
+fi
 
 # Setup a local config file
-if [ ! -f local.yaml ]; then
+if ((YAML)) ; then
+  echo "Configuring local.yaml"
   cp ../etc/zfsbootmenu/config.yaml local.yaml
   yq-go w -i local.yaml Components.ImageDir "$( pwd )"
   yq-go w -i local.yaml Components.Versions false
   yq-go w -i local.yaml Global.ManageImages true
-  yq-go d -i local.yaml Global.BootMountPoint
   yq-go w -i local.yaml Global.DracutFlags[+] -- "--local"
+  yq-go w -i local.yaml Global.DracutConfDir "$( pwd )/dracut.conf.d"
+  yq-go d -i local.yaml Global.BootMountPoint
+  yq-go r -P -C local.yaml
+fi
+
+# Create an image
+if ((IMAGE)) ; then
+	MNT="$( mktemp -d )"
+	LOOP="$( losetup -f )"
+
+	qemu-img create zfsbootmenu-pool.img 1G
+
+	losetup "${LOOP}" zfsbootmenu-pool.img
+	kpartx -u "${LOOP}"
+
+	echo 'label: gpt' | sfdisk "${LOOP}"
+	zpool create -f \
+	 -O compression=lz4 \
+	 -O acltype=posixacl \
+	 -O xattr=sa \
+	 -O relatime=on \
+	 -o autotrim=on \
+	 -o cachefile=none \
+	 -m none ztest "${LOOP}"
+
+	zfs snapshot -r ztest@barepool
+
+	zfs create -o mountpoint=none ztest/ROOT
+	zfs create -o mountpoint=/ -o canmount=noauto ztest/ROOT/void
+
+	zfs snapshot -r ztest@barebe
+
+	zfs set org.zfsbootmenu:commandline="spl_hostid=$( hostid ) ro quiet" ztest/ROOT
+	zpool set bootfs=ztest/ROOT/void ztest
+
+	zpool export ztest
+	zpool import -R "${MNT}" ztest
+	zfs mount ztest/ROOT/void
+
+	case "$(uname -m)" in
+	  ppc64le)
+	    URL="https://mirrors.servercentral.com/void-ppc/current"
+	    ;;
+	  x86_64)
+	    URL="https://mirrors.servercentral.com/voidlinux/current"
+	    ;;
+	esac
+
+	# https://github.com/project-trident/trident-installer/blob/master/src-sh/void-install-zfs.sh#L541
+	mkdir -p "${MNT}/var/db/xbps/keys"
+	cp /var/db/xbps/keys/*.plist "${MNT}/var/db/xbps/keys/."
+
+	mkdir -p "${MNT}/etc/xbps.d"
+	cp /etc/xbps.d/*.conf "${MNT}/etc/xbps.d/."
+
+	# /etc/runit/core-services/03-console-setup.sh depends on loadkeys from kbd
+	# /etc/runit/core-services/05-misc.sh depends on ip from iproute2
+	xbps-install -y -S -M -r "${MNT}" --repository="${URL}" \
+	  base-minimal dracut ncurses-base kbd iproute2
+
+	cp /etc/hostid "${MNT}/etc/"
+	cp /etc/resolv.conf "${MNT}/etc/"
+	cp /etc/rc.conf "${MNT}/etc/"
+
+	mount -t proc proc "${MNT}/proc"
+	mount -t sysfs sys "${MNT}/sys"
+	mount -B /dev "${MNT}/dev"
+	mount -t devpts pts "${MNT}/dev/pts"
+
+	zfs snapshot -r ztest@pre-chroot
+
+	cp chroot.sh "${MNT}/root"
+	chroot "${MNT}" /root/chroot.sh
+
+	umount -R "${MNT}" && rmdir "${MNT}"
+
+	zpool export ztest
+	losetup -d "${LOOP}"
+
+	chown "$( stat -c %U . ):$( stat -c %G . )" zfsbootmenu-pool.img
 fi

--- a/testing/setup.sh
+++ b/testing/setup.sh
@@ -2,12 +2,14 @@
 YAML=0
 MODULES=0
 IMAGE=0
+CONFD=0
 
 usage() {
   cat <<EOF
 Usage: $0 [options]
   -y  Create local.yaml
   -m  Create modules.d
+  -c  Create dracut.conf.d
   -i  Create a test VM image
   -a  Perform all setup options
 EOF
@@ -18,7 +20,7 @@ if [ $# -eq 0 ]; then
   exit
 fi
 
-while getopts "ymia" opt; do
+while getopts "ymcai" opt; do
   case "${opt}" in
     y)
       YAML=1
@@ -26,12 +28,16 @@ while getopts "ymia" opt; do
     m)
       MODULES=1
       ;;
+    c)
+      CONFD=1
+      ;;
     i)
       IMAGE=1
       ;;
     a)
       YAML=1
       MODULES=1
+      CONFD=1
       IMAGE=1
       ;;
     \?)
@@ -50,7 +56,10 @@ if ((MODULES)) ; then
   done
 
   test -L "modules.d/90zfsbootmenu" || ln -s "../../90zfsbootmenu" "modules.d/90zfsbootmenu"
+fi
 
+if ((CONFD)) ; then
+  echo "Creating dracut.conf.d"
   test -d "dracut.conf.d" || cp -Rp ../etc/zfsbootmenu/dracut.conf.d .
 fi
 


### PR DESCRIPTION
The current testing tooling utilizes system-wide Dracut and generate-zbm configuration files. This is an attempt to entirely decouple testing/ from the host OS.

* Create a modules.d directory with symlinks to system-wide Dracut modules, and `90zfsbootmenu` from the git checkout
* Add a new configuration option to `config.yaml` / `generate-zbm` allowing any additional arguments to be passed to Dracut. 
* Copy `config.yaml` and configure it for local use
* Create a new `dracut.conf.d` directory in place of `/etc/zfsbootmenu/dracut.conf.d` and populate it with a default `zfsbootmenu.conf` configuration file
* Add a help section to `setup.sh`, along with handlers for individual pieces (config.yaml, dracut.conf.d, modules.d, zpool image)

The current flaw with this is that `./setup.sh -i` should be run as root, and `./setup.sh -ymc` should be run as the local user.