### PR TITLE
Embedded help system

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -80,6 +80,7 @@ install() {
     "tac"
     "blkid"
     "awk"
+    "fold"
   )
 
   for _exec in "${essential_execs[@]}"; do
@@ -132,6 +133,7 @@ install() {
   inst_simple "${moddir}/zfs-chroot" "/bin/zfs-chroot" || _ret=$?
   inst_simple "${moddir}/zfsbootmenu.sh" "/bin/zfsbootmenu" || _ret=$?
   inst_simple "${moddir}/zfsbootmenu-input.sh" "/bin/zfsbootmenu-input" || _ret=$?
+  inst_simple "${moddir}/zfsbootmenu-help.sh" "/bin/zfsbootmenu-help" || _ret=$?
   inst_hook cmdline 95 "${moddir}/zfsbootmenu-parse-commandline.sh" || _ret=$?
   inst_hook pre-mount 90 "${moddir}/zfsbootmenu-exec.sh" || _ret=$?
 

--- a/90zfsbootmenu/zfsbootmenu-help.sh
+++ b/90zfsbootmenu/zfsbootmenu-help.sh
@@ -2,6 +2,7 @@
 # vim: softtabstop=2 shiftwidth=2 expandtab
 WIDTH="$( tput cols )"
 PREVIEW_SIZE=$(( WIDTH - 26 ))
+[ ${PREVIEW_SIZE} -lt 10 ] && PREVIEW_SIZE=10
 
 [ -z "${FUZZYSEL}" ] && FUZZYSEL="fzf"
 
@@ -70,13 +71,13 @@ Access a list of kernels available in the boot environment.
 $( colorize lightblue "[ALT+D] set bootfs" )
 Set the selected boot environment as the default for the pool.
 
-The operation will gracefully fail if the pool can not be set $( colorize red "read/write" ).
+The operation will fail gracefully if the pool can not be set $( colorize red "read/write" ).
 
 $( colorize lightblue "[ALT+S] snapshots" )
 Access a list of snapshots of the selected boot environment. New boot environments can be created here.
 
 $( colorize lightblue "[ALT+C] cmdline" )
-Temporarily edit the kernel command line that will be used to boot the next kernel and boot environment. This change is not persisted between boots.
+Temporarily edit the kernel command line that will be used to boot the chosen kernel in the selected boot environment. This change does not persist across reboots.
 
 $( colorize lightblue "[ALT+P] Pool status" )
 View the health and status of each imported pool.
@@ -93,7 +94,7 @@ This creates a boot environment that does not depend on any other snapshots, all
 
 A duplicated boot environment is commonly used if you need a new boot environment without any associated snapshots.
 
-The operation will gracefully fail if the pool can not be set $( colorize red "read/write" ).
+The operation will fail gracefully if the pool can not be set $( colorize red "read/write" ).
 
 If $( colorize red "mbuffer" ) is available, it is used to provide feedback.
 
@@ -102,19 +103,19 @@ Creation method: $( colorize red "zfs clone" ) , $( colorize red "zfs promote" )
 
 This creates a boot environment that is not dependent on the origin snapshot, allowing you to destroy the file system that the clone was created from. A cloned and promoted boot environment is commonly used when you've done an upgrade but want to preserve historical snapshots.
 
-The operation will gracefully fail if the pool can not be set $( colorize red "read/write" ).
+The operation will fail gracefully if the pool can not be set $( colorize red "read/write" ).
 
 $( colorize lightblue "[ALT+C] clone" )
 Creation method: $( colorize red "zfs clone" )
 
 This creates a boot environment from a snapshot with out modifying snapshot inheritence. A cloned boot environment is commonly used if you need to boot a previous system state for a short time and then discard the environment.
 
-The operation will gracefully fail if the pool can not be set $( colorize red "read/write" ).
+The operation will fail gracefully if the pool can not be set $( colorize red "read/write" ).
 
 $( colorize lightblue "[ALT+D] diff" )
 Compare the differences between the selected snapshot and the current state of the boot environment.
 
-The operation will gracefully fail if the pool can not be set $( colorize red "read/write" ).
+The operation will fail gracefully if the pool can not be set $( colorize red "read/write" ).
 EOF
 SECTIONS+=("SNAPSHOT Snapshot Management")
 
@@ -122,14 +123,14 @@ SECTIONS+=("SNAPSHOT Snapshot Management")
 read -r -d '' KERNEL <<EOF
 $( colorize magenta "$( center "Kernel Management")" )
 $( colorize lightblue "[ENTER] boot" )
-Immediately boot the selected kernel in the boot environment, with the kernel command line shown at the top of the screen.
+Immediately boot the chosen kernel in the selected boot environment, with the kernel command line shown at the top of the screen.
 
 $( colorize lightblue "[ALT+D] set default" )
 Set the selected kernel as the default for the boot environment.
 
 The ZFS property $( colorize green "org.zfsbootmenu:kernel" ) is used to store the default kernel for the boot environment.
 
-The operation will gracefully fail if the pool can not be set $( colorize red "read/write" ).
+The operation will fail gracefully if the pool can not be set $( colorize red "read/write" ).
 
 EOF
 SECTIONS+=("KERNEL Kernel Management")
@@ -161,9 +162,9 @@ SECTIONS+=("DIFF Diff Viewer")
 read -r -d '' POOL <<EOF
 $( colorize magenta "$( center "zpool Health")" )
 $( colorize lightblue "[ALT+R] Rewind checkpoint" )
-If a pool checkpoint is available, the selected pool is exported and then imported with $( colorize red "--rewind-to-checkpoint" ) set.
+If a pool checkpoint is available, the selected pool is exported and then imported with the $( colorize red "--rewind-to-checkpoint" ) flag set.
 
-The operation will gracefully fail if the pool can not be set $( colorize red "read/write" ).
+The operation will fail gracefully if the pool can not be set $( colorize red "read/write" ).
 EOF
 SECTIONS+=("POOL ZPOOL Health")
 

--- a/90zfsbootmenu/zfsbootmenu-help.sh
+++ b/90zfsbootmenu/zfsbootmenu-help.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+# vim: softtabstop=2 shiftwidth=2 expandtab
+WIDTH="$( tput cols )"
+PREVIEW_SIZE=$(( WIDTH - 26 ))
+
+[ -z "${FUZZYSEL}" ] && FUZZYSEL="fzf"
+
+center() {
+  printf "%*s" $(( (${#1} + WIDTH ) / 2)) "${1}"
+}
+
+colorize() {
+  color="${1}"
+  shift
+  case "${color}" in
+    black) echo -e -n '\033[0;30m' ;;
+    red) echo -e -n '\033[0;31m' ;;
+    green) echo -e -n '\033[0;32m' ;;
+    orange) echo -e -n '\033[0;33m' ;;
+    blue) echo -e -n '\033[0;34m' ;;
+    magenta) echo -e -n '\033[0;35m' ;;
+    cyan) echo -e -n '\033[0;36m' ;;
+    lightgray) echo -e -n '\033[0;37m' ;;
+    darkgray) echo -e -n '\033[1;30m' ;;
+    lightred) echo -e -n '\033[1;31m' ;;
+    lightgreen) echo -e -n '\033[1;32m' ;;
+    yellow) echo -e -n '\033[1;33m' ;;
+    lightblue) echo -e -n '\033[1;34m' ;;
+    lightmagenta) echo -e -n '\033[1;35m' ;;
+    lightcyan) echo -e -n '\033[1;36m' ;;
+    white) echo -e -n '\033[1;37m' ;;
+    *) echo -e -n '\033[0m' ;;
+  esac
+  echo -e -n "$@"
+  echo -e -n '\033[0m'
+}
+
+help_pager() {
+  WANTED="${1}"
+
+  SORTED=()
+  for SECTION in "${SECTIONS[@]}"; do
+    if ! [[ $SECTION =~ ${WANTED} ]]; then
+      SORTED+=("${SECTION}")
+    else
+      FINAL="${SECTION}"
+    fi
+    done
+  SORTED+=("${FINAL}")
+
+  printf '%s\n' "${SORTED[@]}" | ${FUZZYSEL} \
+    --prompt 'Topic >' \
+    --with-nth=2.. \
+    --bind pgup:preview-up,pgdn:preview-down \
+    --preview="$0 -s {1}" \
+    --preview-window="right:${PREVIEW_SIZE}:sharp:wrap" \
+    --tac \
+    --color='border:6'
+}
+
+# shellcheck disable=SC2034
+read -r -d '' MAIN <<EOF
+$( colorize magenta "$( center "Main Menu")" )
+$( colorize lightblue "[ENTER] boot" )
+Boot the selected boot environment, with the listed kernel and kernel command line visible at the top of the screen.
+
+$( colorize lightblue "[ALT+K] kernel" )
+Access a list of kernels available in the boot environment.
+
+$( colorize lightblue "[ALT+D] set bootfs" )
+Set the selected boot environment as the default for the pool.
+
+The operation will gracefully fail if the pool can not be set $( colorize red "read/write" ).
+
+$( colorize lightblue "[ALT+S] snapshots" )
+Access a list of snapshots of the selected boot environment. New boot environments can be created here.
+
+$( colorize lightblue "[ALT+C] cmdline" )
+Temporarily edit the kernel command line that will be used to boot the next kernel and boot environment. This change is not persisted between boots.
+
+$( colorize lightblue "[ALT+P] Pool status" )
+View the health and status of each imported pool.
+EOF
+SECTIONS+=("MAIN Main Menu")
+
+# shellcheck disable=SC2034
+read -r -d '' SNAPSHOT <<EOF
+$( colorize magenta "$( center "Snapshot Management")" )
+$( colorize lightblue "[ENTER] duplicate" )
+Creation method: $( colorize red "zfs send | zfs recv" )
+
+This creates a boot environment that does not depend on any other snapshots, allowing it to be destroyed at will. The new boot environment will immediately consume space on the pool equal to the $( colorize lightgray "REFER" ) value of the snapshot.
+
+A duplicated boot environment is commonly used if you need a new boot environment without any associated snapshots.
+
+The operation will gracefully fail if the pool can not be set $( colorize red "read/write" ).
+
+If $( colorize red "mbuffer" ) is available, it is used to provide feedback.
+
+$( colorize lightblue "[ALT+X] clone and promote" )
+Creation method: $( colorize red "zfs clone" ) , $( colorize red "zfs promote" )
+
+This creates a boot environment that is not dependent on the origin snapshot, allowing you to destroy the file system that the clone was created from. A cloned and promoted boot environment is commonly used when you've done an upgrade but want to preserve historical snapshots.
+
+The operation will gracefully fail if the pool can not be set $( colorize red "read/write" ).
+
+$( colorize lightblue "[ALT+C] clone" )
+Creation method: $( colorize red "zfs clone" )
+
+This creates a boot environment from a snapshot with out modifying snapshot inheritence. A cloned boot environment is commonly used if you need to boot a previous system state for a short time and then discard the environment.
+
+The operation will gracefully fail if the pool can not be set $( colorize red "read/write" ).
+
+$( colorize lightblue "[ALT+D] diff" )
+Compare the differences between the selected snapshot and the current state of the boot environment.
+
+The operation will gracefully fail if the pool can not be set $( colorize red "read/write" ).
+EOF
+SECTIONS+=("SNAPSHOT Snapshot Management")
+
+# shellcheck disable=SC2034
+read -r -d '' KERNEL <<EOF
+$( colorize magenta "$( center "Kernel Management")" )
+$( colorize lightblue "[ENTER] boot" )
+Immediately boot the selected kernel in the boot environment, with the kernel command line shown at the top of the screen.
+
+$( colorize lightblue "[ALT+D] set default" )
+Set the selected kernel as the default for the boot environment.
+
+The ZFS property $( colorize green "org.zfsbootmenu:kernel" ) is used to store the default kernel for the boot environment.
+
+The operation will gracefully fail if the pool can not be set $( colorize red "read/write" ).
+
+EOF
+SECTIONS+=("KERNEL Kernel Management")
+
+# shellcheck disable=SC2034
+read -r -d '' DIFF <<EOF
+$( colorize magenta "$( center "Diff Viewer")" )
+$( colorize lightblue "Column 1 descriptions" )
+ $( colorize orange "-") The path has been removed
+ $( colorize orange "+") The path has been created
+ $( colorize orange "M") The path has been modified
+ $( colorize orange "R") The path has been renamed
+
+$( colorize lightblue "Column 2 descriptions" )
+ $( colorize orange "B") Block device
+ $( colorize orange "C") Character device
+ $( colorize orange "/") Directory
+ $( colorize orange ">") Door
+ $( colorize orange "|") Named pipe
+ $( colorize orange "@") Symbolic link
+ $( colorize orange "P") Event port
+ $( colorize orange "=") Socket
+ $( colorize orange "F") Regular file
+
+EOF
+SECTIONS+=("DIFF Diff Viewer")
+
+# shellcheck disable=SC2034
+read -r -d '' POOL <<EOF
+$( colorize magenta "$( center "zpool Health")" )
+$( colorize lightblue "[ALT+R] Rewind checkpoint" )
+If a pool checkpoint is available, the selected pool is exported and then imported with $( colorize red "--rewind-to-checkpoint" ) set.
+
+The operation will gracefully fail if the pool can not be set $( colorize red "read/write" ).
+EOF
+SECTIONS+=("POOL ZPOOL Health")
+
+while getopts "lL:s:" opt; do
+  case "${opt}" in
+    l)
+      printf '%s\n' "${SECTIONS[@]}"
+      exit
+      ;;
+    L)
+      help_pager "${OPTARG}"
+      exit
+      ;;
+    s)
+      section="${OPTARG}"
+      echo "${!section}" | fold -s -w "${FZF_PREVIEW_COLUMNS}"
+      exit
+      ;;
+    ?)
+      exit
+      ;;
+    *)
+      exit
+      ;;
+  esac
+done
+
+# No options detected, show the main help section
+help_pager "MAIN"

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -27,21 +27,17 @@ OLDIFS="$IFS"
 if command -v fzf >/dev/null 2>&1; then
   export FUZZYSEL=fzf
   #shellcheck disable=SC2016
