### PR TITLE
Use genkernel root prefix by default on Gentoo

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -740,6 +740,10 @@ find_root_prefix() {
             echo "zfs="
             break
             ;;
+          gentoo)
+            echo "root=ZFS="
+            break
+            ;;
           *)
             ;;
         esac


### PR DESCRIPTION
`genkernel` is often used to generate the initramfs on Gentoo.
An initramfs generated by genkernel accepts a ZFS root option
in the form of `root=ZFS=<dataset>`,
but does not accept `root=zfs:<dataset>`,
which is the default format for passing the root dataset
to the BE initramfs in `zfsbootmenu`.

For Gentoo BEs, make the default root prefix `root=ZFS=`,
which is accepted by both `genkernel`- and `dracut`-generated initramfs.

Users can still set the `org.zfsbootmenu:rootprefix` property
on `<pool>/ROOT` or the BE datasets to override the default.

Fixes: #136.