### PR TITLE
Simplify handling of BE command lines, use in previews

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-preview.sh
+++ b/90zfsbootmenu/zfsbootmenu-preview.sh
@@ -10,22 +10,20 @@ BLUE='\033[0;34m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
+# shellcheck disable=SC1091
+test -f /lib/zfsbootmenu-lib.sh && source /lib/zfsbootmenu-lib.sh
+
 while IFS= read -r line
 do
   selected_kernel="${line}"
 done < "${BASE}/${ENV}/default_kernel"
 
-if [ -f "${BASE}/default_args" ]
-then
-  ARGS="${BASE}/default_args"
-else
-  ARGS="${BASE}/${ENV}/default_args"
-fi
+BE_ARGS="$( load_be_cmdline "${ENV}" )"
 
 while IFS= read -r line
 do
   selected_arguments="${line}"
-done < "${ARGS}"
+done <<< "${BE_ARGS}"
 
 if [[ "${BOOTFS}" =~ ${ENV} ]]; then
   selected_env_str="${ENV} (default) - ${selected_kernel}"

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -333,21 +333,15 @@ while true; do
         echo ""
         zfsbootmenu-preview.sh "${BASE}" "${selected_be}" "${BOOTFS}"
 
-        if [ -f "${BASE}/default_args" ]
-        then
-          ARGS="${BASE}/default_args"
-        else
-          ARGS="${BASE}/${selected_be}/default_args"
-        fi
-
-        while IFS= read -r line
-        do
+        BE_ARGS="$( load_be_cmdline "${selected_be}" )"
+        while IFS= read -r line; do
           def_args="${line}"
-        done < "${ARGS}"
+        done <<< "${BE_ARGS}"
+
         echo -e "\nNew kernel command line"
         read -r -e -i "${def_args}" -p "> " cmdline
         if [ -n "${cmdline}" ] ; then
-          echo "${cmdline}" > "${BASE}/default_args"
+          echo "${cmdline}" > "${BASE}/cmdline"
         fi
         ;;
     esac


### PR DESCRIPTION
`find_kernel_args` has been split into `preload_be_cmdline` and `load_be_cmdline`. The `preload_be_cmdline` function reads command-line arguments from a ZFS filesystem or the `/etc/default/{zfsbootmenu,grub}` files therein and stores the command line to `${BASE}/${BE}/cmdline` for a currently selected boot environment `${BE}`.

The `load_be_cmdline` only prints the contents of `${BASE}/cmdline` if it exists; otherwise, it will attempt to load the contents of `${BASE}/${BE}/cmdline` if that file exists (falling back to some generic default when the file does not exist) and attempt to remove any `resume` parameters and add a `noresume` parameter if a pool was mounted read-write in noresume mode.

Tested lightly in the new qemu testbed, with manual addition of a `noresume` trigger from an emergency shell.