### PR TITLE
Improve kernel version detection.

### DIFF
--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -176,13 +176,11 @@ $runConf{umount_on_exit} = 0;
 if ( nonempty $config{Global}{BootMountPoint} ) {
   my $mounted = 0;
 
-  my $cmd    = "mountpoint $config{Global}{BootMountPoint}";
-  my @output = execute($cmd);
+  my @output = execute(qq(mountpoint $config{Global}{BootMountPoint}));
   my $status = pop(@output);
   unless ( $status eq 0 ) {
     print "Mounting $config{Global}{BootMountPoint}\n";
-    $cmd = "mount $config{Global}{BootMountPoint}";
-    my @output = execute($cmd);
+    my @output = execute(qq(mount $config{Global}{BootMountPoint}));
     my $status = pop(@output);
     if ( $status eq 0 ) {
       $runConf{umount_on_exit} = 1;
@@ -268,20 +266,25 @@ if ( nonempty $runConf{kernel} ) {
 
 # Try to determine kernel_prefix or kernel_version if necessary
 unless ( nonempty $runConf{kernel_prefix} and nonempty $runConf{kernel_version} ) {
-  basename( $runConf{kernel} ) =~ m/([^-\s]+)(-(\S+))?/;
+
+  # Kernel version comes from either file name or internal strings
+  unless ( nonempty $runConf{kernel_version} ) {
+    $runConf{kernel_version} = kernelVersion( $runConf{kernel} );
+    unless ( nonempty $runConf{kernel_version} ) {
+      printf "Unable to determine kernel version from %s\n", $runConf{kernel};
+      exit 1;
+    }
+  }
+
   unless ( nonempty $runConf{kernel_prefix} ) {
-    unless ( defined $1 ) {
+
+    # Prefix is basename of file, less any "-<version>" suffix
+    $runConf{kernel_prefix} = basename( $runConf{kernel} );
+    $runConf{kernel_prefix} =~ s/-\Q$runConf{kernel_version}\E$//;
+    unless ( nonempty $runConf{kernel_prefix} ) {
       printf "Unable to determine kernel prefix from %s\n", $runConf{kernel};
       exit 1;
     }
-    $runConf{kernel_prefix} = $1;
-  }
-  unless ( nonempty $runConf{kernel_version} ) {
-    unless ( defined $3 ) {
-      printf "Unable to detrmine kernel version from %s\n", $runConf{kernel};
-      exit 1;
-    }
-    $runConf{kernel_version} = $3;
   }
 }
 
@@ -523,19 +526,88 @@ sub versionedKernel {
   return;
 }
 
-# Finds the latest kernel in /boot, based on form <prefix>-<version>
+# Finds the latest kernel in /boot, if possible
 sub latestKernel {
-  my @prefixes = ( "vmlinux*-*", "vmlinuz*-*", "linux*-*", "kernel*-*" );
+  my @prefixes = ( "vmlinuz*", "vmlinux*", "linux*", "kernel*" );
+
   for my $prefix (@prefixes) {
-    my $glob    = join( '/', ( $runConf{bootdir}, $prefix ) );
-    my @kernels = glob($glob);
-    next if !@kernels;
-    for ( sort { versioncmp( $b, $a ) } @kernels ) {
+    my $glob = join( '/', ( $runConf{bootdir}, $prefix ) );
+    my %kernels;
+
+    for my $kernel ( glob($glob) ) {
+      my $version = kernelVersion($kernel);
+      next unless defined($version);
+      Log("Identified version $version for kernel $kernel");
+      $kernels{$version} = $kernel;
+    }
+
+    next unless ( keys %kernels );
+
+    for ( sort { versioncmp( $b, $a ) } keys %kernels ) {
       Log("Latest kernel: $_");
-      return $_;
+      return $kernels{$_};
     }
   }
 
+  return;
+}
+
+# Attempts to determine a version for the given kernel, by
+#
+# a. Identifying the first version-looking string in the file, or
+# b. Identifying a version-like part in the name of the file
+#
+# If one of these exists and not the other, that value is used;
+# if both exist, they must agree or nothing is returned
+sub kernelVersion {
+  my $kernel = shift;
+
+  my ( $filever, $namever );
+
+  # Consider an unreadable file to have no version
+  unless ( -r $kernel ) {
+    Log("Unable to read path $kernel, assuming no version");
+    return;
+  }
+
+  # Read strings in the kernel to recover a version, if possible
+  my @output = execute(qq(strings $kernel));
+  my $status = pop(@output);
+  if ( $status eq 0 ) {
+    for (@output) {
+      if (/[0-9]+\.[0-9]+\.[0-9]+/) {
+        my @toks = split /\s+/;
+        chomp( $filever = $toks[0] );
+        $filever =~ s/^\s+|\s+$//g;
+        last;
+      }
+    }
+  }
+
+  # Read version from the file name, if possible
+  basename($kernel) =~ m/-([0-9]+\.[0-9]+\.[0-9]+.*)/;
+  if ( defined $1 ) {
+    $namever = $1;
+  }
+
+  # If only one is defined, that's the version
+  unless ( defined $filever ) {
+    Log("No version found in kernel strings, using $namever from path $kernel");
+    return $namever;
+  }
+
+  unless ( defined $namever ) {
+    Log("No version found in path $kernel, using $filever from kernel strings");
+    return $filever;
+  }
+
+  # If both are defined, they must agree
+  if ( $namever eq $filever ) {
+    Log("Found version $filever in both path $kernel and kernel strings");
+    return $filever;
+  }
+
+  Log("Ignoring inconsistent versions $namever from path $kernel and $filever in kernel strings");
   return;
 }
 
@@ -635,8 +707,7 @@ sub cleanupMount {
 
   if ( $runConf{umount_on_exit} ) {
     print "Unmounting $config{Global}{BootMountPoint}\n";
-    my $cmd = "umount $config{Global}{BootMountPoint}";
-    execute($cmd);
+    execute(qq(umount $config{Global}{BootMountPoint}));
   }
 
   if ( defined $signal ) {

--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -557,8 +557,9 @@ sub latestKernel {
 # a. Identifying the first version-looking string in the file, or
 # b. Identifying a version-like part in the name of the file
 #
-# If one of these exists and not the other, that value is used;
-# if both exist, they must agree or nothing is returned
+# If one of these exists and not the other, that value is used; if both exist,
+# the name-derived value is used if that version string can be matched
+# somewhere in the file contents, otherwise the version is undefined.
 sub kernelVersion {
   my $kernel = shift;
 
@@ -570,45 +571,61 @@ sub kernelVersion {
     return;
   }
 
-  # Read strings in the kernel to recover a version, if possible
-  my @output = execute(qq(strings $kernel));
-  my $status = pop(@output);
-  if ( $status eq 0 ) {
-    for (@output) {
-      if (/[0-9]+\.[0-9]+\.[0-9]+/) {
-        my @toks = split /\s+/;
-        chomp( $filever = $toks[0] );
-        $filever =~ s/^\s+|\s+$//g;
-        last;
-      }
-    }
-  }
-
   # Read version from the file name, if possible
   basename($kernel) =~ m/-([0-9]+\.[0-9]+\.[0-9]+.*)/;
   if ( defined $1 ) {
     $namever = $1;
   }
 
+  # Read strings in the kernel to recover a version, if possible
+  my @output = execute(qq(strings $kernel));
+  my $status = pop(@output);
+  if ( $status eq 0 ) {
+    for (@output) {
+
+      # Versions are any three dot-separated numbers followed by non space
+      next unless (/([0-9]+\.[0-9]+\.[0-9]+\S+)/);
+
+      my $ver = $1;
+
+      # First version match is always the file version
+      $filever = $ver unless ( nonempty $filever );
+
+      # When there is no version from the file name, we have a match
+      last unless ( nonempty $namever );
+
+      # A version that equals the file version supersedes the first match
+      if ( $namever eq $ver ) {
+        $filever = $ver;
+        last;
+      }
+    }
+  }
+
   # If only one is defined, that's the version
-  unless ( defined $filever ) {
+  unless ( nonempty $filever ) {
     Log("No version found in kernel strings, using $namever from path $kernel");
     return $namever;
   }
 
-  unless ( defined $namever ) {
+  unless ( nonempty $namever ) {
     Log("No version found in path $kernel, using $filever from kernel strings");
     return $filever;
   }
 
-  # If both are defined, they must agree
-  if ( $namever eq $filever ) {
-    Log("Found version $filever in both path $kernel and kernel strings");
-    return $filever;
+  # Warn if the two alternatives do not agree
+  if ( $namever ne $filever ) {
+    my $warning = <<"EOF";
+WARNING: ignoring inconsistent versions in kernel $kernel:
+  Path suggests version $namever.
+  Kernel strings suggest version $filever.
+  To use this kernel, explicitly specify the path and version.
+EOF
+    print $warning;
+    return;
   }
 
-  Log("Ignoring inconsistent versions $namever from path $kernel and $filever in kernel strings");
-  return;
+  return $namever;
 }
 
 # Returns the path to an initramfs, or dies with an error


### PR DESCRIPTION
The dracut lsinitrd utility determines kernel versions by looking for strings of the form `[0-9]+\.[0-9]+\.[0-9]+`, so we might as well adopt similar logic to try to recover versions when the file name is not sufficient. This improvement attempts to parse both the file name and kernel strings for version-like sequences. If it finds both, they must agree or the kernel is ignored; if it finds only one source of versioning, that is preferred automatically.

With more reliable version detection, we can again relax the kernel detection to look for `/boot/<prefix>` rather than requiring the more strict `/boot/<prefix>-<version>`, and an output kernel prefix becomes just the name of the kernel with the determined version removed (if it exists).

This *should* allow Arch users to rely on automatic version detection rather than requiring explicit specification of the kernel path and version. This also allows Arch users to run `generate-zbm` after updating a kernel package but before rebooting, when using a `%{current}` version string will fail because `/lib/modules/$(uname -r)` has been removed and the kernel file is of a different version anyway.

To test, I populated a false boot directory in a test tree:
```
vmlinuz -> /boot/vmlinuz-5.10.7_1
vmlinuz-5.10.3_1 -> /boot/vmlinuz-5.10.3_1
vmlinuz-5.10.7-generic-53 -> /boot/vmlinuz-5.10.6_1
vmlinuz-kernel-5.10.7_1 -> /boot/vmlinuz-5.10.7_1
vmlinuz-linux -> /boot/vmlinuz-5.10.6_1
```
Note some Arch-style names as well as an Ubuntu-style name (with a file-name version that disagrees with the actual version). Also, the `vmlinuz-kernel-5.10.7_1` name would have thwarted our original scheme, which would pick `vmlinuz` as the prefix and `kernel-5.10.7_1` as the version.

Running
```
PATH=./dracut:${PATH} ./generate-zbm -c ./local.yaml -b ./boot -d
```
in the test tree returns the expected output about kernel versioning:
```
## No version found in path ./boot/vmlinuz, using 5.10.7_1 from kernel strings
## Identified version 5.10.7_1 for kernel ./boot/vmlinuz
## Found version 5.10.3_1 in both path ./boot/vmlinuz-5.10.3_1 and kernel strings
## Identified version 5.10.3_1 for kernel ./boot/vmlinuz-5.10.3_1
## Ignoring inconsistent versions 5.10.7-generic-53 from path ./boot/vmlinuz-5.10.7-generic-53 and 5.10.6_1 in kernel strings
## Found version 5.10.7_1 in both path ./boot/vmlinuz-kernel-5.10.7_1 and kernel strings
## Identified version 5.10.7_1 for kernel ./boot/vmlinuz-kernel-5.10.7_1
## No version found in path ./boot/vmlinuz-linux, using 5.10.6_1 from kernel strings
## Identified version 5.10.6_1 for kernel ./boot/vmlinuz-linux
## Latest kernel: 5.10.7_1
## Found version 5.10.7_1 in both path ./boot/vmlinuz-kernel-5.10.7_1 and kernel strings
Creating ZFSBootMenu 1.8.1 from kernel ./boot/vmlinuz-kernel-5.10.7_1
```