### PR TITLE
Support optional "teardown" script to run before kexec

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -138,6 +138,16 @@ install() {
   inst_hook cmdline 95 "${moddir}/zfsbootmenu-parse-commandline.sh" || _ret=$?
   inst_hook pre-mount 90 "${moddir}/zfsbootmenu-exec.sh" || _ret=$?
 
+  # Install a "teardown" hook if specified and it exists
+  # shellcheck disable=SC2154
+  if [ -n "${zfsbootmenu_teardown}" ]; then
+    if [ -x "${zfsbootmenu_teardown}" ]; then
+      inst_simple "${zfsbootmenu_teardown}" "/libexec/zfsbootmenu-teardown" || _ret=$?
+    else
+      dwarning "no executable teardown script (${zfsbootmenu_teardown}); cannot install"
+    fi
+  fi
+
   if [ ${_ret} -ne 0 ]; then
     dfatal "Unable to install core ZFSBootMenu functions"
     exit 1

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -247,6 +247,9 @@ kexec_kernel() {
     export_pool "${pool}"
   fi
 
+  # Run a teardown script, if one exists
+  [ -x /libexec/zfsbootmenu-teardown ] && /libexec/zfsbootmenu-teardown
+
   kexec -e -i
 }
 

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,4 @@ install:
 	install -m 0644 -t $(DESTDIR)/usr/share/man/man5/ -D man/generate-zbm.5
 	install -m 0644 -t $(DESTDIR)/usr/share/man/man7/ -D man/zfsbootmenu.7
 	install -m 0644 -t $(DESTDIR)/usr/share/man/man8/ -D man/generate-zbm.8
+	install -m 0755 -t $(DESTDIR)/usr/share/examples/zfsbootmenu/ -D contrib/xhci-teardown.sh

--- a/contrib/xhci-teardown.sh
+++ b/contrib/xhci-teardown.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+## Some XHCI USB controllers, like on a 2015 MacBook Air, will not be properly
+## reinitialized after ZFSBootMenu jumps into the system kernel with kexec; no
+## USB devices will be enumerated, so e.g., keyboards will not function.
+##
+## One way to work around this is to just blacklist USB modules in ZFSBootMenu,
+## but this prevents keyboard interaction in the boot menu. A better
+## alternative is to try unbinding all USB controllers from xhci_hcd
+## immediately before jumping into the new kernel, which allows the new kernel
+## to properly initialize the USB subsystem.
+##
+## This could be adapted to other drivers, including {O,U,E}HCI as necessary.
+##
+## To use, put this script somewhere, make sure it is executable, and set the
+## option `zfsbootmenu_teardown=<path to script>` in a dracut.conf(5) file
+## inside the directory specified for `Global.DracutConfDir` in the ZFSBootMenu
+## `config.yaml`.
+
+SYS_XHCI=/sys/bus/pci/drivers/xhci_hcd
+
+# shellcheck disable=SC2231
+for DEVPATH in ${SYS_XHCI}/????:??:??.?; do
+	[ -L "${DEVPATH}" ] || continue
+	DEVICE="${DEVPATH#${SYS_XHCI}/}"
+	echo "Tearing down USB controller ${DEVICE}..."
+	echo "${DEVICE}" > ${SYS_XHCI}/unbind
+done

--- a/man/zfsbootmenu.7
+++ b/man/zfsbootmenu.7
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "zfsbootmenu 7"
-.TH zfsbootmenu 7 "2020-11-11" "1.7.1" "ZFSBootMenu"
+.TH zfsbootmenu 7 "2020-12-08" "1.7.1" "ZFSBootMenu"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -211,9 +211,17 @@ This specifies the prefix added to the \s-1ZFS\s0 filesystem provided as the roo
 The default prefix is \fIroot=zfs:\fR on all systems except those that appear to be Arch Linux. For Arch, the default root prefix is \fIzfs=\fR.
 .Sp
 Set this property to override the value determined from inspecting the boot environment.
+.SH "Dracut Options"
+.IX Header "Dracut Options"
+In addition to standard dracut configuration options, the ZFSBootMenu dracut module supports an addtional option to customize boot behavior.
+.IP "\fBzfsbootmenu_teardown=<executable>\fR" 4
+.IX Item "zfsbootmenu_teardown=<executable>"
+An optional variable specifying the path to a teardown script that will be installed in the ZFSBootMenu initramfs. If this key is set but no file exists at the path \fB<executable>\fR or the file is not executable, a warning will be issued but initramfs creation will proceed.
+.Sp
+Some hardware initialized by the kernel used to boot ZFSBootMenu may not be properly reinitialized when a boot environment is launched. A teardown executable, if provided, will be inovked by ZFSBootMenu immediately before \fBkexec\fR is invoked to jump into the selected kernel. This script can be used, for example, to unbind drivers from hardware or remove kernel modules.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
-\&\fBgenerate-zbm\fR(5) \fBgenerate-zbm\fR(8)
+\&\fBgenerate-zbm\fR(5) \fBgenerate-zbm\fR(8) \fBdracut.conf\fR(5)
 .SH "AUTHOR"
 .IX Header "AUTHOR"
 ZFSBootMenu Team <https://github.com/zbm\-dev/zfsbootmenu>

--- a/pod/zfsbootmenu.7.pod
+++ b/pod/zfsbootmenu.7.pod
@@ -97,9 +97,23 @@ Set this property to override the value determined from inspecting the boot envi
 
 =back
 
+=head1 Dracut Options
+
+In addition to standard dracut configuration options, the ZFSBootMenu dracut module supports an addtional option to customize boot behavior.
+
+=over 4
+
+=item B<zfsbootmenu_teardown=E<lt>executableE<gt>>
+
+An optional variable specifying the path to a teardown script that will be installed in the ZFSBootMenu initramfs. If this key is set but no file exists at the path B<E<lt>executableE<gt>> or the file is not executable, a warning will be issued but initramfs creation will proceed.
+
+Some hardware initialized by the kernel used to boot ZFSBootMenu may not be properly reinitialized when a boot environment is launched. A teardown executable, if provided, will be inovked by ZFSBootMenu immediately before B<kexec> is invoked to jump into the selected kernel. This script can be used, for example, to unbind drivers from hardware or remove kernel modules.
+
+=back
+
 =head1 SEE ALSO
 
-B<generate-zbm>(5) B<generate-zbm>(8)
+B<generate-zbm>(5) B<generate-zbm>(8) B<dracut.conf>(5)
 
 =head1 AUTHOR
 


### PR DESCRIPTION
A new `zfsbootmenu_teardown` dracut option has been added to `module-init.sh` that, when set to a path that refers to an executable, will install the named executable as `/libexec/zfsbootmenu-teardown` in the initramfs. In `kexec_kernel`, if `/libexec/zfsbootmenu-teardown` is found to exist and be executable, the script will be run immediately before the final `kexec` call to jump into the new kernel.

On my 2015 "VoidBook Air", the system keyboard, trackpad and bluetooth controller are connected to the XHCI USB hub. These devices are fully functional in ZBM, but when I boot the final kernel,  I can see the hub but not the peripherals. With the following teardown hook:
```bash
#!/bin/sh

SYS_XHCI=/sys/bus/pci/drivers/xhci_hcd

for DEVPATH in ${SYS_XHCI}/????:??:??.?; do
	[ -L "${DEVPATH}" ] || continue
	DEVICE="${DEVPATH#${SYS_XHCI}/}"
	echo "Tearing down USB controller ${DEVICE}..."
	echo "${DEVICE}" > ${SYS_XHCI}/unbind
done
```
I can unbind the XHCI device from the driver, which allows the final kernel to properly initialize the device and my peripherals to function.

I suspect there are a few use cases like this where a teardown script will be useful to ease the kexec transition. The script is not intended to interact with any ZFS pools or filesystems, so is executed at the last possible moment (specifically, after the pool is exported.)