### PR TITLE
Allow ctrl-c to be used during user input

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -131,6 +131,7 @@ install() {
   inst_simple "${moddir}/zfsbootmenu-preview.sh" "/bin/zfsbootmenu-preview.sh" || _ret=$?
   inst_simple "${moddir}/zfs-chroot" "/bin/zfs-chroot" || _ret=$?
   inst_simple "${moddir}/zfsbootmenu.sh" "/bin/zfsbootmenu" || _ret=$?
+  inst_simple "${moddir}/zfsbootmenu-input.sh" "/bin/zfsbootmenu-input" || _ret=$?
   inst_hook cmdline 95 "${moddir}/zfsbootmenu-parse-commandline.sh" || _ret=$?
   inst_hook pre-mount 90 "${moddir}/zfsbootmenu-exec.sh" || _ret=$?
 

--- a/90zfsbootmenu/zfsbootmenu-input.sh
+++ b/90zfsbootmenu/zfsbootmenu-input.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+trap - SIGINT
+def_args="$1"
+
+function sigint() {
+  exit 1
+}
+
+trap sigint SIGINT
+read -r -e -i "${def_args}" -p "> " input 
+echo "${input}"
+exit 0

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -710,7 +710,7 @@ has_resume_device() {
 # returns: 0 on success, 1 on failure
 
 resume_prompt() {
-  local pool
+  local pool decision
 
   pool="${1}"
   [ -n "${pool}" ] || return 1
@@ -751,7 +751,8 @@ resume_prompt() {
 	Proceed [No] ?
 	EOF
 
-    read -r decision
+
+    decision="$( zfsbootmenu-input )"
 
     if [ "x${decision}" = "xDANGEROUS" ]; then
       return 0

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -8,6 +8,9 @@ printk=${printk:0:1}
 # Set it to 0
 echo 0 > /proc/sys/kernel/printk
 
+# disable ctrl-c (SIGINT)
+trap '' SIGINT
+
 # shellcheck disable=SC1091
 test -f /lib/zfsbootmenu-lib.sh && source /lib/zfsbootmenu-lib.sh
 # shellcheck disable=SC1091
@@ -288,7 +291,12 @@ while true; do
         while true;
         do
           echo -e "\nNew boot environment name"
-          read -r -e -i "${pre_populated}" -p "> " new_be
+          new_be="$( zfsbootmenu-input "${pre_populated}" )"
+
+          if [ -z "${new_be}" ] ; then
+            break
+          fi
+
           if [ -n "${new_be}" ] ; then
             valid_name=$( echo "${new_be}" | tr -c -d 'a-zA-Z0-9-_.,' )
             # If the entered name is invalid, set the prompt to the valid form of the name
@@ -339,7 +347,8 @@ while true; do
         done <<< "${BE_ARGS}"
 
         echo -e "\nNew kernel command line"
-        read -r -e -i "${def_args}" -p "> " cmdline
+        cmdline="$( zfsbootmenu-input "${def_args}" )"
+
         if [ -n "${cmdline}" ] ; then
           echo "${cmdline}" > "${BASE}/cmdline"
         fi

--- a/testing/run.sh
+++ b/testing/run.sh
@@ -86,4 +86,5 @@ fi
 	-object rng-random,id=rng0,filename=/dev/urandom \
 	-device virtio-rng-pci,rng=rng0 \
 	-display "${DISPLAY_TYPE}" \
+	-serial mon:stdio \
 	-append "${APPEND}"


### PR DESCRIPTION
Globally disable ctrl-c in /bin/zfsbootmenu by pointing it to an emptyhandler. Inside a subshell, unset the empty handler and then invoke zfsbootmenu-input with a single quoted argument; the pre-filled line that the user can edit. If ctrl-c is detected here, the script kills itself. Otherwise, it echos the line the user entered.

It is up to the caller to determine how to handle an empty response.