### PR TITLE
testing: clone all of dracut installation to support local mode

### DIFF
--- a/testing/.gitignore
+++ b/testing/.gitignore
@@ -5,5 +5,5 @@ vmlinuz*
 vmlinux*
 local.yaml
 .config
-modules.d
+dracut
 dracut.conf.d

--- a/testing/run.sh
+++ b/testing/run.sh
@@ -55,7 +55,8 @@ if ((CREATE)) ; then
   [ -f "${KERNEL}" ] && rm "${KERNEL}"
   [ -f "${INITRD}" ] && rm "${INITRD}"
 
-  ../bin/generate-zbm -c ./local.yaml
+  # Try to find the local dracut first
+  PATH=./dracut:${PATH} ../bin/generate-zbm -c ./local.yaml
 fi
 
 # Ensure kernel and initramfs exist


### PR DESCRIPTION
If `dracut` is run from the directory which contains files usually installed in `/usr/lib/dracut`, `dracut --local` seems to work.