### PR TITLE
Enable TMUX to support debugging efforts

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -81,6 +81,7 @@ install() {
     "blkid"
     "awk"
     "fold"
+    "ps"
   )
 
   for _exec in "${essential_execs[@]}"; do

--- a/90zfsbootmenu/zfsbootmenu-countdown.sh
+++ b/90zfsbootmenu/zfsbootmenu-countdown.sh
@@ -1,14 +1,6 @@
 #!/bin/bash
 # vim: softtabstop=2 shiftwidth=2 expandtab
 
-# store current kernel log level
-read -r PRINTK < /proc/sys/kernel/printk
-PRINTK=${PRINTK:0:1}
-export PRINTK
-
-# Set it to 0
-echo 0 > /proc/sys/kernel/printk
-
 # disable ctrl-c (SIGINT)
 trap '' SIGINT
 
@@ -16,33 +8,6 @@ trap '' SIGINT
 test -f /lib/zfsbootmenu-lib.sh && source /lib/zfsbootmenu-lib.sh
 # shellcheck disable=SC1091
 test -f zfsbootmenu-lib.sh && source zfsbootmenu-lib.sh
-
-echo "Loading boot menu ..."
-TERM=linux
-tput reset
-
-export BASE="/zfsbootmenu"
-mkdir -p "${BASE}"
-
-modprobe zfs 2>/dev/null
-udevadm settle
-
-# try to set console options for display and interaction
-# this is sometimes run as an initqueue hook, but cannot be guaranteed
-#shellcheck disable=SC2154
-test -x /lib/udev/console_init -a -c "${control_term}" \
-  && /lib/udev/console_init "${control_term##*/}" >/dev/null 2>&1
-
-# set the console size, if indicated
-#shellcheck disable=SC2154
-if [ -n "$zbm_lines" ]; then
-  stty rows "$zbm_lines"
-fi
-
-#shellcheck disable=SC2154
-if [ -n "$zbm_columns" ]; then
-  stty cols "$zbm_columns"
-fi
 
 # Attempt to import all pools read-only
 read_write='' all_pools=yes import_pool

--- a/90zfsbootmenu/zfsbootmenu-exec.sh
+++ b/90zfsbootmenu/zfsbootmenu-exec.sh
@@ -1,12 +1,52 @@
 #!/bin/bash
+# vim: softtabstop=2 shiftwidth=2 expandtab
 
 export spl_hostid
 export force_import
 export menu_timeout
 export root
-export control_term
-export zbm_lines
-export zbm_columns
 
-# https://busybox.net/FAQ.html#job_control
-exec setsid bash -c "exec /libexec/zfsbootmenu-countdown <${control_term} >${control_term} 2>&1"
+# store current kernel log level
+read -r PRINTK < /proc/sys/kernel/printk
+PRINTK=${PRINTK:0:1}
+export PRINTK
+
+# Set it to 0
+echo 0 > /proc/sys/kernel/printk
+
+# try to set console options for display and interaction
+# this is sometimes run as an initqueue hook, but cannot be guaranteed
+#shellcheck disable=SC2154
+test -x /lib/udev/console_init -a -c "${control_term}" \
+  && /lib/udev/console_init "${control_term##*/}" >/dev/null 2>&1
+
+# set the console size, if indicated
+#shellcheck disable=SC2154
+if [ -n "$zbm_lines" ]; then
+  stty rows "$zbm_lines"
+fi
+
+#shellcheck disable=SC2154
+if [ -n "$zbm_columns" ]; then
+  stty cols "$zbm_columns"
+fi
+
+# This is a load bearing echo, do not remove!
+echo "Loading ZFSBootMenu ..."
+
+export BASE="/zfsbootmenu"
+mkdir -p "${BASE}"
+
+modprobe zfs 2>/dev/null
+udevadm settle
+
+#shellcheck disable=SC2154
+if [ -n "${zbm_tmux}" ] && [ -x /bin/tmux ]; then
+  tmux new-session -n ZFSBootMenu -d /libexec/zfsbootmenu-countdown
+  tmux new-window -n logs dmesg -W -T
+  tmux new-window -n shell /bin/bash
+  exec tmux attach-session \; select-window -t ZFSBootMenu
+else
+  # https://busybox.net/FAQ.html#job_control
+  exec setsid bash -c "exec /libexec/zfsbootmenu-countdown <${control_term} >${control_term} 2>&1"
+fi

--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -46,6 +46,13 @@ zbm_lines=$( getarg zbm.lines=)
 # shellcheck disable=SC2034
 zbm_columns=$( getarg zbm.columns=)
 
+# Turn on tmux integrations
+# shellcheck disable=SC2034
+if getargbool 0 zbm.tmux ; then
+  zbm_tmux="yes"
+  info "ZFSBootMenu: Enabling tmux integrations"
+fi
+
 wait_for_zfs=0
 case "${root}" in
   ""|zfsbootmenu|zfsbootmenu:)


### PR DESCRIPTION
It'd be nice to have the ability to see what is on the filesystem, what processes are running, etc in a running initramfs no matter where we are in ZFSBootMenu. Enter `tmux`. Set `zbm.tmux=1` on the ZBM KCL and build the initramfs with [dracut-tmux](https://github.com/zbm-dev/dracut-tmux) and /bin/zfsbootmenu will be launched in `tmux`. This has the added benefit of enabling job control for all processes launched under tmux.

I've moved anything considered 'setup' from `zfsbootmenu-countdown.sh` to `zfsbootmenu-exec.sh` so that whatever is launched (tmux, or zfsbootmenu-countdown) is started with the correct serial terminal size, environment variables, etc.

This requires someone to doubly opt in - both by explicitly enabling the `dracut-tmux` module and by setting the right KCL argument. This is otherwise a very very small code path change in `zfsbootmenu-exec.sh`.