### PR TITLE
Improvements to createInitramfs and handling out-of-space issues

### DIFF
--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -206,7 +206,6 @@ my $tempdir = $dir->dirname;
 if ( nonempty $config{Kernel}{Path} and !nonempty $runConf{kernel} ) {
   $runConf{kernel} = $config{Kernel}{Path};
 }
-
 if ( nonempty $config{Kernel}{Prefix} and !nonempty $runConf{kernel_prefix} ) {
   $runConf{kernel_prefix} = $config{Kernel}{Prefix};
 }
@@ -537,6 +536,7 @@ sub latestKernel {
     my @kernels = glob($glob);
     next if !@kernels;
     for ( sort { versioncmp( $b, $a ) } @kernels ) {
+      Log("Latest kernel: $_");
       return $_;
     }
   }
@@ -580,6 +580,9 @@ sub createInitramfs {
   }
 
   push( @cmd, ( $output_file, $kver ) );
+
+  my $command = join(' ', @cmd);
+  Log("Executing: $command");
 
   my @output = execute(@cmd);
   my $status = pop(@output);
@@ -656,6 +659,7 @@ sub maxRevision {
     }
   }
 
+  Log("maxRevision discovered: $revision");
   return $revision;
 }
 
@@ -877,6 +881,10 @@ Set the I<Global.ManageImages> option to true, enabling image generation.
 =item B<--disable>
 
 Set the I<Global.ManageImages> option to false, disabling image generation.
+
+=item B<--debug|d>
+
+Enable debug output
 
 =back
 

--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -9,7 +9,7 @@ our $VERSION = '1.7.1';
 use Getopt::Long qw(:config no_ignore_case auto_version);
 use Pod::Usage qw(pod2usage);
 use File::Basename;
-use File::Temp qw(tempdir);
+use File::Temp qw(tempdir tempfile);
 use File::Copy;
 use File::stat;
 use File::Path qw(make_path remove_tree);
