### PR TITLE
Fall back to legacy hostid creation for ZFS < 2.0

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -152,17 +152,36 @@ install() {
     type mark_hostonly >/dev/null 2>&1 && mark_hostonly /etc/zfs/vdev_id.conf
   fi
 
-  # Synchronize initramfs and system hostid
-  if [ -e /etc/hostid ]; then
-    # Prefer the hostid file if it exists
+  # Try to synchronize hostid between host and ZFSBootMenu
+  #
+  # DEPRECATION NOTICE: on musl systems, zfs < 2.0 produced a bad hostid in
+  # dracut images. Unfortunately, this should be replicated for now to ensure
+  # those images are bootable. After some time, remove this version check.
+  ZVER="$( zfs version | head -n1 | sed 's/zfs-\(kmod-\)\?//' )"
+  if [ -n "${ZVER}" ] && printf '%s\n' "${ZVER}" "2.0" | sort -VCr; then
+    NEWZFS=yes
+  else
+    NEWZFS=""
+  fi
+
+  if [ -n "${NEWZFS}" ] && [ -e /etc/hostid ]; then
+    # With zfs >= 2.0, prefer the hostid file if it exists
     inst /etc/hostid
-    type mark_hostonly >/dev/null 2>&1 && mark_hostonly /etc/hostid
-  elif HOSTID="$( hostid 2>/dev/null )" && [ "${HOSTID}" != "00000000" ]; then
-    # Fall back to `hostid` output when it is nonzero
-    # The order will be wrong on big-endian architectures; in such a case,
-    # the right thing to do is make sure /etc/hostid exists on the system
-    # shellcheck disable=SC2154
-    echo -ne "\\x${HOSTID:6:2}\\x${HOSTID:4:2}\\x${HOSTID:2:2}\\x${HOSTID:0:2}" > "${initdir}/etc/hostid"
-    type mark_hostonly >/dev/null 2>&1 && mark_hostonly /etc/hostid
+  elif HOSTID="$( hostid 2>/dev/null )"; then
+    # Fall back to `hostid` output when it is nonzero or with zfs < 2.0
+    if [ -z "${NEWZFS}" ]; then
+      # In zfs < 2.0, zgenhostid does not provide necessary behavior
+      # shellcheck disable=SC2154
+      echo -ne "\\x${HOSTID:6:2}\\x${HOSTID:4:2}\\x${HOSTID:2:2}\\x${HOSTID:0:2}" > "${initdir}/etc/hostid"
+    elif [ "${HOSTID}" != "00000000" ]; then
+      # In zfs >= 2.0, zgenhostid writes the output, but only with nonzero hostid
+      # shellcheck disable=SC2154
+      zgenhostid -o "${initdir}/etc/hostid" "${HOSTID}"
+    fi
+  fi
+
+  # shellcheck disable=SC2154
+  if [ -e "${initdir}/etc/hostid" ] && type mark_hostonly >/dev/null 2>&1; then
+    mark_hostonly /etc/hostid
   fi
 }


### PR DESCRIPTION
The dracut module in ZFS < 2.0 produces initramfs images with all-zero hostid files on musl systems, regardless of the contents of /etc/hostid on the host. In ZFS >= 2.0, the dracut module respects the contents of /etc/hostid when possible, and will otherwise create a new /etc/hostid only if the hostid(1) program returns a non-zero value. (NB: to the ZFS kmods, a non-existent /etc/hostid is equivalent to a file containing all zeros.)

To minimize the possibility of import failures, ZFSBootMenu should try hard to replicate the behavior of whichever version of ZFS is creating initramfs images.

The version comparison here should be considered deprecated and removed once ZFS >= 2.0 has had sufficient time to overtake prior versions in popularity.