### PR TITLE
Support configurable, opt-in caching of key files

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-countdown.sh
+++ b/90zfsbootmenu/zfsbootmenu-countdown.sh
@@ -86,7 +86,7 @@ if [ -n "${BOOTFS}" ]; then
     if delay="${menu_timeout}" prompt="Booting ${BOOTFS} in %0.2d seconds" timed_prompt "[ENTER] to boot" "[ESC] boot menu" ; then
       # Clear screen before a possible password prompt
       tput clear
-      if ! load_key "${BOOTFS}"; then
+      if ! NO_CACHE=1 load_key "${BOOTFS}"; then
         emergency_shell "unable to load key for ${BOOTFS}; type 'exit' to continue"
       elif find_be_kernels "${BOOTFS}" && [ ! -e "${BASE}/active" ]; then
         # Automatically select a kernel and boot it

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -395,7 +395,7 @@ duplicate_snapshot() {
 # returns: 0 on success
 
 clone_snapshot() {
-  local selected target pool output opts parent
+  local selected target pool opts parent
 
   selected="${1}"
   target="${2}"
@@ -487,7 +487,7 @@ set_default_kernel() {
 # returns: nothing
 
 set_default_env() {
-  local environment pool output
+  local environment pool
 
   environment="${1}"
   [ -n "${environment}" ] || return 1
@@ -1338,10 +1338,10 @@ load_key() {
 
 # arg1: path to BE list
 # prints: nothing
-# returns: 0 on success, 1 on failure
+# returns: 0 iff at least one valid BE was found
 
 populate_be_list() {
-  local be_list fs mnt active candidates
+  local be_list fs mnt active candidates ret
 
   be_list="${1}"
   [ -n "${be_list}" ] || return 1
@@ -1372,17 +1372,18 @@ populate_be_list() {
   # put bootfs on the end, so it is shown first with --tac
   [ -n "${BOOTFS}" ] && candidates+=( "${BOOTFS}" )
 
+  ret=1
   for fs in "${candidates[@]}"; do
     # Unlock if necessary
     load_key "${fs}" || continue
 
     # Candidates are added to BE list if they have kernels in /boot
-    # shellcheck disable=SC2034
-    if output="$( find_be_kernels "${fs}" )" ; then
+    if find_be_kernels "${fs}"; then
       echo "${fs}" >> "${be_list}"
+      ret=0
     fi
   done
-  return 0
+  return $ret
 }
 
 

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -87,10 +87,13 @@ while true; do
 
   if [ ${BE_SELECTED} -eq 0 ]; then
     # Populate the BE list, load any keys as necessary
-    populate_be_list "${BASE}/env"
-    if [ ! -f "${BASE}/env" ]; then
-      emergency_shell "no boot environments with kernels found"
-      continue
+    if ! populate_be_list "${BASE}/env" || [ ! -f "${BASE}/env" ]; then
+      color=red delay=10 timed_prompt \
+        "No boot environments with kernels found" \
+        "Dropping to an emergency shell to allow recovery attempts"
+      tput clear
+      tput cnorm
+      exit 1
     fi
 
     bootenv="$( draw_be "${BASE}/env" )"

--- a/man/zfsbootmenu.7
+++ b/man/zfsbootmenu.7
@@ -214,6 +214,13 @@ This specifies the prefix added to the \s-1ZFS\s0 filesystem provided as the roo
 The default prefix is \fIroot=zfs:\fR on all systems except those that appear to be Arch Linux. For Arch, the default root prefix is \fIzfs=\fR.
 .Sp
 Set this property to override the value determined from inspecting the boot environment.
+.IP "\fBorg.zfsbootmenu:keysource=<filesystem>\fR" 4
+.IX Item "org.zfsbootmenu:keysource=<filesystem>"
+If specified, this provides the name of the \s-1ZFS\s0 filesystem from which keys for a particular boot environment will be sourced.
+.Sp
+Normally, when ZFSBootMenu attempts to load encryption keys for a boot environment, it will attempt to look for a key file at the path specified by the \fIkeylocation\fR property on the \fIencryptionroot\fR for that boot environment. If that file does not exist, and \fIkeyformat=passphrase\fR is set for the \fIencryptionroot\fR (or \fIkeylocation=prompt\fR), ZFSBootMenu will prompt for a passphrase to unlock the boot environment. These passphrases entered are not cached by default.
+.Sp
+When \fBorg.zfsbootmenu:keysource\fR is a mountable \s-1ZFS\s0 filesystem, before prompting for a passphrase when \fIkeylocation\fR is not set to \fIprompt\fR, ZFSBootMenu will attempt to mount \fB<filesystem>\fR (unlocking that, if necessary) and search for the key file at \fIkeylocation\fR relative to \fB<filesystem>\fR. If such a file is found, it will be copied to the initramfs, and the copy in the initramfs will be used to decrypt the original boot environment. Any copied keys are retained until ZFSBootMenu boots an environment, so a single password prompt can be sufficient to unlock several pools with the same \fIkeysource\fR or prevent prompts from reappearing when the pool must be exported and reimported (for example, to alter boot parameters from within ZFSBootMenu).
 .SH "Dracut Options"
 .IX Header "Dracut Options"
 In addition to standard dracut configuration options, the ZFSBootMenu dracut module supports addtional options to customize boot behavior.

--- a/pod/zfsbootmenu.7.pod
+++ b/pod/zfsbootmenu.7.pod
@@ -99,6 +99,14 @@ The default prefix is I<root=zfs:> on all systems except those that appear to be
 
 Set this property to override the value determined from inspecting the boot environment.
 
+=item B<org.zfsbootmenu:keysource=E<lt>filesystemE<gt>>
+
+If specified, this provides the name of the ZFS filesystem from which keys for a particular boot environment will be sourced.
+
+Normally, when ZFSBootMenu attempts to load encryption keys for a boot environment, it will attempt to look for a key file at the path specified by the I<keylocation> property on the I<encryptionroot> for that boot environment. If that file does not exist, and I<keyformat=passphrase> is set for the I<encryptionroot> (or I<keylocation=prompt>), ZFSBootMenu will prompt for a passphrase to unlock the boot environment. These passphrases entered are not cached by default.
+
+When B<org.zfsbootmenu:keysource> is a mountable ZFS filesystem, before prompting for a passphrase when I<keylocation> is not set to I<prompt>, ZFSBootMenu will attempt to mount B<E<lt>filesystemE<gt>> (unlocking that, if necessary) and search for the key file at I<keylocation> relative to B<E<lt>filesystemE<gt>>. If such a file is found, it will be copied to the initramfs, and the copy in the initramfs will be used to decrypt the original boot environment. Any copied keys are retained until ZFSBootMenu boots an environment, so a single password prompt can be sufficient to unlock several pools with the same I<keysource> or prevent prompts from reappearing when the pool must be exported and reimported (for example, to alter boot parameters from within ZFSBootMenu).
+
 =back
 
 =head1 Dracut Options


### PR DESCRIPTION
By setting `org.zfsbootmenu:keysource=<keysource>` on a BE or its parent, load_key will attempt to look for a key file specified by a `file://` keylocation relative to the filesystem specified by `<keysource>` and will cache this key within the initramfs. This allows single-sign-on for multiple BEs that have different encryption roots but a common keysource and keylocation.

Note: to prevent needless mounts, the cache is disabled when loading a key for automatic boot following the expiration of the countdown.

## Tests
- [x] Single pool, ZBM VM, set `org.zfsbootmenu:keysource=ztest/ROOT/void` on the common `ztest/ROOT` parent
- [x] Two pools, four BEs, bare metal, see details below
- [x] Multiple pools with cyclic dependencies (*e.g.*, `org.zfsbootmenu:keysource=zbackup/ROOT/void` on `ztest/ROOT/void` and `org.zfsbootmenu:keysource=ztest/ROOT/void` on `zbackup/ROOT/void`); I *believe* the recursion breakout does the right thing, but this needs to be tested
- [ ] Any other arbitrarily complex pool layouts you can imagine
- [ ] Regression test for existing setups without `org.zfsbootmenu:keysource` (should never touch `${BASE}/.keys` in this case)

## Two-pool, four-BE detail
Pool layout (relevant portions):
```
NAME                                        MOUNTPOINT          ENCROOT                           KEYLOCATION                 ORG.ZFSBOOTMENU:KEYSOURCE
system                                      none                system                            file:///etc/zfs/system.key  -
system/OS                                   none                system                            none                        system/OS/void
system/OS/void                              /                   system                            none                        system/OS/void
system/OS/void-musl                         /                   system                            none                        system/OS/void
tank                                        /tank               -                                 none                        -
tank/replicant                              none                -                                 none                        -
tank/replicant/gggggggggggg                 none                -                                 none                        -
tank/replicant/gggggggggggg/OS              none                tank/replicant/gleason40rmt/OS    prompt                      -
tank/replicant/gggggggggggg/OS/void         /                   tank/replicant/gleason40rmt/OS    none                        -
tank/replicant/localhost                    none                -                                 none                        -
tank/replicant/localhost/OS                 none                tank/replicant/localhost/OS       file:///etc/zfs/system.key  system/OS/void
tank/replicant/localhost/OS/void            /                   tank/replicant/localhost/OS       none                        system/OS/void
tank/replicant/localhost/OS/void-musl       /                   tank/replicant/localhost/OS       none                        system/OS/void
tank/replicant/vba                          none                -                                 none                        -
tank/replicant/vba/OS                       none                tank/replicant/vba/OS             prompt                      -
tank/replicant/vba/OS/void                  /                   tank/replicant/vba/OS             none                        -
```

1. At boot, press `[Esc]` to drop to the menu.
2. ZBM prompts for passphrases (order is arbitrary):
    - `system`
    - `tank/replicant/gggggggggggg/OS`
    - `tank/replicant/vba/OS`
3. Menu appears, showing all six of the `void` BEs and the two `void-musl` BEs.
    - Note that ZBM did not prompt for `tank/replciant/localhost/OS` because the key was cached.
4. Drop to emergency shell, confirm existence of `/zfsbootmenu/.keys/system/OS/void/etc/zfs/system.key`
