### PR TITLE
Allow BE and snapshot sorting by different criteria 

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-exec.sh
+++ b/90zfsbootmenu/zfsbootmenu-exec.sh
@@ -6,6 +6,7 @@ export force_import
 export menu_timeout
 export loglevel
 export root
+export zbm_sort
 
 # store current kernel log level
 read -r PRINTK < /proc/sys/kernel/printk

--- a/90zfsbootmenu/zfsbootmenu-help.sh
+++ b/90zfsbootmenu/zfsbootmenu-help.sh
@@ -129,6 +129,17 @@ This is not possible if any of the following conditions are met:
 
 Upon successful re-import in $( colorize red "read/write") mode, each of the boot environments on this pool will be highlighted in $( colorize red "red") at the top of the screen.
 
+
+$( mod_header O "sort order" )
+
+Cycle the sorting key through the following list:
+
+     $( colorize orange "name") Use the filesystem or snapshot name
+ $( colorize orange "creation") Use the filesystem or snapshot creation time
+     $( colorize orange "used") Use the filesystem or snapshot size
+
+The default sort key is $( colorize orange "name") . 
+
 EOF
 SECTIONS+=("MAIN Main Menu")
 
@@ -177,6 +188,17 @@ The operation will fail gracefully if the pool can not be set $( colorize red "r
 $( mod_header I "interactive chroot" )
 
 Enter a chroot of the selected boot environment snapshot. The snapshot is always mounted read-only.
+
+
+$( mod_header O "sort order" )
+
+Cycle the sorting key through the following list:
+
+     $( colorize orange "name") Use the filesystem or snapshot name
+ $( colorize orange "creation") Use the filesystem or snapshot creation time
+     $( colorize orange "used") Use the filesystem or snapshot size
+
+The default sort key is $( colorize orange "name") . 
 
 EOF
 SECTIONS+=("SNAPSHOT Snapshot Management")

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -278,7 +278,6 @@ draw_snapshots() {
 
   expects="--expect=alt-x,alt-c,alt-d,alt-i,alt-o"
 
-  # shellcheck disable=SC2154
   if ! selected="$( zfs list -t snapshot -H -o name "${benv}" -S "${sort_key}" |
       HELP_SECTION=SNAPSHOT ${FUZZYSEL} \
         --prompt "Snapshot > " --header="${header}" --tac \
@@ -1442,7 +1441,6 @@ populate_be_list() {
   : > "${be_list}"
 
   # Find valid BEs
-  # shellcheck disable=SC2154
   while IFS=$'\t' read -r fs mnt active; do
     if [ "x${mnt}" = "x/" ]; then
       # When mountpoint=/, BE is a candidate unless org.zfsbootmenu:active=off

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -106,15 +106,8 @@ mount_zfs() {
 get_sort_key() {
   local sort_key
   sort_key="${zbm_sort%%;*}"
-  
-  # Validate the sort key, otherwise use 'name'
-  if ! zfs list -s "${sort_key}" >/dev/null 2>&1 ; then
-    zdebug "${sort_key} invalid, using 'name'"
-    echo -n "name"
-  else
-    zdebug "${sort_key} valid, using"
-    echo -n "${sort_key}"
-  fi
+  zdebug "Using sorting key ${sort_key}"
+  echo -n "${sort_key}"
 }
 
 # arg1: value to substitute for empty first line (default: "enter")

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -107,7 +107,7 @@ get_sort_key() {
   local sort_key
   sort_key="${zbm_sort%%;*}"
   zdebug "Using sorting key ${sort_key}"
-  echo -n "${sort_key}"
+  echo -n "${sort_key:-name}"
 }
 
 # arg1: value to substitute for empty first line (default: "enter")

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -104,7 +104,17 @@ mount_zfs() {
 # returns: nothing
 
 get_sort_key() {
-  echo -n "${zbm_sort%%;*}"
+  local sort_key
+  sort_key="${zbm_sort%%;*}"
+  
+  # Validate the sort key, otherwise use 'name'
+  if ! zfs list -s "${sort_key}" >/dev/null 2>&1 ; then
+    zdebug "${sort_key} invalid, using 'name'"
+    echo -n "name"
+  else
+    zdebug "${sort_key} valid, using"
+    echo -n "${sort_key}"
+  fi
 }
 
 # arg1: value to substitute for empty first line (default: "enter")

--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -62,12 +62,20 @@ zbm_lines=$( getarg zbm.lines=)
 zbm_columns=$( getarg zbm.columns=)
 
 # Allow sorting based on a key. Accept any value, default to name.
-zbm_sort=$( getarg zbm.sort_key=)
-if [ -n "${zbm_sort}" ]; then
-  info  "ZFSBootMenu: Setting sort key to ${zbm_sort}"
+zbm_sort=
+sort_key=$( getarg zbm.sort_key=)
+if [ -n "${sort_key}" ]; then
+  zbm_sort="${sort_key}"
+  info "ZFSBootMenu: Setting sort key to ${zbm_sort}"
+
+  for key in "name" "creation"; do
+    if [ "${key}" != "${sort_key}" ]; then
+      zbm_sort="${zbm_sort};${key}"
+    fi
+  done
 else
-  zbm_sort="name"
-  info "ZFSBootMenu: defaulting sort key to ${zbm_sort}"
+  zbm_sort="name;creation"
+  info "ZFSBootMenu: Defaulting sort key order to ${zbm_sort}"
 fi
 
 # Turn on tmux integrations

--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -61,6 +61,15 @@ zbm_lines=$( getarg zbm.lines=)
 # shellcheck disable=SC2034
 zbm_columns=$( getarg zbm.columns=)
 
+# Allow sorting based on a key. Accept any value, default to name.
+zbm_sort=$( getarg zbm.sort_key=)
+if [ -n "${zbm_sort}" ]; then
+  info  "ZFSBootMenu: Setting sort key to ${zbm_sort}"
+else
+  zbm_sort="name"
+  info "ZFSBootMenu: defaulting sort key to ${zbm_sort}"
+fi
+
 # Turn on tmux integrations
 # shellcheck disable=SC2034
 if getargbool 0 zbm.tmux ; then

--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -61,22 +61,37 @@ zbm_lines=$( getarg zbm.lines=)
 # shellcheck disable=SC2034
 zbm_columns=$( getarg zbm.columns=)
 
-# Allow sorting based on a key. Accept any value, default to name.
+# Allow sorting based on a key
 zbm_sort=
 sort_key=$( getarg zbm.sort_key=)
-if [ -n "${sort_key}" ]; then
-  zbm_sort="${sort_key}"
-  info "ZFSBootMenu: Setting sort key to ${zbm_sort}"
+if [ -n "${sort_key}" ] ; then
+  valid_keys=( "name" "creation" "used" )
+  for key in "${valid_keys[@]}"; do
+    if [ "${key}" == "${sort_key}" ]; then
+      zbm_sort="${key}"
+    fi
+  done
 
-  for key in "name" "creation"; do
+  # If zbm_sort is empty (invalid user provided key)
+  # Default the starting sort key to 'name'
+  if [ -z "${zbm_sort}" ] ; then
+    sort_key="name"
+    zbm_sort="name"
+  fi
+
+  # Append any other sort keys to the selected one
+  for key in "${valid_keys[@]}"; do
     if [ "${key}" != "${sort_key}" ]; then
       zbm_sort="${zbm_sort};${key}"
     fi
   done
+
+  info "ZFSBootMenu: Setting sort key order to ${zbm_sort}"
 else
-  zbm_sort="name;creation"
+  zbm_sort="name;creation;used"
   info "ZFSBootMenu: Defaulting sort key order to ${zbm_sort}"
 fi
+
 
 # Turn on tmux integrations
 # shellcheck disable=SC2034

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -196,8 +196,8 @@ while true; do
           BE_SELECTED=1
           continue
         ;;
-        "mod-l")
-          toggle_sort
+        "mod-o")
+          change_sort
           BE_SELECTED=1
           continue
         ;;
@@ -297,8 +297,8 @@ while true; do
     "mod-i")
       zfs_chroot "${selected_be}"
     ;;
-    "mod-l")
-      toggle_sort
+    "mod-o")
+      change_sort
     ;;
   esac
 done

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -196,6 +196,11 @@ while true; do
           BE_SELECTED=1
           continue
         ;;
