### PR TITLE
Rewrite pool import process

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-exec.sh
+++ b/90zfsbootmenu/zfsbootmenu-exec.sh
@@ -2,7 +2,6 @@
 
 export spl_hostid
 export force_import
-export read_write
 export menu_timeout
 export root
 

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -624,7 +624,7 @@ import_pool() {
   fi
 
   # shellcheck disable=SC2086
-  status="$( zpool import "${import_args[@]}" ${pool} )"
+  status="$( zpool import "${import_args[@]}" ${pool} >/dev/null 2>&1 )"
   ret=$?
 
   return ${ret}

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -606,6 +606,12 @@ find_online_pools() {
           importable+=("${pool}")
         fi
         ;;
+      status*)
+        pool_status="${line#status: }"
+        if [[ "${pool_status}" =~ "read-only" ]]; then
+          importable+=("${pool}")
+        fi
+      ;;
     esac
   done <<<"$( zpool import )"
   (IFS=',' ; printf '%s' "${importable[*]}")

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -588,36 +588,6 @@ load_be_cmdline() {
   echo "${zfsbe_args}"
 }
 
-# no arguments
-# prints: nothing
-# returns: number of pools that can be imported
-
-find_online_pools() {
-  local importable pool state
-  importable=()
-  while read -r line; do
-    case "$line" in
-      pool*)
-        pool="${line#pool: }"
-        ;;
-      state*)
-        state="${line#state: }"
-        if [ "${state}" == "ONLINE" ]; then
-          importable+=("${pool}")
-        fi
-        ;;
-      status*)
-        pool_status="${line#status: }"
-        if [[ "${pool_status}" =~ "read-only" ]]; then
-          importable+=("${pool}")
-        fi
-      ;;
-    esac
-  done <<<"$( zpool import )"
-  (IFS=',' ; printf '%s' "${importable[*]}")
-  return "${#importable[@]}"
-}
-
 # arg1: pool name
 # prints: nothing
 # returns: 0 on success, 1 on failure