-  export FZF_DEFAULT_OPTS='--layout=reverse-list --cycle --inline-info --tac --color=16 --bind "alt-h:execute[ zfsbootmenu-help -L ${_SECTION} ]"'
+  export FZF_DEFAULT_OPTS='--layout=reverse-list --cycle --inline-info --tac --color=16 --bind "alt-h:execute[ zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
   export PREVIEW_HEIGHT=2
 elif command -v sk >/dev/null 2>&1; then
   export FUZZYSEL=sk
   #shellcheck disable=SC2016
-  export SKIM_DEFAULT_OPTIONS='--layout=reverse-list --inline-info --tac --color=16 --bind "alt-h:execute[ zfsbootmenu-help -L ${_SECTION} ]"'
+  export SKIM_DEFAULT_OPTIONS='--layout=reverse-list --inline-info --tac --color=16 --bind "alt-h:execute[ zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
   export PREVIEW_HEIGHT=3
 fi
 
 BASE="$( mktemp -d /tmp/zfs.XXXX )"
 export BASE
-
-# Set a default help section
-_SECTION="MAIN"
-export _SECTION
 
 modprobe zfs 2>/dev/null
 udevadm settle

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -26,16 +26,22 @@ OLDIFS="$IFS"
 
 if command -v fzf >/dev/null 2>&1; then
   export FUZZYSEL=fzf
