### PR TITLE
Change chroot keys, add help text

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-help.sh
+++ b/90zfsbootmenu/zfsbootmenu-help.sh
@@ -113,9 +113,21 @@ $( mod_header R "recovery shell" )
 Execute a Bash shell with minimal tooling, enabling system maintenance.
 
 
-$( mod_header C "chroot" )
+$( mod_header I "interactive chroot" )
 
 Enter a chroot of the selected boot environment. The boot environment is mounted $( colorize red "read/write") if the zpool is imported $( colorize red "read/write" ).
+
+
+$( mod_header W "import read/write" )
+
+If possible, the pool behind the selected boot environment is exported and then re-imported in $( colorize red "read/write") mode.
+
+This is not possible if any of the following conditions are met:
+
+ $( colorize red "*") The version of ZFS in ZFSBootMenu has detected unsupported pool features, due to an upgraded pool.
+ $( colorize red "*") The system has an active $( colorize red "resume") image, indicating that the pool is currently in use.
+
+Upon successful re-import in $( colorize red "read/write") mode, each of the boot environments on this pool will be highlighted in $( colorize red "red") at the top of the screen.
 
 EOF
 SECTIONS+=("MAIN Main Menu")
@@ -160,6 +172,12 @@ $( mod_header D "diff" )
 Compare the differences between the selected snapshot and the current state of the boot environment.
 
 The operation will fail gracefully if the pool can not be set $( colorize red "read/write" ).
+
+
+$( mod_header I "interactive chroot" )
+
+Enter a chroot of the selected boot environment snapshot. The snapshot is always mounted read-only.
+
 EOF
 SECTIONS+=("SNAPSHOT Snapshot Management")
 

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -194,9 +194,9 @@ draw_be() {
 
   header="$( header_wrap "[ENTER] boot" "[ESC] refresh view" "[CTRL+H] help" "" \
     "[CTRL+E] edit kcl" "[CTRL+K] kernels" "[CTRL+D] set bootfs" "[CTRL+S] snapshots" "" \
-    "[CTRL+C] chroot" "[CTRL+R] recovery shell" "[CTRL+P] pool status" )"
+    "[CTRL+I] interactive chroot" "[CTRL+R] recovery shell" "[CTRL+P] pool status" )"
 
-  expects="--expect=alt-k,alt-d,alt-s,alt-c,alt-r,alt-p,alt-w,alt-e"
+  expects="--expect=alt-k,alt-d,alt-s,alt-c,alt-r,alt-p,alt-w,alt-i"
 
   if ! selected="$( ${FUZZYSEL} -0 --prompt "BE > " \
       ${expects} ${expects//alt-/ctrl-} ${expects//alt-/ctrl-alt-} \
@@ -261,10 +261,10 @@ draw_snapshots() {
 
   header="$( header_wrap \
     "[ENTER] duplicate" "[ESC] back" "[CTRL+H] help" "" \
-    "[CTRL+D] show diff" "[CTRL+E] chroot" "" \
+    "[CTRL+D] show diff" "[CTRL+I] interactive chroot" "" \
     "[CTRL+X] clone and promote" "[CTRL+C] clone only" )"
 
-  expects="--expect=alt-x,alt-c,alt-d,alt-e"
+  expects="--expect=alt-x,alt-c,alt-d,alt-i"
 
   if ! selected="$( zfs list -t snapshot -H -o name "${benv}" |
       HELP_SECTION=SNAPSHOT ${FUZZYSEL} \

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -193,7 +193,7 @@ while true; do
           BE_SELECTED=1
           continue
         ;;
-          "mod-e")
+        "mod-i")
           zfs_chroot "${selected_snap}"
           BE_SELECTED=1
           continue
@@ -291,7 +291,7 @@ while true; do
         echo "${cmdline}" > "${BASE}/cmdline"
       fi
       ;;
-    "mod-c")
+    "mod-i")
       zfs_chroot "${selected_be}"
     ;;
   esac


### PR DESCRIPTION
On the main screen and the snapshot screen, normalize the chroot key
combination to MOD-i (interactive chroot). Help documentation has been
updated for the main screen and added for the snapshot screen.

Additionally, document MOD-w and list the caveats for when it can be
used. This key is not documented in the header text - read the
documentation to understand what kind of foot-gun you're loading.