### PR TITLE
Namespace our KCL args, organize parsing

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -16,21 +16,7 @@ else
   warn "ZFSBootMenu: Pools may not import correctly."
 fi
 
-# Force import pools only when explicitly told to do so
-if getargbool 0 force_import ; then
-  # shellcheck disable=SC2034
-  force_import="yes"
-  info "ZFSBootMenu: Enabling force import of ZFS pools"
-fi
-
-# Set a menu timeout, to allow immediate booting
-menu_timeout=$( getarg timeout=)
-if [ -n "${menu_timeout}" ]; then
-  info "ZFSBootMenu: Setting menu timeout from command line: ${menu_timeout}"
-else
-  menu_timeout=10
-fi
-
+# Use the last defined console= to control menu output
 control_term=$( getarg console=)
 if [ -n "${control_term}" ]; then
   info "ZFSBootMenu: Setting controlling terminal to: ${control_term}"
@@ -38,6 +24,35 @@ if [ -n "${control_term}" ]; then
 else
   control_term="/dev/tty1"
   info "ZFSBootMenu: Defaulting controlling terminal to: ${control_term}"
+fi
+
+# Use loglevel to determine logging to /dev/kmsg
+loglevel=$( getarg loglevel=)
+if [ -n "${loglevel}" ]; then
+  info "ZFSBootMenu: setting log level from command line: ${loglevel}"
+else
+  loglevel=3
+fi
+
+# Force import pools only when explicitly told to do so
+if getargbool 0 zbm.force_import -d force_import ; then
+  # shellcheck disable=SC2034
+  force_import="yes"
+  info "ZFSBootMenu: Enabling force import of ZFS pools"
+fi
+
+# zbm.timeout= overrides timeout=
+menu_timeout=$( getarg zbm.timeout -d timeout )
+if [ -n "${menu_timeout}" ]; then
+  info "ZFSBootMenu: Setting menu timeout from command line: ${menu_timeout}"
+elif getargbool 0 zbm.show ; then
+  menu_timeout=-1;
+  info "ZFSBootMenu: forcing display of menu"
+elif getargbool 0 zbm.skip ; then
+  menu_timeout=0;
+  info "ZFSBootMenu: skipping display of menu"
+else
+  menu_timeout=10
 fi
 
 # Allow setting of console size; there are no defaults here
@@ -51,13 +66,6 @@ zbm_columns=$( getarg zbm.columns=)
 if getargbool 0 zbm.tmux ; then
   zbm_tmux="yes"
   info "ZFSBootMenu: Enabling tmux integrations"
-fi
-
-loglevel=$( getarg loglevel=)
-if [ -n "${loglevel}" ]; then
-  info "ZFSBootMenu: setting log level from command line: ${loglevel}"
-else
-  loglevel=3
 fi
 
 wait_for_zfs=0

--- a/pod/zfsbootmenu.7.pod
+++ b/pod/zfsbootmenu.7.pod
@@ -12,42 +12,50 @@ These options are set on the kernel command line when booting the initramfs or U
 
 =over 4
 
+=item B<root=zfsbootmenu:POOL=E<lt>poolE<gt>>
+
+By default, ZFSBootMenu will look for the I<bootfs> property on the first pool it imports to select the default boot environment. If you have multiple pools, substitute the name of your preferred pool for B<E<lt>poolE<gt>> in the argument B<root=zfsbootmenu:POOL=E<lt>poolE<gt>>.
+
 =item B<spl_hostid=E<lt>hostidE<gt>>
 
 When creating an initramfs or UEFI bundle, the I<hostid> from the system is copied into the target. If this image will be used on another system with a different I<hostid>, it can be overridden with this option.
 
 Replace B<E<lt>hostidE<gt>> with an eight-digit hexadecimal number.
 
-=item B<force_import=1>
+=item B<zbm.force_import=1>
 
 Set this option to attempt to force pool imports. When set, this invokes I<zpool import -f> in place of the regular I<zpool import> command, which will attempt to import a pool that's potentially in use on another system. Use this option with caution!
 
-Omit this option or explicitly specify B<force_import=0> to disable forced imports.
+Omit this option or explicitly specify B<zbm.force_import=0> to disable forced imports.
 
-=item B<timeout>
+=item B<force_import=1>
+
+Deprecated; use B<zbm.force_import>.
+
+=item B<zbm.timeout>
 
 This option accepts numeric values that control whether and when the
 boot-environment menu should be displayed.
 
 =over 2
 
-=item B<timeout=0>
+=item B<zbm.timeout=0> | B<zbm.skip>
 
 When possible, bypass the menu and immediately boot a configured I<bootfs> pool property.
 
-=item B<timeout=-1>
+=item B<zbm.timeout=-1> | B<zbm.show>
 
 Rather than present a countdown timer for automatic selection, immediately display the boot-environment menu.
 
-=item B<timeout=E<lt>positive integerE<gt>>
+=item B<zbm.timeout=E<lt>positive integerE<gt>>
 
 Display a countdown timer for the specified number of seconds before booting the configured I<bootfs> boot environment.
 
 =back
 
-=item B<root=zfsbootmenu:POOL=E<lt>poolE<gt>>
+=item B<timeout>
 
-By default, ZFSBootMenu will look for the I<bootfs> property on the first pool it imports to select the default boot environment. If you have multiple pools, substitute the name of your preferred pool for B<E<lt>poolE<gt>> in the argument B<root=zfsbootmenu:POOL=E<lt>poolE<gt>>.
+Deprecated; use B<zbm.timeout>.
 
 =item B<zbm.tmux>
 

--- a/testing/run.sh
+++ b/testing/run.sh
@@ -49,14 +49,14 @@ case "$(uname -m)" in
     BIN="qemu-system-ppc64"
     KERNEL="${TESTDIR}/vmlinux-bootmenu"
     MACHINE="pseries,accel=kvm,kvm-type=HV,cap-hpt-max-page-size=4096"
-    APPEND="loglevel=7 timeout=5 root=zfsbootmenu:POOL=ztest"
+    APPEND="loglevel=7 zbm.timeout=5 root=zfsbootmenu:POOL=ztest"
     SERDEV="hvc0"
   ;;
   x86_64)
     BIN="qemu-system-x86_64"
     KERNEL="${TESTDIR}/vmlinuz-bootmenu"
     MACHINE="type=q35,accel=kvm"
-    APPEND="loglevel=7 timeout=5 root=zfsbootmenu:POOL=ztest"
+    APPEND="loglevel=7 zbm.timeout=5 root=zfsbootmenu:POOL=ztest"
     SERDEV="ttyS0"
   ;;
 esac


### PR DESCRIPTION
Move all ZFSBootMenu-specific arguments to the `zbm.*` argument space. Legacy values are still accepted in lieu of the new `zbm.` value, but will produce a warning on the kernel ring buffer. Timeout values have been expanded to work as follows:

zbm.timeout (or timeout) to set an explicit timeout option
OR zbm.show sets `menu_timeout=-1` to force the main menu
OR zbm.skip sets `menu_timeout=0` to skip the menu and directly boot `BOOTFS`
finally if none of these options are set, `menu_timeout=10` is set. 

The order of these tests might want to be flipped around to give precedence to `zbm.show` / `zbm.skip` - thoughts?