@@ -297,12 +297,12 @@ if ( enabled $config{EFI} ) {
 
   my $efi_target;
 
-  my $efi_prefix =
-    sprintf( "%s/%s", $config{EFI}{ImageDir}, $runConf{kernel_prefix} );
+  my $efi_prefix = sprintf( "%s/%s", $config{EFI}{ImageDir}, $runConf{kernel_prefix} );
   Log("Setting \$efi_prefix: $efi_prefix");
+
   my $efi_versions = int $config{EFI}{Versions};
 
-  my $postAction;
+  make_path $config{EFI}{ImageDir};
 
   if ( $efi_versions > 0 ) {
     Log("EFI.Versions is $efi_versions");
@@ -313,35 +313,43 @@ if ( enabled $config{EFI} ) {
     Log($efi_groups);
 
     # Determine the revision to use for this image
-    my $revision =
-      maxRevision( $efi_groups->{ $runConf{version} }, ".EFI" ) + 1;
+    my $revision = maxRevision( $efi_groups->{ $runConf{version} }, ".EFI" ) + 1;
     $efi_target = sprintf( "%s-%s_%s.EFI", $efi_prefix, $runConf{version}, $revision );
     Log("Setting \$efi_target: $efi_target");
 
-    $postAction = sub {
-
-      # Prune the old versions
-      pruneVersions( $efi_groups, $runConf{version}, $efi_versions );
+    # Attempt to copy the file, clean up if it does not
+    unless ( safeCopy( $unified_efi, $efi_target, 0 ) ) {
+      verboseUnlink( $efi_target, "Failed to create $efi_target" );
+      exit 1;
     }
+
+    # Prune the old versions
+    pruneVersions( $efi_groups, $runConf{version}, $efi_versions );
   } else {
-    $postAction = sub {
-      $efi_target = sprintf( "%s.EFI", $efi_prefix );
-      my $efi_backup = sprintf( "%s-backup.EFI", $efi_prefix );
+    $efi_target = sprintf( "%s.EFI", $efi_prefix );
 
-      if ( -f $efi_target and safeCopy( $efi_target, $efi_backup ) ) {
-        printf "Created backup %s -> %s\n", $efi_target, $efi_backup;
-      }
+    # Copy to a placeholder location to ensure success
+    my ( $efi_fh, $efi_tempfile ) = tempfile( "zbm.XXXXXX", DIR => $config{EFI}{ImageDir}, UNLINK => 0 );
+    close $efi_fh;
+
+    unless ( safeCopy( $unified_efi, $efi_tempfile, 0 ) ) {
+      verboseUnlink( $efi_tempfile, "Failed to create $efi_target" );
+      exit 1;
+    }
+
+    # Roll backups
+    my $efi_backup = sprintf( "%s-backup.EFI", $efi_prefix );
+    if ( -f $efi_target and rename( $efi_target, $efi_backup ) ) {
+      printf "Created backup %s -> %s\n", $efi_target, $efi_backup;
+    }
+
+    unless ( rename( $efi_tempfile, $efi_target ) ) {
+      verboseUnlink( $efi_tempfile, "Failed to create $efi_target" );
+      exit 1;
     }
   }
 
-  make_path $config{EFI}{ImageDir};
-  unless ( safeCopy( $unified_efi, $efi_target, 0 ) ) {
-    verboseUnlink($efi_target);
-    exit 1;
-  }
   printf "Created new UEFI image %s\n", $efi_target;
-
-  $postAction->();
 }
 
 # Create a separate kernel / initramfs. Used by syslinux/extlinux/grub.
@@ -353,7 +361,7 @@ if ( enabled $config{Components} ) {
   my $component_prefix   = sprintf( "%s/%s", $config{Components}{ImageDir}, $runConf{kernel_prefix} );
   my $component_versions = int $config{Components}{Versions};
 
-  my $postAction;
+  make_path $config{Components}{ImageDir};
 
   if ( $component_versions > 0 ) {
 
@@ -366,59 +374,76 @@ if ( enabled $config{Components} ) {
     $initramfs_target =
       sprintf( "%s/initramfs-%s_%s.img", $config{Components}{ImageDir}, $runConf{version}, $revision );
 
-    $postAction = sub {
-
-      # Prune old versions
-      pruneVersions( $kern_groups, $runConf{version}, $component_versions );
-
-      # Map kernel to initramfs and prune
-      keys %$kern_groups;
-      while ( my ( $kver, $image ) = each %$kern_groups ) {
-        foreach (@$image) {
-          s/\Q$component_prefix\E/$config{Components}{ImageDir}\/initramfs/;
-          s/$/.img/;
-        }
-      }
-      pruneVersions( $kern_groups, $runConf{version}, $component_versions );
+    unless ( safeCopy( $initramfs, $initramfs_target, 0 ) ) {
+      verboseUnlink( $initramfs_target, "Failed to create $initramfs_target" );
+      exit 1;
     }
+
+    unless ( safeCopy( $runConf{kernel}, $kernel_target, 0 ) ) {
+      verboseUnlink( $kernel_target,    "Failed to create $kernel_target" );
+      verboseUnlink( $initramfs_target, "" );
+      exit 1;
+    }
+
+    # Prune old versions of the kernel
+    pruneVersions( $kern_groups, $runConf{version}, $component_versions );
+
+    # Map each kernel to initramfs and prune those too
+    keys %$kern_groups;
+    while ( my ( $kver, $image ) = each %$kern_groups ) {
+      foreach (@$image) {
+        s/\Q$component_prefix\E/$config{Components}{ImageDir}\/initramfs/;
+        s/$/.img/;
+      }
+    }
+    pruneVersions( $kern_groups, $runConf{version}, $component_versions );
   } else {
-    $kernel_target = sprintf( "%s-bootmenu", $component_prefix );
-    $initramfs_target =
-      sprintf( "%s/initramfs-bootmenu.img", $config{Components}{ImageDir} );
+    $kernel_target    = sprintf( "%s-bootmenu",               $component_prefix );
+    $initramfs_target = sprintf( "%s/initramfs-bootmenu.img", $config{Components}{ImageDir} );
 
-    my $kernel_backup    = sprintf( "%s-backup",                        $kernel_target );
+    # Copy to a placeholder location to ensure success
+    my ( $init_fh, $init_tempfile ) = tempfile( "init.XXXXXX", DIR => $config{Components}{ImageDir}, UNLINK => 0 );
+    close $init_fh;
+
+    unless ( safeCopy( $initramfs, $init_tempfile, 0 ) ) {
+      verboseUnlink( $init_tempfile, "Failed to create $initramfs_target" );
+      exit 1;
+    }
+
+    my ( $kern_fh, $kern_tempfile ) = tempfile( "kern.XXXXXX", DIR => $config{Components}{ImageDir}, UNLINK => 0 );
+    close $kern_fh;
+
+    unless ( safeCopy( $runConf{kernel}, $kern_tempfile, 0 ) ) {
+      verboseUnlink( $kern_tempfile, "Failed to create $kernel_target" );
+      verboseUnlink( $init_tempfile, "" );
+      exit 1;
+    }
+
+    # Roll backups
+    my $kernel_backup = sprintf( "%s-backup", $kernel_target );
+    if ( -f $kernel_target and rename( $kernel_target, $kernel_backup ) ) {
+      printf "Created backup %s -> %s\n", $kernel_target, $kernel_backup;
+    }
+
     my $initramfs_backup = sprintf( "%s/initramfs-bootmenu-backup.img", $config{Components}{ImageDir} );
+    if ( -f $initramfs_target and rename( $initramfs_target, $initramfs_backup ) ) {
+      printf "Created backup %s -> %s\n", $initramfs_target, $initramfs_backup;
+    }
 
-    $postAction = sub {
-      if ( -f $kernel_target
-        and safeCopy( $kernel_target, $kernel_backup ) )
-      {
-        printf "Created backup %s -> %s\n", $kernel_target, $kernel_backup;
-      }
+    unless ( rename( $init_tempfile, $initramfs_target ) ) {
+      verboseUnlink( $init_tempfile, "Failed to create $initramfs_target" );
+      verboseUnlink( $kern_tempfile, "" );
+      exit 1;
+    }
 
-      if ( -f $initramfs_target
-        and safeCopy( $initramfs_target, $initramfs_backup ) )
-      {
-        printf "Created backup %s -> %s\n", $initramfs_target, $initramfs_backup;
-      }
+    unless ( rename( $kern_tempfile, $kernel_target ) ) {
+      verboseUnlink( $kern_tempfile, "Failed to create $kernel_target" );
+      exit 1;
     }
   }
 
-  make_path $config{Components}{ImageDir};
-
-  unless ( safeCopy( $initramfs, $initramfs_target, 0 ) ) {
-    verboseUnlink($initramfs_target);
-    exit 1;
-  }
   printf "Created initramfs image %s\n", $initramfs_target;
-
-  unless ( safeCopy( $runConf{kernel}, $kernel_target, 0 ) ) {
-    verboseUnlink($kernel_target);
-    exit 1;
-  }
-  printf "Created kernel image %s\n", $kernel_target;
-
-  $postAction->();
+  printf "Created kernel image %s\n",    $kernel_target;
 }
 
 # Generate syslinux.cfg, requires components to be built
@@ -705,14 +730,21 @@ sub purgeFiles {
 }
 
 sub verboseUnlink {
-  my $file = shift;
+  my ( $file, $message ) = @_;
 
   return unless ( -f $file );
 
+  # If a message is defined, display regardless of unlink success
+  if ( defined $message and ( $message ne "" ) ) {
+    print "$message\n";
+  }
+
   if ( unlink $file ) {
-    print "Removed file $file\n";
+
+    # Print a default success message if none was defined
+    print "Removed file $file\n" unless ( defined $message );
   } else {
-    print "Unable to remove $file: $!\n";
+    print "ERROR: unable to remove $file: $!\n";
   }
 }
 

--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -590,9 +590,8 @@ sub execute {
 sub safeCopy {
   my ( $source, $dest, $savetime ) = @_;
 
-  Log("safeCopy called with: $source, $dest, $savetime");
-
   my $preserve = ( defined $savetime ) ? boolean($savetime) : true;
+  Log("safeCopy called with: $source, $dest, $preserve");
 
   unless ( copy( $source, $dest ) ) {
     printf "Unable to copy %s to %s: %s\n", $source, $dest, $!;

--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -9,7 +9,7 @@ our $VERSION = '1.7.1';
 use Getopt::Long qw(:config no_ignore_case auto_version);
 use Pod::Usage qw(pod2usage);
 use File::Basename;
-use File::Temp qw(tempfile tempdir);
+use File::Temp qw(tempdir);
 use File::Copy;
 use File::stat;
 use File::Path qw(make_path remove_tree);
@@ -35,7 +35,6 @@ use constant REFARRAY => ref [];
 sub versionedKernel;
 sub latestKernel;
 sub createInitramfs;
-sub unifiedEFI;
 sub execute;
 sub safeCopy;
 sub nonempty;
@@ -294,8 +293,7 @@ printf "Creating ZFSBootMenu %s from kernel %s\n", $runConf{version}, $runConf{k
 
 # Create a unified kernel/initramfs/command line EFI file
 if ( enabled $config{EFI} ) {
-  my $unified_efi =
-    unifiedEFI( $tempdir, $runConf{kernel}, $runConf{kernel_version} );
+  my $unified_efi = createInitramfs( $tempdir, $runConf{kernel_version}, $runConf{kernel} );
 
   my $efi_target;
 
@@ -523,10 +521,11 @@ sub latestKernel {
 
 # Returns the path to an initramfs, or dies with an error
 sub createInitramfs {
-  my ( $temp, $kver ) = @_;
+  my ( $imagedir, $kver, $kernfile ) = @_;
 
-  my $output_file = join( '/', $temp, "zfsbootmenu" );
-  my @cmd         = ( qw(dracut -q -f --confdir), $runConf{confd}, $output_file, qw(--kver), $kver, );
+  my $output_file = join( '/', $imagedir, "zfsbootmenu.img" );
+
+  my @cmd = ( qw(dracut -q -f --confdir), $runConf{confd} );
 
   if ( defined $config{Global}{DracutFlags} ) {
     if ( ref $config{Global}{DracutFlags} eq REFARRAY ) {
@@ -538,37 +537,24 @@ sub createInitramfs {
     }
   }
 
-  my @output = execute(@cmd);
-  my $status = pop(@output);
-  if ( $status eq 0 ) {
-    return $output_file;
-  } else {
-    foreach my $line (@output) {
-      print $line;
+  # If $kernfile is provided, make a unified EFI image with the named kernel
+  if ( defined $kernfile ) {
+    my $efi_stub = $config{EFI}{Stub} || "/usr/lib/gummiboot/linuxx64.efi.stub";
+
+    unless ( -e $efi_stub ) {
+      die "Missing EFI stub: $efi_stub";
     }
-    print "Failed to create $output_file\n";
-    exit $status;
-  }
-}
 
-sub unifiedEFI {
-  my ( $temp, $kernfile, $kver ) = @_;
+    push( @cmd, ( qw(--uefi --uefi-stub), $efi_stub, qq(--kernel-image), $kernfile ) );
 
-  my $output_file = join( '/', $temp, "zfsbootmenu.efi" );
-  my $efi_stub    = $config{EFI}{Stub} || "/usr/lib/gummiboot/linuxx64.efi.stub";
+    if ( nonempty $runConf{cmdline} ) {
+      push( @cmd, qq(--kernel-cmdline=\"$runConf{cmdline}\") );
+    }
 
-  unless ( -e $efi_stub ) {
-    die "Missing EFI stub: $efi_stub";
+    $output_file = join( '/', $imagedir, "zfsbootmenu.efi" );
   }
 
-  my @cmd =
-    ( qw(dracut -q -f --uefi --confdir), $runConf{confd}, qq(--uefi-stub), $efi_stub, qq(--kernel-image), $kernfile, );
-
-  if ( nonempty $runConf{cmdline} ) {
-    push( @cmd, qq(--kernel-cmdline=\"$runConf{cmdline}\") );
-  }
-
-  push( @cmd, ( qq(--kver), $kver, $output_file, ) );
+  push( @cmd, ( $output_file, $kver ) );
 
   my @output = execute(@cmd);
   my $status = pop(@output);

--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -72,6 +72,7 @@ GetOptions(
   "config|c=s"  => \$runConf{config},
   "enable"      => \$runConf{enable},
   "disable"     => \$runConf{disable},
+  "debug|d"     => \$runConf{debug},
   "help|h"      => sub {
     pod2usage( -verbose => 2 );
     exit;
@@ -112,7 +113,8 @@ if ( defined $runConf{migrate} ) {
 if ( -r $runConf{config} ) {
   eval {
     local $SIG{'__DIE__'};
-    my $yaml = YAML::PP->new( boolean => 'boolean' )->load_file( $runConf{config} );
+    my $yaml =
+      YAML::PP->new( boolean => 'boolean' )->load_file( $runConf{config} );
     %config = %$yaml;
   } or do {
     my $error = <<"EOF";
@@ -231,7 +233,9 @@ if ( nonempty $runConf{version} ) {
 }
 
 # Map "%current" kernel version to output of `uname r`
-if ( nonempty $runConf{kernel_version} and $runConf{kernel_version} =~ /%\{current\}/i ) {
+if ( nonempty $runConf{kernel_version}
+  and $runConf{kernel_version} =~ /%\{current\}/i )
+{
   my @uname  = execute(qw(uname -r));
   my $status = pop(@uname);
   unless ( $status eq 0 and scalar @uname ) {
@@ -266,7 +270,9 @@ if ( nonempty $runConf{kernel} ) {
 }
 
 # Try to determine kernel_prefix or kernel_version if necessary
-unless ( nonempty $runConf{kernel_prefix} and nonempty $runConf{kernel_version} ) {
+unless ( nonempty $runConf{kernel_prefix}
+  and nonempty $runConf{kernel_version} )
+{
   basename( $runConf{kernel} ) =~ m/([^-\s]+)(-(\S+))?/;
   unless ( nonempty $runConf{kernel_prefix} ) {
     unless ( defined $1 ) {
@@ -288,37 +294,56 @@ printf "Creating ZFSBootMenu %s from kernel %s\n", $runConf{version}, $runConf{k
 
 # Create a unified kernel/initramfs/command line EFI file
 if ( enabled $config{EFI} ) {
-  my $unified_efi = unifiedEFI( $tempdir, $runConf{kernel}, $runConf{kernel_version} );
+  my $unified_efi =
+    unifiedEFI( $tempdir, $runConf{kernel}, $runConf{kernel_version} );
 
   my $efi_target;
 
-  my $efi_prefix   = sprintf( "%s/%s", $config{EFI}{ImageDir}, $runConf{kernel_prefix} );
+  my $efi_prefix =
+    sprintf( "%s/%s", $config{EFI}{ImageDir}, $runConf{kernel_prefix} );
+  Log("Setting \$efi_prefix: $efi_prefix");
   my $efi_versions = int $config{EFI}{Versions};
 
+  my $postAction;
+
   if ( $efi_versions > 0 ) {
+    Log("EFI.Versions is $efi_versions");
 
     # Find UEFI bundles and group by apparent version
     my @efi        = glob sprintf( "%s-*.EFI", $efi_prefix );
     my $efi_groups = groupKernels( \@efi, $efi_prefix, ".EFI" );
+    Log($efi_groups);
 
     # Determine the revision to use for this image
-    my $revision = maxRevision( $efi_groups->{ $runConf{version} }, ".EFI" ) + 1;
+    my $revision =
+      maxRevision( $efi_groups->{ $runConf{version} }, ".EFI" ) + 1;
     $efi_target = sprintf( "%s-%s_%s.EFI", $efi_prefix, $runConf{version}, $revision );
+    Log("Setting \$efi_target: $efi_target");
 
-    # Prune the old versions
-    pruneVersions( $efi_groups, $runConf{version}, $efi_versions );
+    $postAction = sub {
+
+      # Prune the old versions
+      pruneVersions( $efi_groups, $runConf{version}, $efi_versions );
+    }
   } else {
-    $efi_target = sprintf( "%s.EFI", $efi_prefix );
-    my $efi_backup = sprintf( "%s-backup.EFI", $efi_prefix );
+    $postAction = sub {
+      $efi_target = sprintf( "%s.EFI", $efi_prefix );
+      my $efi_backup = sprintf( "%s-backup.EFI", $efi_prefix );
 
-    if ( -f $efi_target and safeCopy( $efi_target, $efi_backup ) ) {
-      printf "Created backup %s -> %s\n", $efi_target, $efi_backup;
+      if ( -f $efi_target and safeCopy( $efi_target, $efi_backup ) ) {
+        printf "Created backup %s -> %s\n", $efi_target, $efi_backup;
+      }
     }
   }
 
   make_path $config{EFI}{ImageDir};
-  safeCopy( $unified_efi, $efi_target, 0 ) or exit 1;
+  unless ( safeCopy( $unified_efi, $efi_target, 0 ) ) {
+    verboseUnlink($efi_target);
+    exit 1;
+  }
   printf "Created new UEFI image %s\n", $efi_target;
+
+  $postAction->();
 }
 
 # Create a separate kernel / initramfs. Used by syslinux/extlinux/grub.
@@ -329,6 +354,8 @@ if ( enabled $config{Components} ) {
 
   my $component_prefix   = sprintf( "%s/%s", $config{Components}{ImageDir}, $runConf{kernel_prefix} );
   my $component_versions = int $config{Components}{Versions};
+
+  my $postAction;
 
   if ( $component_versions > 0 ) {
 
@@ -341,41 +368,59 @@ if ( enabled $config{Components} ) {
     $initramfs_target =
       sprintf( "%s/initramfs-%s_%s.img", $config{Components}{ImageDir}, $runConf{version}, $revision );
 
-    # Prune old versions
-    pruneVersions( $kern_groups, $runConf{version}, $component_versions );
+    $postAction = sub {
 
-    # Map kernel to initramfs and prune
-    keys %$kern_groups;
-    while ( my ( $kver, $image ) = each %$kern_groups ) {
-      foreach (@$image) {
-        s/\Q$component_prefix\E/$config{Components}{ImageDir}\/initramfs/;
-        s/$/.img/;
+      # Prune old versions
+      pruneVersions( $kern_groups, $runConf{version}, $component_versions );
+
+      # Map kernel to initramfs and prune
+      keys %$kern_groups;
+      while ( my ( $kver, $image ) = each %$kern_groups ) {
+        foreach (@$image) {
+          s/\Q$component_prefix\E/$config{Components}{ImageDir}\/initramfs/;
+          s/$/.img/;
+        }
       }
+      pruneVersions( $kern_groups, $runConf{version}, $component_versions );
     }
-    pruneVersions( $kern_groups, $runConf{version}, $component_versions );
   } else {
-    $kernel_target    = sprintf( "%s-bootmenu",               $component_prefix );
-    $initramfs_target = sprintf( "%s/initramfs-bootmenu.img", $config{Components}{ImageDir} );
+    $kernel_target = sprintf( "%s-bootmenu", $component_prefix );
+    $initramfs_target =
+      sprintf( "%s/initramfs-bootmenu.img", $config{Components}{ImageDir} );
 
     my $kernel_backup    = sprintf( "%s-backup",                        $kernel_target );
     my $initramfs_backup = sprintf( "%s/initramfs-bootmenu-backup.img", $config{Components}{ImageDir} );
 
-    if ( -f $kernel_target and safeCopy( $kernel_target, $kernel_backup ) ) {
-      printf "Created backup %s -> %s\n", $kernel_target, $kernel_backup;
-    }
+    $postAction = sub {
+      if ( -f $kernel_target
+        and safeCopy( $kernel_target, $kernel_backup ) )
+      {
+        printf "Created backup %s -> %s\n", $kernel_target, $kernel_backup;
+      }
 
-    if ( -f $initramfs_target and safeCopy( $initramfs_target, $initramfs_backup ) ) {
-      printf "Created backup %s -> %s\n", $initramfs_target, $initramfs_backup;
+      if ( -f $initramfs_target
+        and safeCopy( $initramfs_target, $initramfs_backup ) )
+      {
+        printf "Created backup %s -> %s\n", $initramfs_target, $initramfs_backup;
+      }
     }
   }
 
   make_path $config{Components}{ImageDir};
 
-  safeCopy( $runConf{kernel}, $kernel_target, 0 ) or exit 1;
+  unless ( safeCopy( $initramfs, $initramfs_target, 0 ) ) {
+    verboseUnlink($initramfs_target);
+    exit 1;
+  }
+  printf "Created initramfs image %s\n", $initramfs_target;
+
+  unless ( safeCopy( $runConf{kernel}, $kernel_target, 0 ) ) {
+    verboseUnlink($kernel_target);
+    exit 1;
+  }
   printf "Created kernel image %s\n", $kernel_target;
 
-  safeCopy( $initramfs, $initramfs_target, 0 ) or exit 1;
-  printf "Created initramfs image %s\n", $initramfs_target;
+  $postAction->();
 }
 
 # Generate syslinux.cfg, requires components to be built
@@ -438,7 +483,8 @@ EOF
   close CFG;
 
   make_path dirname( $config{Components}{syslinux}{Config} );
-  safeCopy( $runConf{syslinux_temp}, $config{Components}{syslinux}{Config} ) or exit 1;
+  safeCopy( $runConf{syslinux_temp}, $config{Components}{syslinux}{Config} )
+    or exit 1;
 }
 
 END {
@@ -450,7 +496,8 @@ sub versionedKernel {
   my ( $kver, ) = @_;
 
   foreach my $prefix (qw(vmlinuz linux vmlinux kernel)) {
-    my $kernel = join( '/', ( $runConf{bootdir}, join( '-', ( $prefix, $kver ) ) ) );
+    my $kernel =
+      join( '/', ( $runConf{bootdir}, join( '-', ( $prefix, $kver ) ) ) );
     if ( -f $kernel ) {
       return $kernel;
     }
@@ -543,6 +590,8 @@ sub execute {
 sub safeCopy {
   my ( $source, $dest, $savetime ) = @_;
 
+  Log("safeCopy called with: $source, $dest, $savetime");
+
   my $preserve = ( defined $savetime ) ? boolean($savetime) : true;
 
   unless ( copy( $source, $dest ) ) {
@@ -617,6 +666,9 @@ sub groupKernels {
 sub pruneVersions {
   my ( $versions, $current, $keep ) = @_;
   my $old_version;
+
+  Log("pruneVersions called with: $current, $keep");
+  Log($versions);
 
   $keep = 0 unless ( defined $keep and $keep gt 0 );
 
@@ -698,7 +750,8 @@ sub convertConfig {
   );
 
   # Force boolean
-  $ini_config{Global}{ManageImages} = boolean( $ini_config{Global}{ManageImages} );
+  $ini_config{Global}{ManageImages} =
+    boolean( $ini_config{Global}{ManageImages} );
 
   # Convert the component and EFI image sections to the new format
   convertImageConfig $ini_config{Components};
@@ -706,7 +759,8 @@ sub convertConfig {
 
   # Move syslinux to be a sub section of Components
   $ini_config{Components}{syslinux} = dclone( $ini_config{syslinux} );
-  $ini_config{Components}{syslinux}{Enabled} = boolean( $ini_config{Components}{syslinux}{CreateConfig} );
+  $ini_config{Components}{syslinux}{Enabled} =
+    boolean( $ini_config{Components}{syslinux}{CreateConfig} );
   delete $ini_config{Components}{syslinux}{CreateConfig};
   delete $ini_config{syslinux};
 
@@ -733,6 +787,18 @@ sub convertImageConfig {
 
   delete $section->{Versioned};
   delete $section->{Copies};
+}
+
+sub Log {
+  my $entry = shift;
+
+  return unless $runConf{debug};
+  chomp($entry);
+  unless ( ref($entry) ) {
+    print STDERR "## $entry\n";
+  } else {
+    print STDERR Dumper($entry);
+  }
 }
 
 __END__

--- a/testing/validation/.gitignore
+++ b/testing/validation/.gitignore
@@ -1,0 +1,3 @@
+*.yaml
+*.yml
+*.log

--- a/testing/validation/out-of-space-error-handling.sh
+++ b/testing/validation/out-of-space-error-handling.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+TMP="$( mktemp -d )"
+# shellcheck disable=SC2064
+trap "sudo umount '${TMP}'" EXIT
+
+cp ../../etc/zfsbootmenu/config.yaml spaced.yaml
+yq-go w -i spaced.yaml Global.ManageImages true
+yq-go w -i spaced.yaml Global.BootMountPoint "${TMP}"
+yq-go w -i spaced.yaml Components.ImageDir "${TMP}"
+yq-go w -i spaced.yaml Components.Versions false
+yq-go w -i spaced.yaml EFI.ImageDir "${TMP}"
+
+sudo mount tmpfs -t tmpfs -o size=10M "${TMP}"
+echo ""
+echo "Unversioned component build, not enough space"
+echo ""
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+sudo umount "${TMP}"
+
+sudo mount tmpfs -t tmpfs -o size=60M "${TMP}"
+echo ""
+echo "Unversioned component build, enough space"
+echo ""
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+sudo umount "${TMP}"
+
+sudo mount tmpfs -t tmpfs -o size=60M "${TMP}"
+echo ""
+echo "Unversioned component build, with backup, not enough space"
+echo ""
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+sudo umount "${TMP}"
+
+sudo mount tmpfs -t tmpfs -o size=120M "${TMP}"
+echo ""
+echo "Unversioned component build, with backup, enough space"
+echo ""
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+sudo umount "${TMP}"
+
+yq-go w -i spaced.yaml Components.Versions 2
+sudo mount tmpfs -t tmpfs -o size=10M "${TMP}"
+echo ""
+echo "Versioned component build, not enough space"
+echo ""
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+sudo umount "${TMP}"
+
+sudo mount tmpfs -t tmpfs -o size=60M "${TMP}"
+echo ""
+echo "Versioned component build, enough space"
+echo ""
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+sudo umount "${TMP}"
+
+sudo mount tmpfs -t tmpfs -o size=60M "${TMP}"
+echo ""
+echo "Versioned component build, twice, not enough space"
+echo ""
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+sudo umount "${TMP}"
+
+sudo mount tmpfs -t tmpfs -o size=120M "${TMP}"
+echo ""
+echo "Versioned component build, twice, enough space"
+echo ""
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+sudo umount "${TMP}"
+
+yq-go w -i spaced.yaml Components.Enabled false
+yq-go w -i spaced.yaml EFI.Enabled true
+
+sudo mount tmpfs -t tmpfs -o size=10M "${TMP}"
+echo ""
+echo "Unversioned UEFI build, not enough space"
+echo ""
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+sudo umount "${TMP}"
+
+sudo mount tmpfs -t tmpfs -o size=60M "${TMP}"
+echo ""
+echo "Unversioned UEFI build, enough space"
+echo ""
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+sudo umount "${TMP}"
+
+sudo mount tmpfs -t tmpfs -o size=60M "${TMP}"
+echo ""
+echo "Unversioned UEFI build, with backup, not enough space"
+echo ""
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+sudo umount "${TMP}"
+
+sudo mount tmpfs -t tmpfs -o size=120M "${TMP}"
+echo ""
+echo "Unversioned UEFI build, with backup, enough space"
+echo ""
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+sudo umount "${TMP}"
+
+yq-go w -i spaced.yaml EFI.Versions 2
+sudo mount tmpfs -t tmpfs -o size=10M "${TMP}"
+echo ""
+echo "Versioned UEFI build, not enough space"
+echo ""
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+sudo umount "${TMP}"
+
+sudo mount tmpfs -t tmpfs -o size=60M "${TMP}"
+echo ""
+echo "Versioned UEFI build, enough space"
+echo ""
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+sudo umount "${TMP}"
+
+sudo mount tmpfs -t tmpfs -o size=60M "${TMP}"
+echo ""
+echo "Versioned UEFI build, twice, not enough space"
+echo ""
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+sudo umount "${TMP}"
+
+sudo mount tmpfs -t tmpfs -o size=120M "${TMP}"
+echo ""
+echo "Versioned UEFI build, twice, enough space"
+echo ""
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+../../bin/generate-zbm -c spaced.yaml
+ls -lah "${TMP}"
+sudo umount "${TMP}"


### PR DESCRIPTION
There are a few changes in here that need review. The first is not directly connected to most of the changes: merging the `unifiedEFI` and `createInitramfs` subroutines to ensure consistent behavior in both modes (in particular, honoring dracut flags specified in the ZBM config for unified EFI images, where this feature was not present before).

Other changes are related to properly handling situations where the ESP free space is exhausted while copying a new initramfs, kernel or unified EFI image. The unified image will probably be copied in place, but may not be bootable in this situation; if individual components are copied, a partial initramfs may be left behind and appear bootable, but it may be missing key contents.

For unversioned backups, this is avoided by copying files (either the unified EFI image or the kernel and initramfs) into the target directory of the ESP *under a temporary name*, so we have a nondestructive way to learn that the copy was successful before rolling the backups and replacing the target file. The replacement is done with `move`, which I don't expect to fail because it should be doing `rename` under the hood.

For versioned backups, the temporary dance is not required, because the destination file(s) have unique names by design. The change here is confirming that the files can be copied successfully before rolling backups, and aborting if they can't.

In both modes, any partial files (either temporary or versioned) are cleaned up on failure. The `verboseUnlink` subroutine now supports custom status messages so we can print some informative text while deleting these partial files.

**Question**: I would like to use `rename` rather than `move` to guarantee we are using the atomic operation instead of falling back to a copy in some edge case (which could still fail due to space exhaustion, rendering all of this work pointless). I don't think `move` should *ever* resort to copying as used here, since the source and destination are on the same filesystem (same directory, no less). Is there *any* reason not to explicitly use `rename` here?

Tests: I've done some tests on a space-constrained target directory and believe everything works, but the following tests should be independently verified:
- [x] Component mode, versioned backups
- [x] Component mode, unversioned backups
- [x] Unified EFI mode, versioned backups
- [x] Unified EFI mode, unversioned backups

**NB**: It is conceivable that there are still some unlikely circumstances that could result in destruction of viable backups with this implementation. In unversioned backup mode, if the copy to a temporary file succeeds and we roll the backups, but the move to final somehow fails, we've inappropriately discarded the backup. I'm not sure under what circumstances a move might fail, but I think the likelihood is small enough that we shouldn't worry about trying to avoid this scenario.