### PR TITLE
Console fixes

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-exec.sh
+++ b/90zfsbootmenu/zfsbootmenu-exec.sh
@@ -5,7 +5,8 @@ export force_import
 export menu_timeout
 export root
 export control_term
+export zbm_lines
+export zbm_columns
 
 # https://busybox.net/FAQ.html#job_control
 exec setsid bash -c "exec /bin/zfsbootmenu <${control_term} >${control_term} 2>&1"
-#exec /bin/zfsbootmenu

--- a/90zfsbootmenu/zfsbootmenu-exec.sh
+++ b/90zfsbootmenu/zfsbootmenu-exec.sh
@@ -4,6 +4,8 @@ export spl_hostid
 export force_import
 export menu_timeout
 export root
+export control_term
 
 # https://busybox.net/FAQ.html#job_control
-exec setsid bash -c 'exec /bin/zfsbootmenu </dev/tty1 >/dev/tty1 2>&1'
+exec setsid bash -c "exec /bin/zfsbootmenu <${control_term} >${control_term} 2>&1"
+#exec /bin/zfsbootmenu

--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -31,6 +31,15 @@ else
   menu_timeout=10
 fi
 
+control_term=$( getarg console=)
+if [ -n "${control_term}" ]; then
+  info "ZFSBootMenu: Setting controlling terminal to: ${control_term}"
+  control_term="/dev/${control_term}"
+else
+  control_term="/dev/tty0"
+  info "ZFSBootMenu: Defaulting controlling terminal to: ${control_term}"
+fi
+
 wait_for_zfs=0
 case "${root}" in
   ""|zfsbootmenu|zfsbootmenu:)

--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -40,6 +40,10 @@ else
   info "ZFSBootMenu: Defaulting controlling terminal to: ${control_term}"
 fi
 
+# Allow setting of console size; there are no defaults here
+zbm_lines=$( getarg zbm.lines=)
+zbm_columns=$( getarg zbm.columns=)
+
 wait_for_zfs=0
 case "${root}" in
   ""|zfsbootmenu|zfsbootmenu:)

--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -41,7 +41,9 @@ else
 fi
 
 # Allow setting of console size; there are no defaults here
+# shellcheck disable=SC2034
 zbm_lines=$( getarg zbm.lines=)
+# shellcheck disable=SC2034
 zbm_columns=$( getarg zbm.columns=)
 
 wait_for_zfs=0

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -18,8 +18,6 @@ test -f zfsbootmenu-lib.sh && source zfsbootmenu-lib.sh
 
 echo "Loading boot menu ..."
 TERM=linux
-# shellcheck disable=SC2034
-CLEAR_SCREEN=0
 tput reset
 
 OLDIFS="$IFS"
@@ -48,10 +46,12 @@ udevadm settle
 test -x /lib/udev/console_init -a -c "${control_term}" && /lib/udev/console_init "${control_term##*/}"
 
 # set the console size, if indicated
+#shellcheck disable=SC2154
 if [ -n "$zbm_lines" ]; then
   stty rows "$zbm_lines"
 fi
 
+#shellcheck disable=SC2154
 if [ -n "$zbm_columns" ]; then
   stty cols "$zbm_columns"
 fi

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -47,6 +47,15 @@ udevadm settle
 #shellcheck disable=SC2154
 test -x /lib/udev/console_init -a -c "${control_term}" && /lib/udev/console_init "${control_term##*/}"
 
+# set the console size, if indicated
+if [ -n "$zbm_lines" ]; then
+  stty rows "$zbm_lines"
+fi
+
+if [ -n "$zbm_columns" ]; then
+  stty cols "$zbm_columns"
+fi
+
 # Attempt to import all pools read-only
 read_write='' all_pools=yes import_pool
 

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -25,12 +25,12 @@ OLDIFS="$IFS"
 if command -v fzf >/dev/null 2>&1; then
   export FUZZYSEL=fzf
   #shellcheck disable=SC2016
-  export FZF_DEFAULT_OPTS='--ansi --layout=reverse-list --cycle --inline-info --tac --color=16 --bind "alt-h:execute[ zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
+  export FZF_DEFAULT_OPTS='--ansi --no-clear --layout=reverse-list --cycle --inline-info --tac --color=16 --bind "alt-h:execute[ zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
   export PREVIEW_HEIGHT=2
 elif command -v sk >/dev/null 2>&1; then
   export FUZZYSEL=sk
   #shellcheck disable=SC2016
