### PR TITLE
RFC/WIP: Add zlog() logging helper, along with debug-level logging

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -136,6 +136,7 @@ install() {
   inst_simple "${moddir}/zfsbootmenu.sh" "/bin/zfsbootmenu" || _ret=$?
   inst_simple "${moddir}/zfsbootmenu-input.sh" "/bin/zfsbootmenu-input" || _ret=$?
   inst_simple "${moddir}/zfsbootmenu-help.sh" "/bin/zfsbootmenu-help" || _ret=$?
+  inst_simple "${moddir}/zlogtail.sh" "/bin/zlogtail" || _ret=$?
   inst_hook cmdline 95 "${moddir}/zfsbootmenu-parse-commandline.sh" || _ret=$?
   inst_hook pre-mount 90 "${moddir}/zfsbootmenu-exec.sh" || _ret=$?
 

--- a/90zfsbootmenu/zfsbootmenu-exec.sh
+++ b/90zfsbootmenu/zfsbootmenu-exec.sh
@@ -4,6 +4,7 @@
 export spl_hostid
 export force_import
 export menu_timeout
+export loglevel
 export root
 
 # store current kernel log level
@@ -43,7 +44,7 @@ test -x /lib/udev/console_init -a -c "${control_term}" \
 #shellcheck disable=SC2154
 if [ -n "${zbm_tmux}" ] && [ -x /bin/tmux ]; then
   tmux new-session -n ZFSBootMenu -d /libexec/zfsbootmenu-countdown
-  tmux new-window -n logs dmesg -W -T
+  tmux new-window -n logs /bin/zlogtail
   tmux new-window -n shell /bin/bash
   exec tmux attach-session \; select-window -t ZFSBootMenu
 else

--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -53,6 +53,13 @@ if getargbool 0 zbm.tmux ; then
   info "ZFSBootMenu: Enabling tmux integrations"
 fi
 
+loglevel=$( getarg loglevel=)
+if [ -n "${loglevel}" ]; then
+  info "ZFSBootMenu: setting log level from command line: ${loglevel}"
+else
+  loglevel=3
+fi
+
 wait_for_zfs=0
 case "${root}" in
   ""|zfsbootmenu|zfsbootmenu:)

--- a/90zfsbootmenu/zlogtail.sh
+++ b/90zfsbootmenu/zlogtail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+dmesg -T --time-format reltime --noescape -w | fzf --no-sort --ansi --tac --no-info


### PR DESCRIPTION
Before I continue any further with adding zdebug/zinfo logging throughout the code base, I'd like to get a second set of eyes on the work as it stands.  The `zdebug` function generates log lines at a debug level in the kernel ring buffer:

```
2020-12-08T22:24:02,974442+00:00 ZBM:/libexec/zfsbootmenu-countdown[404]:import_pool(): read_write unset
2020-12-08T22:24:02,974535+00:00 ZBM:/libexec/zfsbootmenu-countdown[404]:import_pool(): all_pools set: yes
2020-12-08T22:24:02,974606+00:00 ZBM:/libexec/zfsbootmenu-countdown[404]:import_pool(): zpool import arguments: -N -o readonly=on -a 
2020-12-08T22:24:03,229771+00:00 ZBM:/libexec/zfsbootmenu-countdown[404]:import_pool(): import process return: 0
2020-12-08T22:24:06,779267+00:00 ZBM:/bin/zfsbootmenu[570]:be_has_encroot(): feature@encryption not active on ztest
2020-12-08T22:24:06,787297+00:00 ZBM:/bin/zfsbootmenu[570]:be_has_encroot(): feature@encryption not active on ztest
2020-12-08T22:24:06,798461+00:00 ZBM:/bin/zfsbootmenu[570]:mount_zfs(): mounting ztest/ROOT/void at /zfsbootmenu/ztest/ROOT/void/mnt with zfsutil                                                                                                                                         
2020-12-08T22:24:06,824862+00:00 ZBM:/bin/zfsbootmenu[570]:mount_zfs(): mount return code: 0
2020-12-08T22:24:06,849739+00:00 ZBM:/bin/zfsbootmenu[570]:preload_be_cmdline(): using org.zfsbootmenu:commandline
2020-12-08T22:24:06,853193+00:00 ZBM:/bin/zfsbootmenu[570]:draw_be(): using environment file: /zfsbootmenu/env
2020-12-08T22:24:06,885556+00:00 ZBM:/usr/sbin/zfsbootmenu-preview.sh[616]:load_be_cmdline(): using /zfsbootmenu/ztest/ROOT/void/cmdline as commandline for ztest/ROOT/void                                                                                                               
2020-12-08T22:24:06,887859+00:00 ZBM:/usr/sbin/zfsbootmenu-preview.sh[616]:load_be_cmdline(): processed commandline: spl_hostid=68f7287a ro quiet console=tty1 console=hvc0
```
The log format is `ZBM: <calling script>[PID]:function_name(): arbitrary message` . These log lines are colorized to allow easier at-a-glance consumption.