@@ -645,6 +615,12 @@ import_pool() {
   # shellcheck disable=SC2154
   if [ -n "${rewind_to_checkpoint}" ]; then
     import_args+=( "--rewind-to-checkpoint" )
+  fi
+
+  # shellcheck disable=SC2154
+  if [ -n "${all_pools}" ]; then
+    import_args+=( "-a" )
+    pool=''
   fi
 
   # shellcheck disable=SC2086

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -687,8 +687,44 @@ has_resume_device() {
   return 1
 }
 
+# arg1: warning message
+# arg2: persistence in seconds (optional, default 30)
+# prints: warning message
+# returns: nothing
+
+warning_prompt() {
+  local delay prompt warning x y
+
+  warning="$1"
+  [ -n "${warning}" ] || return
+
+  delay="${2:-30}"
+
+  prompt="Press [ENTER] or wait ${delay} seconds to continue"
+
+  tput civis
+  HEIGHT=$( tput lines )
+  WIDTH=$( tput cols )
+  tput clear
+
+  x=$(( (HEIGHT - 0) / 2))
+  y=$(( (WIDTH - ${#warning}) / 2 ))
+
+  tput cup $x $y
+  echo -n "${warning}"
+
+  x=$(( x + 1 ))
+  y=$(( (WIDTH - ${#prompt}) / 2 ))
+  tput cup $x $y
+  echo -n "${prompt}"
+
+  # shellcheck disable=SC2162
+  read -s -N 1 -t "${delay}" key
+  tput clear
+}
+
 # arg1: pool name
-# prints: nothing
+# prints: warning message
 # returns: 0 on success, 1 on failure
 
 resume_prompt() {
@@ -758,6 +794,11 @@ set_rw_pool() {
 
   pool="${1}"
   [ -n "${pool}" ] || return 1
+
+  if [ -r "${BASE}/degraded" ] && grep -q "${pool}" "${BASE}/degraded"; then
+    warning_prompt "Operation prohibited: ZFSBootMenu cannot import '${pool}' read-write" "10"
+    return 1
+  fi
 
   # If force_export is set, skip evaluating if the pool is already read-write
   # shellcheck disable=SC2154

--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -38,10 +38,6 @@ else
   menu_timeout=10
 fi
 
-if getargbool 1 die_on_import_failure ; then
-  info "ZFSBootMenu: Disabling die on import failure"
-fi
-
 wait_for_zfs=0
 case "${root}" in
   ""|zfsbootmenu|zfsbootmenu:)

--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -23,13 +23,6 @@ if getargbool 0 force_import ; then
   info "ZFSBootMenu: Enabling force import of ZFS pools"
 fi
 
-# Import pools by default in read-write mode
-if getargbool 0 read_write ; then
-  # shellcheck disable=SC2034
-  read_write="yes"
-  info "ZFSBootMenu: Enabling read-write ZFS pool import"
-fi
-
 # Set a menu timeout, to allow immediate booting
 menu_timeout=$( getarg timeout=)
 if [ -n "${menu_timeout}" ]; then

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -90,7 +90,6 @@ fi
 
 # Attempt to find the bootfs property
 # shellcheck disable=SC2086
-datasets="$( zpool list -H -o bootfs ${boot_pool} )"
 while read -r line; do
   if [ "${line}" = "-" ]; then
     BOOTFS=
@@ -98,7 +97,7 @@ while read -r line; do
     BOOTFS="${line}"
     break
   fi
-done <<<"${datasets}"
+done <<<"$( zpool list -H -o bootfs ${boot_pool} )"
 
 # If BOOTFS is not empty display the fast boot menu
 fast_boot=0

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -37,7 +37,6 @@ fi
 BASE="$( mktemp -d /tmp/zfs.XXXX )"
 export BASE
 
-# I should probably just modprobe zfs right off the bat
 modprobe zfs 2>/dev/null
 udevadm settle
 
@@ -67,8 +66,9 @@ if [ $ret -eq 0 ]; then
   unsupported=0
   while IFS=$'\t' read -r _pool _property; do
     if [[ "${_property}" =~ "unsupported@" ]]; then
-      # TODO: dedupe this file
-      echo "${_pool}" >> "${BASE}/degraded"
+      if ! grep -q "${_pool}" "${BASE}/degraded" >/dev/null 2>&1 ; then
+        echo "${_pool}" >> "${BASE}/degraded"
+      fi
       unsupported=1
     fi
   done <<<"$( zpool get all -H -o name,property )"

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -74,20 +74,7 @@ if [ $ret -eq 0 ]; then
   done <<<"$( zpool get all -H -o name,property )"
 
   if [ "${unsupported}" -ne 0 ]; then
-    tput civis
-    HEIGHT=$( tput lines )
-    WIDTH=$( tput cols )
-    tput clear
-
-    warning="Unsupported features detected, upgrade ZFS in ZFSBootMenu"
-    x=$(( (HEIGHT - 0) / 2 ))
-    y=$(( (WIDTH - ${#warning}) / 2 ))
-    tput cup $x $y
-    echo -n "${warning}"
-
-    # shellcheck disable=SC2162
-    read -s -N 1 -t 30 key
-    tput clear
+    warning_prompt "Unsupported features detected, upgrade ZFS modules in ZFSBootMenu"
   fi
 else
   emergency_shell "zpool import 1 handler"

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -61,13 +61,11 @@ if [ $ret -gt 0 ]; then
   done
   if [ $import_success -ne 1 ]; then
     emergency_shell "unable to successfully import a pool"
+    exit
   fi
 else
-  # shellcheck disable=SC2154,SC2086
-  if [ ${die_on_import_failure} -eq 1 ]; then
-    emergency_shell "no pools available to import"
-    exit;
-  fi
+  emergency_shell "no pools available to import"
+  exit;
 fi
 
 # Prefer a specific pool when checking for a bootfs value

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -49,11 +49,12 @@ read_write='' all_pools=yes import_pool
 
 import_success=0
 while IFS=$'\t' read -r _pool _health; do
+  [ -n "${_pool}" ] || continue
+
+  import_success=1
   if [ "${_health}" != "ONLINE" ]; then
     echo "${_pool}" >> "${BASE}/degraded"
   fi
-  # We were able to successfully import at least one pool
-  import_success=1
 done <<<"$( zpool list -H -o name,health )"
 
 if [ "${import_success}" -ne 1 ]; then

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ efibootmgr --disk /dev/sda \
   --verbose
 ```
 
-Take note to adjust `zfsbootmenu:POOL=`, `spl_hostid=`, `--disk` and `--part` to match your system configuration.
+Take note to adjust `root=zfsbootmenu:POOL=`, `spl_hostid=`, `--disk` and `--part` to match your system configuration.
 
 Each time the bootmenu is updated, a new EFI entry will need to be manually added.
 
@@ -137,12 +137,12 @@ Each time the bootmenu is updated, a new EFI entry will need to be manually adde
 `rEFInd` is considerably easier to install and manage. Refer to your distributions packages for installation. Once rEFInd has been installed, you can create `refind_linux.conf` in the directory holding the ZFSBootMenu files (`/boot/efi/EFI/void` in our example):
 
 ```
-"Boot Default BE" "ro quiet loglevel=0 timeout=0 zfsbootmenu:POOL= spl_hostid="
-"Select BE" "ro quiet loglevel=0 timeout=-1 zfsbootmenu:POOL= spl_hostid="
+"Boot Default BE" "ro quiet loglevel=0 timeout=0 root=zfsbootmenu:POOL= spl_hostid="
+"Select BE" "ro quiet loglevel=0 timeout=-1 root=zfsbootmenu:POOL= spl_hostid="
 ```
 
 
-As with the efibootmgr section, the `zfsbootmenu:POOL=` and `spl_hostid=` options need to be configured to match your environment.
+As with the efibootmgr section, the `root=zfsbootmenu:POOL=` and `spl_hostid=` options need to be configured to match your environment.
 
 This file will configure `rEFInd` to create two entries for each kernel and initrams pair it finds. The first will directly boot into the environment set via the `bootfs` pool property. The second will force ZFSBootMenu to display an environment / kernel / snapshot selection menu, allowing you to boot alternate environments, kernels and snapshots.
 

--- a/testing/run.sh
+++ b/testing/run.sh
@@ -27,7 +27,7 @@ INITRD="initramfs-bootmenu.img"
 MEMORY="2048M"
 SMP="2"
 DISPLAY_TYPE="gtk"
-APPEND="loglevel=7 timeout=5 zfsbootmenu:POOL=ztest"
+APPEND="loglevel=7 timeout=5 root=zfsbootmenu:POOL=ztest"
 CREATE=1
 
 # Override any default variables


### PR DESCRIPTION
The historical pool import process relied on scraping the pool status and attempting to import any pool that is marked as ONLINE. This process fails for pools that feature flags enabled from a newer version of ZFS than what is in the initramfs. The process has been reworked as follows:

* Rely on `zpool` to import every pool possible in `read-only` mode
* If any pool has unavailable feature flags, set a global flag disabling read-write pool operations, and then provide a warning indicating that ZFS in the initramfs should be upgraded.
* If the preferred zpool could not be imported, warn and then drop to a recovery shell. 

This PR removes the `read_write` kernel command line option, as this behavior directly conflicts with requirement that all pools be imported read-only initially.