-  export SKIM_DEFAULT_OPTIONS='--ansi --layout=reverse-list --inline-info --tac --color=16 --bind "alt-h:execute[ zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
+  export SKIM_DEFAULT_OPTIONS='--ansi --no-clear --layout=reverse-list --inline-info --tac --color=16 --bind "alt-h:execute[ zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
   export PREVIEW_HEIGHT=3
 fi
 

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -43,7 +43,8 @@ udevadm settle
 # try to set console options for display and interaction
 # this is sometimes run as an initqueue hook, but cannot be guaranteed
 #shellcheck disable=SC2154
-test -x /lib/udev/console_init -a -c "${control_term}" && /lib/udev/console_init "${control_term##*/}"
+test -x /lib/udev/console_init -a -c "${control_term}" \
+  && /lib/udev/console_init "${control_term##*/}" >/dev/null 2>&1
 
 # set the console size, if indicated
 #shellcheck disable=SC2154

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -44,7 +44,8 @@ udevadm settle
 
 # try to set console options for display and interaction
 # this is sometimes run as an initqueue hook, but cannot be guaranteed
-test -x /lib/udev/console_init -a -c /dev/tty0 && /lib/udev/console_init tty0
+#shellcheck disable=SC2154
+test -x /lib/udev/console_init -a -c "${control_term}" && /lib/udev/console_init "${control_term##*/}"
 
 # Attempt to import all pools read-only
 read_write='' all_pools=yes import_pool

--- a/testing/chroot.sh
+++ b/testing/chroot.sh
@@ -31,9 +31,11 @@ EOF
 # Set root password
 echo 'root:zfsbootmenu' | chpasswd -c SHA256
 
-# enable dhclient
+# enable services
 ln -s /etc/sv/dhclient /etc/runit/runsvdir/default
 ln -s /etc/sv/sshd /etc/runit/runsvdir/default
+ln -s /etc/sv/ttyS0 /etc/runit/runsvdir/default
+ln -s /etc/sv/hvc0 /etc/runit/runsvdir/default
 
 # /bin/dash sucks
 chsh -s /bin/bash

--- a/testing/chroot.sh
+++ b/testing/chroot.sh
@@ -21,7 +21,16 @@ EOF
 xbps-reconfigure -f linux5.8
 
 # Set kernel commandline
-zfs set org.zfsbootmenu:commandline="spl_hostid=$( hostid ) ro quiet" ztest/ROOT
+case "$(uname -m)" in
+  ppc64*)
+    consoles="console=tty0 console=hvc0"
+    ;;
+  x86_64)
+    consoles="console=tty0 console=ttyS0"
+    ;;
+esac
+
+zfs set org.zfsbootmenu:commandline="spl_hostid=$( hostid ) ro quiet ${consoles}" ztest/ROOT
 
 # Configure the system to create a recursive snapshot every boot
 cat << \EOF > /etc/rc.local
@@ -34,8 +43,8 @@ echo 'root:zfsbootmenu' | chpasswd -c SHA256
 # enable services
 ln -s /etc/sv/dhclient /etc/runit/runsvdir/default
 ln -s /etc/sv/sshd /etc/runit/runsvdir/default
-ln -s /etc/sv/ttyS0 /etc/runit/runsvdir/default
-ln -s /etc/sv/hvc0 /etc/runit/runsvdir/default
+ln -s /etc/sv/agetty-ttyS0 /etc/runit/runsvdir/default
+ln -s /etc/sv/agetty-hvc0 /etc/runit/runsvdir/default
 
 # /bin/dash sucks
 chsh -s /bin/bash

--- a/testing/run.sh
+++ b/testing/run.sh
@@ -20,7 +20,7 @@ case "$(uname -m)" in
     BIN="qemu-system-x86_64"
     KERNEL="vmlinuz-bootmenu"
     MACHINE="type=q35,accel=kvm"
-    APPEND="loglevel=7 timeout=5 root=zfsbootmenu:POOL=ztest console=ttyS0 console=tty0"
+    APPEND="loglevel=7 timeout=5 root=zfsbootmenu:POOL=ztest"
   ;;
 esac
 

--- a/testing/run.sh
+++ b/testing/run.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
+
 usage() {
   cat <<EOF
 Usage: $0 [options]
   -a  Set kernel command line
+  -A+ Append additional arguments to kernel command line
   -d+ Set one or more non-standard disk images 
   -n  Do not recreate the initramfs
+  -s  Enable serial console on stdio
+  -v  Set type of qemu display to use
 EOF
 }
 