+        "mod-l")
+          toggle_sort
+          BE_SELECTED=1
+          continue
+        ;;
         # Check available space early in the process
         "enter")
           avail_space_exact="$( zfs list -p -H -o available "${parent_ds}" )"
@@ -291,6 +296,9 @@ while true; do
       ;;
     "mod-i")
       zfs_chroot "${selected_be}"
+    ;;
+    "mod-l")
+      toggle_sort
     ;;
   esac
 done

--- a/man/generate-zbm.5
+++ b/man/generate-zbm.5
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "generate-zbm 5"
-.TH generate-zbm 5 "2020-09-30" "1.8.1" "config.yaml"
+.TH generate-zbm 5 "2020-11-05" "1.8.1" "config.yaml"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l

--- a/man/generate-zbm.8
+++ b/man/generate-zbm.8
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "generate-zbm 8"
-.TH generate-zbm 8 "2021-01-06" "1.8.1" "generate-zbm"
+.TH generate-zbm 8 "2021-02-03" "1.8.1" "generate-zbm"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l

--- a/man/zfsbootmenu.7
+++ b/man/zfsbootmenu.7
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "zfsbootmenu 7"
-.TH zfsbootmenu 7 "2020-12-21" "1.8.1" "ZFSBootMenu"
+.TH zfsbootmenu 7 "2021-02-06" "1.8.1" "ZFSBootMenu"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -162,6 +162,22 @@ Omit this option or explicitly specify \fBzbm.force_import=0\fR to disable force
 .IP "\fBforce_import=1\fR" 4
 .IX Item "force_import=1"
 Deprecated; use \fBzbm.force_import\fR.
