### PR TITLE
Sort environments, fix preview

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -957,7 +957,7 @@ key_wrapper() {
 # returns: 0 on success, 1 on failure
 
 populate_be_list() {
-  local be_list fs mnt active candidates sorted
+  local be_list fs mnt active candidates
 
   be_list="${1}"
   [ -n "${be_list}" ] || return 1
@@ -977,19 +977,18 @@ populate_be_list() {
       # All other datasets are ignored
       continue
     fi
-    if [ -n "${BOOTFS}" ] && [ "${BOOTFS}" = "${fs}" ] ; then
+    if [ "x${BOOTFS}" = "x${fs}" ] ; then
       # If BOOTFS is defined, we'll manually append it to the array
       continue
     fi
 
     candidates+=( "${fs}" )
-  done <<< "$(zfs list -H -o name,mountpoint,org.zfsbootmenu:active)"
+  done <<< "$(zfs list -H -o name,mountpoint,org.zfsbootmenu:active | sort -r)"
 
-  # Reverse sort the list, to line up with our global usage of --tac
-  readarray -t sorted < <( for env in "${candidates[@]}" ; do echo "$env" ; done | sort -r )
-  [ -n "${BOOTFS}" ] && sorted+=( "${BOOTFS}" )
+  # put bootfs on the end, so it is shown first with --tac
+  [ -n "${BOOTFS}" ] && candidates+=( "${BOOTFS}" )
 
-  for fs in "${sorted[@]}"; do
+  for fs in "${candidates[@]}"; do
     # Unlock if necessary
     key_wrapper "${fs}" || continue
 

--- a/90zfsbootmenu/zfsbootmenu-preview.sh
+++ b/90zfsbootmenu/zfsbootmenu-preview.sh
@@ -30,7 +30,7 @@ pool="${ENV%%/*}"
 readonly_prop="$( zpool get -H -o value readonly "${pool}" )"
 [[ ${readonly_prop} = "on" ]] && _readonly="r/o" || _readonly="r/w"
 
-if [[ "${BOOTFS}" =~ ${ENV} ]]; then
+if [ "${BOOTFS}" = "${ENV}" ]; then
   selected_env_str="${ENV} (default, ${_readonly}) - ${selected_kernel}"
 else
   selected_env_str="${ENV} (${_readonly}) - ${selected_kernel}"


### PR DESCRIPTION
Fix a string comparison in zfsbootmenu-preview.sh to make it an exact
match instead of a regexp match. This will prevent multiple environments
showing up as (default).

In populate_be_list, reverse sort the list of candidate boot
environments and then append the BOOTFS value if defined. Combined with
fzf/sk --tac, this pushes the boot environment to the top of the list so
that it's the first selected item on the main screen.