### PR TITLE
Encapsulate test environments within subdirectories

### DIFF
--- a/testing/.gitignore
+++ b/testing/.gitignore
@@ -7,3 +7,4 @@ local.yaml
 .config
 dracut
 dracut.conf.d
+generate-zbm

--- a/testing/README.md
+++ b/testing/README.md
@@ -10,11 +10,13 @@ The testing environment setup and runtime depends on the following tools:
 
 # Creating a ZFSBootMenu Test Pool for QEMU
 
-First, run `./setup.sh -a` to:
+First, run `./setup.sh -a`; this will create, if necessary, a test directory
+(chosen automatically or specified with the `-D` command-line flag) and, within
+the test directory:
 
 * Create a test pool
-  1. Create a 1GB RAW image file,
-  2. Attach it to the `loop0` loopback device,
+  1. Create a 2GB RAW image file,
+  2. Attach it to a loopback device,
   3. Create a GPT label and a ZFS pool `ztest`,
   4. Install Void base-minimal onto the pool,
   5. Configure the installation, and

--- a/testing/chroot.sh
+++ b/testing/chroot.sh
@@ -9,7 +9,7 @@ xbps-reconfigure -f glibc-locales
 
 # Install a kernel and ZFS
 xbps-install -S
-xbps-install -y linux5.8 linux5.8-headers zfs
+xbps-install -y linux5.9 linux5.9-headers zfs
 
 # Setup ZFS in Dracut
 cat << EOF > /etc/dracut.conf.d/zol.conf
@@ -18,7 +18,7 @@ add_dracutmodules+=" zfs "
 omit_dracutmodules+=" btrfs "
 EOF
 
-xbps-reconfigure -f linux5.8
+xbps-reconfigure -f linux5.9
 
 # Set kernel commandline
 case "$(uname -m)" in