-  export FZF_DEFAULT_OPTS="--layout=reverse-list --cycle --inline-info --tac"
+  #shellcheck disable=SC2016
+  export FZF_DEFAULT_OPTS='--layout=reverse-list --cycle --inline-info --tac --color=16 --bind "alt-h:execute[ zfsbootmenu-help -L ${_SECTION} ]"'
   export PREVIEW_HEIGHT=2
 elif command -v sk >/dev/null 2>&1; then
   export FUZZYSEL=sk
-  export SKIM_DEFAULT_OPTIONS="--layout=reverse-list --inline-info --tac --color=16"
+  #shellcheck disable=SC2016
+  export SKIM_DEFAULT_OPTIONS='--layout=reverse-list --inline-info --tac --color=16 --bind "alt-h:execute[ zfsbootmenu-help -L ${_SECTION} ]"'
   export PREVIEW_HEIGHT=3
 fi
 
 BASE="$( mktemp -d /tmp/zfs.XXXX )"
 export BASE
+
+# Set a default help section
+_SECTION="MAIN"
+export _SECTION
 
 modprobe zfs 2>/dev/null
 udevadm settle


### PR DESCRIPTION
To enable a global help system, bind alt-h by default to all instances
of fzf and sk. The bind executes zfsbootmenu-help -L $_SECTION.

Before invoking each instance of fzf/sk, set _SECTION to the appropriate
value (MAIN, SNAPSHOT, ...). zfsbootmenu-help then uses this argument to
pre-sort the list of topics, pushing that topic to the head of the list
/ pre-selecting it.

The documentation is internal to zfsbootmenu-help, and is created using
a very simple templating system with basic colors and text centering.
fold is used to word wrap based on the size of the preview window. The
preview window size is calculated based on the number of columns minus
26 characters (the longest topic title + fzf marker ).

When adding new help sections, care should be taken with colorizing
text. Because ANSI escape sequences are used, fold is not able to
correctly calculate the length of given word, so it word wraps
incorrectly.

The text / pager can be reviewed by manually executing `90zfsbootmenu/zfsbootmenu-help.sh`.