@@ -14,13 +18,15 @@ case "$(uname -m)" in
     BIN="qemu-system-ppc64"
     KERNEL="vmlinux-bootmenu"
     MACHINE="pseries,accel=kvm,kvm-type=HV,cap-hpt-max-page-size=4096"
-    APPEND="loglevel=7 timeout=5 root=zfsbootmenu:POOL=ztest console=hvc0 console=tty0"
+    APPEND="loglevel=7 timeout=5 root=zfsbootmenu:POOL=ztest"
+    SERDEV="hvc0"
   ;;
   x86_64)
     BIN="qemu-system-x86_64"
     KERNEL="vmlinuz-bootmenu"
     MACHINE="type=q35,accel=kvm"
     APPEND="loglevel=7 timeout=5 root=zfsbootmenu:POOL=ztest"
+    SERDEV="ttyS0"
   ;;
 esac
 
@@ -28,14 +34,15 @@ DRIVE="-drive format=raw,file=zfsbootmenu-pool.img"
 INITRD="initramfs-bootmenu.img"
 MEMORY="2048M"
 SMP="2"
-DISPLAY_TYPE="gtk"
 CREATE=1
+SERIAL=0
+DISPLAY_TYPE=
 
 # Override any default variables
 #shellcheck disable=SC1091
 [ -f .config ] && source .config
 
-while getopts "A:a:d:nh" opt; do
+while getopts "A:a:d:nsv:h" opt; do
   case "${opt}" in
     A)
       AAPPEND+=( "$OPTARG" )
@@ -44,10 +51,16 @@ while getopts "A:a:d:nh" opt; do
       APPEND="${OPTARG}"
       ;;
     d)
-      MDRIVE+=("-drive format=raw,file=${OPTARG}")
+      MDRIVE+=("-drive" "format=raw,file=${OPTARG}")
       ;;
     n)
       CREATE=0
+      ;;
+    s)
+      SERIAL=1
+      ;;
+    v)
+      DISPLAY_TYPE="${OPTARG}"
       ;;
     \?|h)
       usage
@@ -60,6 +73,25 @@ done
 
 if [ "${#MDRIVE[@]}" -gt 0 ]; then
   DRIVE="${MDRIVE[*]}"
+fi
+
+if [ -n "${DISPLAY_TYPE}" ]; then
+  # Use the indicated graphical display
+  DISPLAY_ARGS=( "-display" "${DISPLAY_TYPE}" )
+else
+  # Suppress graphical display (implies serial mode)
+  DISPLAY_ARGS=( "-nographic" )
+  SERIAL=1
+fi
+
+if ((SERIAL)) ; then
+  AAPPEND+=( "console=tty0" "console=${SERDEV}" )
+  LINES="$( tput lines 2>/dev/null )"
+  COLUMNS="$( tput cols 2>/dev/null )"
+  [ -n "${LINES}" ] && AAPPEND+=( "zbm.lines=${LINES}" )
+  [ -n "${COLUMNS}" ] && AAPPEND+=( "zbm.columns=${COLUMNS}" )
+else
+  AAPPEND+=("console=${SERDEV}" "console=tty0")
 fi
 
 if [ "${#AAPPEND[@]}" -gt 0 ]; then
@@ -95,7 +127,11 @@ fi
 	-machine "${MACHINE}" \
 	-object rng-random,id=rng0,filename=/dev/urandom \
 	-device virtio-rng-pci,rng=rng0 \
-	-display "${DISPLAY_TYPE}" \
+	"${DISPLAY_ARGS[@]}" \
 	-serial mon:stdio \
 	-netdev user,id=n1,hostfwd=tcp::2222-:22 -device virtio-net-pci,netdev=n1 \
 	-append "${APPEND}"
+
+if ((SERIAL)) ; then
+  reset
+fi


### PR DESCRIPTION
zfsbootmenu-exec.sh was forcing stdin/stdout on `/dev/tty1`. This works correctly for systems with one GPU, but it causes problems for systems with multiple GPUs or when attempting to use a serial port for the console. To work around this problem, ZFSBootMenu now respects the `console=` parameter on the KCL, and plumbs the input/output of `zfsbootmenu.sh` to that device. If multiple `console=` entries are found, the last one found is used (consistent with kernel behavior). If no entries are found, `/dev/tty0` is used instead.

The testing infrastructure was reworked to default the output to a serial port (`ttyS0` or `hvc0`, depending on platform) which is then plumbed to the terminal used to invoke `run.sh`. `-v gtk` or `-v sdl` can instead be used to start a graphical display. When the serial output is active, it is automatically resized via stty, by reading `zbm.lines` and `zbm.columns` from the KCL. 