### PR TITLE
Read-only helpers

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -57,7 +57,7 @@ draw_be() {
   test -f "${env}" || return 130
 
   selected="$( ${FUZZYSEL} -0 --prompt "BE > " \
-    --expect=alt-k,alt-d,alt-s,alt-c,alt-r,alt-p \
+    --expect=alt-k,alt-d,alt-s,alt-c,alt-r,alt-p,alt-w \
     --preview-window="up:${PREVIEW_HEIGHT}" \
     --header="[ENTER] boot [ALT+K] kernel [ALT+D] set bootfs [ALT+S] snapshots [ALT+C] cmdline [ALT+P] Pool status" \
     --preview="zfsbootmenu-preview.sh ${BASE} {} ${BOOTFS}" < "${env}" )"

--- a/90zfsbootmenu/zfsbootmenu-preview.sh
+++ b/90zfsbootmenu/zfsbootmenu-preview.sh
@@ -25,10 +25,14 @@ do
   selected_arguments="${line}"
 done <<< "${BE_ARGS}"
 
+pool="${ENV%%/*}"
+readonly_prop="$( zpool get -H -o value readonly "${pool}" )"
+[[ ${readonly_prop} = "on" ]] && _readonly="r/o" || _readonly="r/w"
+
 if [[ "${BOOTFS}" =~ ${ENV} ]]; then
-  selected_env_str="${ENV} (default) - ${selected_kernel}"
+  selected_env_str="${ENV} (default, ${_readonly}) - ${selected_kernel}"
 else
-  selected_env_str="${ENV} - ${selected_kernel}"
+  selected_env_str="${ENV} (${_readonly}) - ${selected_kernel}"
 fi
 
 if [ -z "${FZF_PREVIEW_COLUMNS}" ]

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -344,6 +344,12 @@ while true; do
       "alt-r")
         emergency_shell "alt-r invoked"
         ;;
+      "alt-w")
+        pool="${selected_be%%/*}"
+        if set_rw_pool "${pool}"; then
+          CLEAR_SCREEN=1 key_wrapper "${pool}"
+        fi
+        ;;
       "alt-c")
         tput clear
         tput cnorm


### PR DESCRIPTION
Add an alt-w helper to the main screen to set a pool r/w
Show r/o or r/w in the preview header for a selected pool (extracted from a BE)