--- a/testing/image.sh
+++ b/testing/image.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# vim: softtabstop=2 shiftwidth=2 expandtab
+
+TESTDIR="${1?Usage: $0 <testdir>}"
+
+if [ -z "${TESTDIR}" ] || [ ! -d "${TESTDIR}" ]; then
+  echo "ERROR: test directory must be specified and must exist"
+  exit 1
+fi
+
+XBPS_ARCH="$(uname -m)"
+
+case "${XBPS_ARCH}" in
+  ppc64le)
+    URL="https://mirrors.servercentral.com/void-ppc/current"
+    ;;
+  x86_64)
+    URL="https://mirrors.servercentral.com/voidlinux/current"
+    ;;
+  *)
+    echo "ERROR: unsupported architecture"
+    exit 1
+    ;;
+esac
+
+if [ -n "${MUSL}" ]; then
+  URL="${URL}/musl"
+  XBPS_ARCH="${XBPS_ARCH}-musl"
+fi
+
+export XBPS_ARCH
+
+MNT="$( mktemp -d )" || exit 1
+# shellcheck disable=SC2064
+trap "rmdir '${MNT}'" EXIT
+
+qemu-img create "${TESTDIR}/zfsbootmenu-pool.img" 2G
+chown "$( stat -c %U . ):$( stat -c %G . )" "${TESTDIR}/zfsbootmenu-pool.img"
+
+LOOP="$( losetup -f )" || exit 1
+losetup "${LOOP}" "${TESTDIR}/zfsbootmenu-pool.img" || exit 1
+# shellcheck disable=SC2064
+trap "rmdir '${MNT}'; losetup -d '${LOOP}'" EXIT
+
+kpartx -u "${LOOP}"
+
+echo 'label: gpt' | sfdisk "${LOOP}"
+
+zpool create -f \
+  -O compression=lz4 \
+  -O acltype=posixacl \
+  -O xattr=sa \
+  -O relatime=on \
+  -o autotrim=on \
+  -o cachefile=none \
+  -m none ztest "${LOOP}"
+
+zfs snapshot -r ztest@barepool
+
+zfs create -o mountpoint=none ztest/ROOT
+zfs create -o mountpoint=/ -o canmount=noauto ztest/ROOT/void
+
+zfs snapshot -r ztest@barebe
+
+zfs set org.zfsbootmenu:commandline="spl_hostid=$( hostid ) ro quiet" ztest/ROOT
+zpool set bootfs=ztest/ROOT/void ztest
+
+zpool export ztest
+
+zpool import -o cachefile=none -R "${MNT}" ztest || exit 1
+# shellcheck disable=SC2064
+trap "zpool export ztest; rmdir '${MNT}'; losetup -d '${LOOP}'" EXIT
+
+zfs mount ztest/ROOT/void || exit 1
+# shellcheck disable=SC2064
+trap "umount -R '${MNT}'; zpool export ztest; rmdir '${MNT}'; losetup -d '${LOOP}'" EXIT
+
+# https://github.com/project-trident/trident-installer/blob/master/src-sh/void-install-zfs.sh#L541
+mkdir -p "${MNT}/var/db/xbps/keys"
+cp /var/db/xbps/keys/*.plist "${MNT}/var/db/xbps/keys/."
+
+mkdir -p "${MNT}/etc/xbps.d"
+cp /etc/xbps.d/*.conf "${MNT}/etc/xbps.d/."
+
+# /etc/runit/core-services/03-console-setup.sh depends on loadkeys from kbd
+# /etc/runit/core-services/05-misc.sh depends on ip from iproute2
+xbps-install -y -M -r "${MNT}" --repository="${URL}" \
+  base-minimal dracut ncurses-base kbd iproute2 dhclient openssh
+
+cp /etc/hostid "${MNT}/etc/"
+cp /etc/resolv.conf "${MNT}/etc/"
+cp /etc/rc.conf "${MNT}/etc/"
+
+mkdir -p "${MNT}/etc/xbps.d"
+echo "repository=${URL}" > "${MNT}/etc/xbps.d/00-repository-main.conf"
+
+mount -t proc proc "${MNT}/proc"
+mount -t sysfs sys "${MNT}/sys"
+mount -B /dev "${MNT}/dev"
+mount -t devpts pts "${MNT}/dev/pts"
+
+zfs snapshot -r ztest@pre-chroot
+
+cp chroot.sh "${MNT}/root"
+chroot "${MNT}" /root/chroot.sh

--- a/testing/image.sh
+++ b/testing/image.sh
@@ -34,7 +34,7 @@ MNT="$( mktemp -d )" || exit 1
 # shellcheck disable=SC2064
 trap "rmdir '${MNT}'" EXIT
 
-qemu-img create "${TESTDIR}/zfsbootmenu-pool.img" 2G
+qemu-img create "${TESTDIR}/zfsbootmenu-pool.img" "${SIZE}" 
 chown "$( stat -c %U . ):$( stat -c %G . )" "${TESTDIR}/zfsbootmenu-pool.img"
 
 LOOP="$( losetup -f )" || exit 1

--- a/testing/setup.sh
+++ b/testing/setup.sh
@@ -6,6 +6,7 @@ GENZBM=0
 IMAGE=0
 CONFD=0
 DRACUT=0
+SIZE="2G"
 
 usage() {
   cat <<EOF
@@ -18,6 +19,7 @@ Usage: $0 [options]
   -a  Perform all setup options
   -m  When making an image, use musl instead of glibc
   -D  Specify a test directory to use
+  -s  Specify size of VM image
 EOF
 }
 
@@ -26,7 +28,7 @@ if [ $# -eq 0 ]; then
   exit
 fi
 
-while getopts "ycgdaimD:" opt; do
+while getopts "ycgdaimD:s:" opt; do
   case "${opt}" in
     y)
       YAML=1
@@ -55,6 +57,9 @@ while getopts "ycgdaimD:" opt; do
       ;;
     D)
       TESTDIR="${OPTARG}"
+      ;;
+    s)
+      SIZE="${OPTARG}"
       ;;
     \?)
       usage
@@ -125,5 +130,5 @@ fi
 
 # Create an image
 if ((IMAGE)) ; then
-  sudo env MUSL="${MUSL}" ./image.sh "${TESTDIR}"
+  sudo env MUSL="${MUSL}" SIZE="${SIZE}" ./image.sh "${TESTDIR}"
 fi


### PR DESCRIPTION
It is sometimes helpful to have multiple active test setups, and it is also convenient to be able to destroy a test setup with one command rather than having to delete multiple different files and directories.

This command adds a `-D` argument to setup.sh, allowing all activity in the setup script to occur within a specified directory. When a subdirectory is not specified, a default of `test.$(uname -r)` is used.

The run.sh script is also now aware of the test directory, searching for a default of `test.$(uname -r)` and allowing manual specification by setting the TESTDIR environment variable. If the TESTDIR does not exist, run.sh reverts to running from the CWD.

Also, the image-creation script has been pulled out of a heredoc in setup.sh into a standalone script, making maintenance a little easier.