### PR TITLE
Integrate the work done in dracut-tmux for a decreased deployment burden

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -154,6 +154,29 @@ install() {
     exit 1
   fi
 
+  # Optionally install tmux
+  # shellcheck disable=SC2154
+  if [ "${zfsbootmenu_tmux}" = true ]; then
+    # user-defined configuration file
+    if [ -n "${zfsbotmenu_tmux_conf}" ] && [ -e "${zfsbootmenu_tmux_conf}" ]; then
+      tmux_conf="${zfsbootmenu_tmux_conf}"
+    # default file shipped with zfsbootmenu
+    elif [ -e "${moddir}/tmux.conf" ]; then
+      tmux_conf="${moddir}/tmux.conf"
+    fi
+
+    # Only attempt to install if we have a configuration file available
+    if [ -n "${tmux_conf}" ] ; then
+      dracut_install tmux
+      inst_simple "${tmux_conf}" "/etc/tmux.conf"
+      
+      # glibc locale file
+      if [ -e "/usr/lib/locale/locale-archive" ]; then
+        inst_simple "/usr/lib/locale/locale-archive" "/usr/lib/locale/locale-archive"
+      fi
+    fi
+  fi
+
   if [ -e /etc/zfs/zpool.cache ]; then
     inst /etc/zfs/zpool.cache
     type mark_hostonly >/dev/null 2>&1 && mark_hostonly /etc/zfs/zpool.cache

--- a/90zfsbootmenu/tmux.conf
+++ b/90zfsbootmenu/tmux.conf
@@ -1,0 +1,6 @@
+set -g default-terminal "vt220"
+set -g default-shell "/bin/bash"
+set -g status-justify centre
+set -g status-style fg=colour255,bg=colour0
+set -g status-left ""
+set -g status-right ""

--- a/man/generate-zbm.8
+++ b/man/generate-zbm.8
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "generate-zbm 8"
-.TH generate-zbm 8 "2020-11-16" "1.7.1" "generate-zbm"
+.TH generate-zbm 8 "2020-12-06" "1.7.1" "generate-zbm"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -179,6 +179,9 @@ Set the \fIGlobal.ManageImages\fR option to true, enabling image generation.
 .IP "\fB\-\-disable\fR" 4
 .IX Item "--disable"
 Set the \fIGlobal.ManageImages\fR option to false, disabling image generation.
+.IP "\fB\-\-debug|d\fR" 4
+.IX Item "--debug|d"
+Enable debug output
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
 \&\fBgenerate-zbm\fR(5) \fBzfsbootmenu\fR(7)

--- a/man/zfsbootmenu.7
+++ b/man/zfsbootmenu.7
@@ -211,14 +211,23 @@ This specifies the prefix added to the \s-1ZFS\s0 filesystem provided as the roo
 The default prefix is \fIroot=zfs:\fR on all systems except those that appear to be Arch Linux. For Arch, the default root prefix is \fIzfs=\fR.
 .Sp
 Set this property to override the value determined from inspecting the boot environment.
+.IP "\fBzbm.tmux\fR" 4
+.IX Item "zbm.tmux"
+Indicate that ZFSBootMenu should be run under \fBtmux\fR in the initramfs. With this enabled, debug-level logging for the ZFSBootMenu scripts can be easily viewed. The tooling must also be installed with an additional dracut configuration option listed below.
 .SH "Dracut Options"
 .IX Header "Dracut Options"
-In addition to standard dracut configuration options, the ZFSBootMenu dracut module supports an addtional option to customize boot behavior.
+In addition to standard dracut configuration options, the ZFSBootMenu dracut module supports addtional options to customize boot behavior.
 .IP "\fBzfsbootmenu_teardown=<executable>\fR" 4
 .IX Item "zfsbootmenu_teardown=<executable>"
 An optional variable specifying the path to a teardown script that will be installed in the ZFSBootMenu initramfs. If this key is set but no file exists at the path \fB<executable>\fR or the file is not executable, a warning will be issued but initramfs creation will proceed.
 .Sp
 Some hardware initialized by the kernel used to boot ZFSBootMenu may not be properly reinitialized when a boot environment is launched. A teardown executable, if provided, will be inovked by ZFSBootMenu immediately before \fBkexec\fR is invoked to jump into the selected kernel. This script can be used, for example, to unbind drivers from hardware or remove kernel modules.
+.IP "\fBzfsbootmenu_tmux=true\fR" 4
+.IX Item "zfsbootmenu_tmux=true"
+An optional variable enabling the installation of \fBtmux\fR and a minimal \fBtmux.conf\fR in the initramfs.
+.IP "\fBzfsbootmenu_tmux_conf=<tmux.conf>\fR" 4
+.IX Item "zfsbootmenu_tmux_conf=<tmux.conf>"
+An optional variable specifying the path to an alternate \fBtmux\fR configuration file. If this key is set but no file exists at the path \fB<tmux.conf>\fR, the default configuration file is instead used.
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"
 \&\fBgenerate-zbm\fR(5) \fBgenerate-zbm\fR(8) \fBdracut.conf\fR(5)

--- a/pod/zfsbootmenu.7.pod
+++ b/pod/zfsbootmenu.7.pod
@@ -95,11 +95,15 @@ The default prefix is I<root=zfs:> on all systems except those that appear to be
 
 Set this property to override the value determined from inspecting the boot environment.
 
+=item B<zbm.tmux>
+
+Indicate that ZFSBootMenu should be run under B<tmux> in the initramfs. With this enabled, debug-level logging for the ZFSBootMenu scripts can be easily viewed. The tooling must also be installed with an additional dracut configuration option listed below.
+
 =back
 
 =head1 Dracut Options
 
-In addition to standard dracut configuration options, the ZFSBootMenu dracut module supports an addtional option to customize boot behavior.
+In addition to standard dracut configuration options, the ZFSBootMenu dracut module supports addtional options to customize boot behavior.
 
 =over 4
 
@@ -108,6 +112,14 @@ In addition to standard dracut configuration options, the ZFSBootMenu dracut mod
 An optional variable specifying the path to a teardown script that will be installed in the ZFSBootMenu initramfs. If this key is set but no file exists at the path B<E<lt>executableE<gt>> or the file is not executable, a warning will be issued but initramfs creation will proceed.
 
 Some hardware initialized by the kernel used to boot ZFSBootMenu may not be properly reinitialized when a boot environment is launched. A teardown executable, if provided, will be inovked by ZFSBootMenu immediately before B<kexec> is invoked to jump into the selected kernel. This script can be used, for example, to unbind drivers from hardware or remove kernel modules.
+
+=item B<zfsbootmenu_tmux=true>
+
+An optional variable enabling the installation of B<tmux> and a minimal B<tmux.conf> in the initramfs.
+
+=item B<zfsbootmenu_tmux_conf=E<lt>tmux.confE<gt>>
+
+An optional variable specifying the path to an alternate B<tmux> configuration file. If this key is set but no file exists at the path B<E<lt>tmux.confE<gt>>, the default configuration file is instead used.
 
 =back
 


### PR DESCRIPTION
Instead of relying on another Dracut module to install a few files this can be integrated fairly easily in `module-setup.sh`. A double opt-in is still required; once to enable installation of the tools and a second time to subsequently turn tmux on in the initramfs.