### PR TITLE
Only specify `--uefi-stub` when EFI.Stub is configured

### DIFF
--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -648,13 +648,11 @@ sub createInitramfs {
 
   # If $kernfile is provided, make a unified EFI image with the named kernel
   if ( defined $kernfile ) {
-    my $efi_stub = $config{EFI}{Stub} || "/usr/lib/gummiboot/linuxx64.efi.stub";
-
-    unless ( -e $efi_stub ) {
-      die "Missing EFI stub: $efi_stub";
+    if ( nonempty $config{EFI}{Stub} ) {
+      push( @cmd, ( qq(--uefi-stub), $config{EFI}{Stub} ) );
     }
 
-    push( @cmd, ( qw(--uefi --uefi-stub), $efi_stub, qq(--kernel-image), $kernfile ) );
+    push( @cmd, ( qw(--uefi --kernel-image), $kernfile ) );
 
     if ( nonempty $runConf{cmdline} ) {
       push( @cmd, qq(--kernel-cmdline=\"$runConf{cmdline}\") );


### PR DESCRIPTION
When `--uefi` is passed to dracut without a `--uefi-stub` argument, it looks first for a stub provided by systemd-boot and, if one isn't found, for a stub provided by gummiboot. The gummiboot location agrees with our default location at /usr/lib/gummiboot/linuxx64.efi.stub.

By dropping the `--uefi-stub` unless the `generate-zbm` configuration explicitly specifies a value, `generate-zbm` should work out of the box on systems that use gummiboot as well as its successor, systemd-boot. If a user specifies a value in EFI.Stub, the `--uefi-stub` argument will be passed with the configured value.

Fixes: #135.

Tested and produces the expected results on Void:
- With the default stub at `/usr/lib/gummiboot/linuxx64.efi.stub`
- With no gummiboot stub but the following two systemd components:
```
/usr/lib/systemd/systemd-udevd
/usr/lib/systemd/boot/efi/linuxx64.efi.stub
```
(Note: `dracut` requires that `systemd-udevd` exist before it looks in `boot/efi` for the stub.)
- With no default locations (fails, as expected)
- With no default location but `EFI.Stub` set to `/etc/zfsbootmenu/linuxx64.efi.stub` (which exists)