### PR TITLE
Respect ZFS hostid behavior on musl

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -153,7 +153,16 @@ install() {
   fi
 
   # Synchronize initramfs and system hostid
-  HOSTID="$( hostid )"
-  # shellcheck disable=SC2154
-  echo -ne "\\x${HOSTID:6:2}\\x${HOSTID:4:2}\\x${HOSTID:2:2}\\x${HOSTID:0:2}" > "${initdir}/etc/hostid"
+  if [ -e /etc/hostid ]; then
+    # Prefer the hostid file if it exists
+    inst /etc/hostid
+    type mark_hostonly >/dev/null 2>&1 && mark_hostonly /etc/hostid
+  elif HOSTID="$( hostid 2>/dev/null )" && [ "${HOSTID}" != "00000000" ]; then
+    # Fall back to `hostid` output when it is nonzero
+    # The order will be wrong on big-endian architectures; in such a case,
+    # the right thing to do is make sure /etc/hostid exists on the system
+    # shellcheck disable=SC2154
+    echo -ne "\\x${HOSTID:6:2}\\x${HOSTID:4:2}\\x${HOSTID:2:2}\\x${HOSTID:0:2}" > "${initdir}/etc/hostid"
+    type mark_hostonly >/dev/null 2>&1 && mark_hostonly /etc/hostid
+  fi
 }


### PR DESCRIPTION
When OpenZFS moved to `zgenhostid` in its dracut module, it uncovered some inconsistent behavior (see [#11189](https://github.com/openzfs/zfs/pull/11189)) with musl systems where `hostid(1)` always returns "00000000" regardless of the contents of `/etc/hostid`. I proposed a fix in that issue that should do the right thing, but relies on behavior of the new `zgenhostid` in `OpenZFS 2.0.0`. We can't rely on that here, because ZFSBootMenu may still be used with older ZoL releases. Thus, we still use the old `echo` behavior to write out `/etc/hostid` in the ZBM initramfs when there is no `/etc/hostid` on the running system. The observable should be identical to the solution proposed for OpenZFS.

This still needs testing.

@ericonr: note the use of the `inst` function here, as well as the `mark_hostonly` which seems appropriate since `/etc/hostid` should rightfully be considered a per-host file.