### PR TITLE
Wrap the shortcut key footer based on terminal width

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-help.sh
+++ b/90zfsbootmenu/zfsbootmenu-help.sh
@@ -70,21 +70,21 @@ $( colorize magenta "$( center "Main Menu")" )
 $( colorize lightblue "[ENTER] boot" )
 Boot the selected boot environment, with the listed kernel and kernel command line visible at the top of the screen.
 
-$( colorize lightblue "[ALT+K] kernel" )
+$( colorize lightblue "[ALT+K] kernels" )
 Access a list of kernels available in the boot environment.
+
+$( colorize lightblue "[ALT+S] snapshots" )
+Access a list of snapshots of the selected boot environment. New boot environments can be created here.
 
 $( colorize lightblue "[ALT+D] set bootfs" )
 Set the selected boot environment as the default for the pool.
 
 The operation will fail gracefully if the pool can not be set $( colorize red "read/write" ).
 
-$( colorize lightblue "[ALT+S] snapshots" )
-Access a list of snapshots of the selected boot environment. New boot environments can be created here.
-
-$( colorize lightblue "[ALT+C] cmdline" )
+$( colorize lightblue "[ALT+C] edit kcl" )
 Temporarily edit the kernel command line that will be used to boot the chosen kernel in the selected boot environment. This change does not persist across reboots.
 
-$( colorize lightblue "[ALT+P] Pool status" )
+$( colorize lightblue "[ALT+P] pool status" )
 View the health and status of each imported pool.
 EOF
 SECTIONS+=("MAIN Main Menu")
@@ -165,8 +165,8 @@ SECTIONS+=("DIFF Diff Viewer")
 
 # shellcheck disable=SC2034
 read -r -d '' POOL <<EOF
-$( colorize magenta "$( center "zpool Health")" )
-$( colorize lightblue "[ALT+R] Rewind checkpoint" )
+$( colorize magenta "$( center "ZPOOL Health")" )
+$( colorize lightblue "[ALT+R] rewind checkpoint" )
 If a pool checkpoint is available, the selected pool is exported and then imported with the $( colorize red "--rewind-to-checkpoint" ) flag set.
 
 The operation will fail gracefully if the pool can not be set $( colorize red "read/write" ).

--- a/90zfsbootmenu/zfsbootmenu-help.sh
+++ b/90zfsbootmenu/zfsbootmenu-help.sh
@@ -59,6 +59,7 @@ help_pager() {
     --bind pgup:preview-up,pgdn:preview-down \
     --preview="$0 -s {1}" \
     --preview-window="right:${PREVIEW_SIZE}:sharp:wrap" \
+    --header="[ESC] back" \
     --tac \
     --color='border:6'
 }

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -55,7 +55,7 @@ header_wrap() {
 
   width="$( tput cols )"
   footer="$( echo -n -e "${footer}" | fold -s -w "${width}" )"
-  footer="${footer//[/\\033[0;32m[}"
+  footer="${footer//\[/\\033[0;32m\[}"
   footer="${footer//]/]\\033[0m}"
   echo -n -e "${footer}"
 }
@@ -170,13 +170,15 @@ draw_diff() {
 # returns: 130 on error, 0 otherwise
 
 draw_pool_status() {
-  local selected ret
+  local selected ret header
+
+  header="$( header_wrap "[ALT+R]_Rewind_checkpoint [ESC]_back [ALT+H]_help" )"
 
   selected="$( zpool list -H -o name |
     HELP_SECTION=POOL ${FUZZYSEL} --prompt "Pool > " \
       --tac --expect=alt-r \
       --preview="zpool status -v {}" \
-      --header="[ALT+R] Rewind checkpoint [ESC] back" \
+        --header="${header//_/ }"
   )"
   ret=$?
   csv_cat <<< "${selected}"

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -62,7 +62,7 @@ header_wrap() {
   done
 
   # Pick a wrap width if none was specified
-  [ -n "$wrap_width" ] || wrap_width="$( tput cols )"
+  [ -n "$wrap_width" ] || wrap_width="$(( $( tput cols ) - 4 ))"
 
   footer="$( echo -n -e "${tokens[@]}" | fold -s -w "${wrap_width}" )"
   footer="${footer//\[/\\033\[0;32m\[}"
@@ -81,8 +81,8 @@ draw_be() {
 
   test -f "${env}" || return 130
 
-  header="$( header_wrap "[ENTER] boot" "[ALT+K] kernel" \
-    "[ALT+D] set bootfs" "[ALT+S] snapshots" "[ALT+C] cmdline" \
+  header="$( header_wrap "[ENTER] boot" "[ALT+K] kernels" \
+    "[ALT+S] snapshots" "[ALT+D] set bootfs" "[ALT+C] edit kcl" \
     "[ALT+P] pool status" "[ALT+R] recovery shell" "[ALT+H] help")"
 
   selected="$( ${FUZZYSEL} -0 --prompt "BE > " \
@@ -184,9 +184,9 @@ draw_pool_status() {
   local selected ret header hdr_width
 
   # Wrap to half width to avoid the preview window
-  hdr_width="$(( $( tput cols ) / 2 ))"
+  hdr_width="$(( ( $( tput cols ) / 2 ) - 4 ))"
   header="$( wrap_width="$hdr_width" header_wrap \
-    "[ALT+R] Rewind checkpoint" "[ESC] back" "[ALT+H] help" )"
+    "[ALT+R] rewind checkpoint" "[ESC] back" "[ALT+H] help" )"
 
   selected="$( zpool list -H -o name |
     HELP_SECTION=POOL ${FUZZYSEL} --prompt "Pool > " --tac \

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -122,7 +122,7 @@ draw_snapshots() {
         --tac --expect=alt-x,alt-c,alt-d \
         --preview="zfsbootmenu-preview.sh ${BASE} ${benv} ${BOOTFS}" \
         --preview-window="up:${PREVIEW_HEIGHT}" \
-        --header="${header//_/ }"
+        --header="${header//_/ }" )"
   ret=$?
   # shellcheck disable=SC2119
   csv_cat <<< "${selected}"

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -27,12 +27,12 @@ OLDIFS="$IFS"
 if command -v fzf >/dev/null 2>&1; then
   export FUZZYSEL=fzf
   #shellcheck disable=SC2016
-  export FZF_DEFAULT_OPTS='--layout=reverse-list --cycle --inline-info --tac --color=16 --bind "alt-h:execute[ zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
+  export FZF_DEFAULT_OPTS='--ansi --layout=reverse-list --cycle --inline-info --tac --color=16 --bind "alt-h:execute[ zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
   export PREVIEW_HEIGHT=2
 elif command -v sk >/dev/null 2>&1; then
   export FUZZYSEL=sk
   #shellcheck disable=SC2016
-  export SKIM_DEFAULT_OPTIONS='--layout=reverse-list --inline-info --tac --color=16 --bind "alt-h:execute[ zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
+  export SKIM_DEFAULT_OPTIONS='--ansi --layout=reverse-list --inline-info --tac --color=16 --bind "alt-h:execute[ zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
   export PREVIEW_HEIGHT=3
 fi
 


### PR DESCRIPTION
Terminal widths can change dramatically based on the hardware in use on a system. To ensure that all of the shortcut key entries can be read, the line is now wrapped at either the width of the display, or at an arbitrary width. The caller is expected to tokenize the header line to mark acceptable line break boundaries. 

Shortcut key texts were also slightly reordered and adjusted to have consistent capitalization between screens. Help documentation was modified to match these changes. 