+.IP "\fBzbm.sort_key\fR" 4
+.IX Item "zbm.sort_key"
+This option accepts a \s-1ZFS\s0 property name by which the boot environment and snapshot lists should be sorted.
+.RS 4
+.IP "\fBzbm.sort_key=name\fR" 2
+.IX Item "zbm.sort_key=name"
+Sort the lists by \fIname\fR. This is the default sorting method.
+.IP "\fBzbm.sort_key=creation\fR" 2
+.IX Item "zbm.sort_key=creation"
+Sort the lists by \fIcreation\fR date.
+.IP "\fBzbm.sort_key=used\fR" 2
+.IX Item "zbm.sort_key=used"
+Sort the lists by size \fIused\fR.
+.RE
+.RS 4
+.RE
 .IP "\fBzbm.timeout\fR" 4
 .IX Item "zbm.timeout"
 This option accepts numeric values that control whether and when the

--- a/pod/zfsbootmenu.7.pod
+++ b/pod/zfsbootmenu.7.pod
@@ -32,6 +32,26 @@ Omit this option or explicitly specify B<zbm.force_import=0> to disable forced i
 
 Deprecated; use B<zbm.force_import>.
 
+=item B<zbm.sort_key>
+
+This option accepts a ZFS property name by which the boot environment and snapshot lists will be sorted.
+
+=over 2
+
+=item B<zbm.sort_key=name>
+
+Sort the lists by I<name>. This is the default sorting method.
+
+=item B<zbm.sort_key=creation>
+
+Sort the lists by I<creation> date.
+
+=item B<zbm.sort_key=used>
+
+Sort the lists by size I<used>.
+
+=back
+
 =item B<zbm.timeout>
 
 This option accepts numeric values that control whether and when the


### PR DESCRIPTION
On systems with a large number of boot environments or snapshots, sorting by name can be less than optimal. This PR adds the following:

* Allow `zbm.sort_key` to be set on the KCL, with `name`, `creation`, `used` considered valid sort keys
* Add a hook for `mod-o` on the BE and snapshot list screens, allowing the sorting method to be changed. Changing the sorting method on one screen changes it on the other, as well. This change persists until `zfsbootmenu.sh` is exited, at which point the selected method reverts to the default (`name`) or the method defined on the KCL.

Packing the sort methods into the global `zbm_sort` variable allows easy expansion of sort keys in the future. Simply add the list of valid keys to the array in parse-commandline.sh and it will be accepted and rotated through the list.

The shortcut key combinations have been documented in the online help and the man page, but not in the footer text. I'm open to persuasion on this.

Closes https://github.com/zbm-dev/zfsbootmenu/issues/137