### PR TITLE
Move more helper functions to -lib, cleanup scripts

### DIFF
--- a/90zfsbootmenu/zfs-chroot.sh
+++ b/90zfsbootmenu/zfs-chroot.sh
@@ -22,12 +22,12 @@ if mountpoint="$( allow_rw=yes mount_zfs "${selected}" )"; then
 
   # Snapshots and read-only pools always produce read-only mounts
   if [[ "${selected}" =~ @ ]] || ! is_writable "${pool}"; then
-    writemode="read-only"
+    writemode="$( colorize green "read-only")"
   else
-    writemode="read/write"
+    writemode="$( colorize red "read/write")"
   fi
 
-  echo -e "${selected} is mounted ${writemode}, /tmp is shared and read/write\n"
+  echo -e "$( colorize orange "${selected}") is mounted ${writemode}, /tmp is shared and read/write\n"
 
   if [ -x "${mountpoint}/bin/bash" ]; then
     _SHELL="/bin/bash"

--- a/90zfsbootmenu/zfsbootmenu-help.sh
+++ b/90zfsbootmenu/zfsbootmenu-help.sh
@@ -13,10 +13,6 @@ PREVIEW_SIZE="$(( WIDTH - 26 ))"
 
 [ -z "${FUZZYSEL}" ] && FUZZYSEL="fzf"
 
-center() {
-  printf "%*s" $(( (${#1} + WIDTH ) / 2)) "${1}"
-}
-
 mod_header() {
   local key="$1"
   local subject="$2"
@@ -51,7 +47,7 @@ help_pager() {
 
 # shellcheck disable=SC2034
 read -r -d '' MAIN <<EOF
-$( colorize magenta "$( center "Main Menu")" )
+$( colorize magenta "$( center_string "${WIDTH}" "Main Menu")" )
 $( colorize lightblue "boot" )
 $( colorize green "[ENTER]" )
 
@@ -122,7 +118,7 @@ SECTIONS+=("MAIN Main Menu")
 
 # shellcheck disable=SC2034
 read -r -d '' SNAPSHOT <<EOF
-$( colorize magenta "$( center "Snapshot Management")" )
+$( colorize magenta "$( center_string "${WIDTH}" "Snapshot Management")" )
 $( colorize lightblue "duplicate" )
 $( colorize green "[ENTER]" )
 
@@ -182,7 +178,7 @@ SECTIONS+=("SNAPSHOT Snapshot Management")
 
 # shellcheck disable=SC2034
 read -r -d '' KERNEL <<EOF
-$( colorize magenta "$( center "Kernel Management")" )
+$( colorize magenta "$( center_string "${WIDTH}" "Kernel Management")" )
 $( colorize lightblue "boot" )
 $( colorize green "[ENTER]" )
 
@@ -202,7 +198,7 @@ SECTIONS+=("KERNEL Kernel Management")
 
 # shellcheck disable=SC2034
 read -r -d '' DIFF <<EOF
-$( colorize magenta "$( center "Diff Viewer")" )
+$( colorize magenta "$( center_string "${WIDTH}" "Diff Viewer")" )
 $( colorize lightblue "Column 1 descriptions" )
  $( colorize orange "-") The path has been removed
  $( colorize orange "+") The path has been created
@@ -225,7 +221,7 @@ SECTIONS+=("DIFF Diff Viewer")
 
 # shellcheck disable=SC2034
 read -r -d '' POOL <<EOF
-$( colorize magenta "$( center "ZPOOL Health")" )
+$( colorize magenta "$( center_string "${WIDTH}" "ZPOOL Health")" )
 $( mod_header R "rewind checkpoint" )
 
 If a pool checkpoint is available, the selected pool is exported and then imported with the $( colorize red "--rewind-to-checkpoint" ) flag set.

--- a/90zfsbootmenu/zfsbootmenu-help.sh
+++ b/90zfsbootmenu/zfsbootmenu-help.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # vim: softtabstop=2 shiftwidth=2 expandtab
 
+# shellcheck disable=SC1091
+[ -r /lib/zfsbootmenu-lib.sh ] && source /lib/zfsbootmenu-lib.sh
+
 # zfsbootmenu-help invokes itself, so the value of $WIDTH depends
 # on if $0 is launching fzf/sk (-L) or is being launched inside
 # fzf/sk (-s).
@@ -12,32 +15,6 @@ PREVIEW_SIZE="$(( WIDTH - 26 ))"
 
 center() {
   printf "%*s" $(( (${#1} + WIDTH ) / 2)) "${1}"
-}
-
-colorize() {
-  color="${1}"
-  shift
-  case "${color}" in
-    black) echo -e -n '\033[0;30m' ;;
-    red) echo -e -n '\033[0;31m' ;;
-    green) echo -e -n '\033[0;32m' ;;
-    orange) echo -e -n '\033[0;33m' ;;
-    blue) echo -e -n '\033[0;34m' ;;
-    magenta) echo -e -n '\033[0;35m' ;;
-    cyan) echo -e -n '\033[0;36m' ;;
-    lightgray) echo -e -n '\033[0;37m' ;;
-    darkgray) echo -e -n '\033[1;30m' ;;
-    lightred) echo -e -n '\033[1;31m' ;;
-    lightgreen) echo -e -n '\033[1;32m' ;;
-    yellow) echo -e -n '\033[1;33m' ;;
-    lightblue) echo -e -n '\033[1;34m' ;;
-    lightmagenta) echo -e -n '\033[1;35m' ;;
-    lightcyan) echo -e -n '\033[1;36m' ;;
-    white) echo -e -n '\033[1;37m' ;;
-    *) echo -e -n '\033[0m' ;;
-  esac
-  echo -e -n "$@"
-  echo -e -n '\033[0m'
 }
 
 mod_header() {

--- a/90zfsbootmenu/zfsbootmenu-help.sh
+++ b/90zfsbootmenu/zfsbootmenu-help.sh
@@ -47,7 +47,7 @@ help_pager() {
 
 # shellcheck disable=SC2034
 read -r -d '' MAIN <<EOF
-$( colorize magenta "$( center_string "${WIDTH}" "Main Menu")" )
+$( colorize magenta "$( center_string "Main Menu")" )
 $( colorize lightblue "boot" )
 $( colorize green "[ENTER]" )
 
@@ -118,7 +118,7 @@ SECTIONS+=("MAIN Main Menu")
 
 # shellcheck disable=SC2034
 read -r -d '' SNAPSHOT <<EOF
-$( colorize magenta "$( center_string "${WIDTH}" "Snapshot Management")" )
+$( colorize magenta "$( center_string "Snapshot Management")" )
 $( colorize lightblue "duplicate" )
 $( colorize green "[ENTER]" )
 
@@ -178,7 +178,7 @@ SECTIONS+=("SNAPSHOT Snapshot Management")
 
 # shellcheck disable=SC2034
 read -r -d '' KERNEL <<EOF
-$( colorize magenta "$( center_string "${WIDTH}" "Kernel Management")" )
+$( colorize magenta "$( center_string "Kernel Management")" )
 $( colorize lightblue "boot" )
 $( colorize green "[ENTER]" )
 
@@ -198,7 +198,7 @@ SECTIONS+=("KERNEL Kernel Management")
 
 # shellcheck disable=SC2034
 read -r -d '' DIFF <<EOF
-$( colorize magenta "$( center_string "${WIDTH}" "Diff Viewer")" )
+$( colorize magenta "$( center_string "Diff Viewer")" )
 $( colorize lightblue "Column 1 descriptions" )
  $( colorize orange "-") The path has been removed
  $( colorize orange "+") The path has been created
@@ -221,7 +221,7 @@ SECTIONS+=("DIFF Diff Viewer")
 
 # shellcheck disable=SC2034
 read -r -d '' POOL <<EOF
-$( colorize magenta "$( center_string "${WIDTH}" "ZPOOL Health")" )
+$( colorize magenta "$( center_string "ZPOOL Health")" )
 $( mod_header R "rewind checkpoint" )
 
 If a pool checkpoint is available, the selected pool is exported and then imported with the $( colorize red "--rewind-to-checkpoint" ) flag set.

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -76,16 +76,25 @@ colorize() {
   echo -e -n '\033[0m'
 }
 
-# arg1: screen width
-# arg2: text to center
+# arg1: text to center
 # prints: left-padded text
 # returns: nothing
 
-center_string() {
-  local width
-  width="${1}"
+# Accepted environment variables:
+# WIDTH: pre-calculated screen width
 
-  printf "%*s" $(( (${#2} + width ) / 2)) "${2}"
+center_string() {
+  local _WIDTH
+  if [ -z "${WIDTH}" ]; then
+    if [ -z "${FZF_PREVIEW_COLUMNS}" ]; then
+      _WIDTH="$( tput cols )"
+    else
+      _WIDTH="${FZF_PREVIEW_COLUMNS}"
+    fi
+  else
+    _WIDTH="${WIDTH}"
+  fi
+  printf "%*s" $(( (${#1} + _WIDTH ) / 2)) "${1}"
 }
 
 # arg1: ZFS filesystem name
@@ -923,6 +932,12 @@ load_be_cmdline() {
 # arg1: pool name
 # prints: nothing
 # returns: 0 on success, 1 on failure
+
+# Accepted environment variables
+# force_import=1: enable force importing of a pool
+# read_write=1: import read-write, defaults to read-only
+# rewind_to_checkpoint=1: enable --rewind-to-checkpoint
+# all_pools=1: import all pools instead of a single specific pool
 
 import_pool() {
   local pool import_args

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -44,6 +44,37 @@ zerror() {
   zlog 3 "$@"
 }
 
+# arg1: color name
+# arg2...argN: text to color
+# prints: text with color escape codes
+# returns: nothing
+
+colorize() {
+  color="${1}"
+  shift
+  case "${color}" in
+    black)        echo -e -n '\033[0;30m' ;;
+    red)          echo -e -n '\033[0;31m' ;;
+    green)        echo -e -n '\033[0;32m' ;;
+    orange)       echo -e -n '\033[0;33m' ;;
+    blue)         echo -e -n '\033[0;34m' ;;
+    magenta)      echo -e -n '\033[0;35m' ;;
+    cyan)         echo -e -n '\033[0;36m' ;;
+    lightgray)    echo -e -n '\033[0;37m' ;;
+    darkgray)     echo -e -n '\033[1;30m' ;;
+    lightred)     echo -e -n '\033[1;31m' ;;
+    lightgreen)   echo -e -n '\033[1;32m' ;;
+    yellow)       echo -e -n '\033[1;33m' ;;
+    lightblue)    echo -e -n '\033[1;34m' ;;
+    lightmagenta) echo -e -n '\033[1;35m' ;;
+    lightcyan)    echo -e -n '\033[1;36m' ;;
+    white)        echo -e -n '\033[1;37m' ;;
+    *)            echo -e -n '\033[0m' ;;
+  esac
+  echo -e -n "$@"
+  echo -e -n '\033[0m'
+}
+
 # arg1: ZFS filesystem name
 # prints: mountpoint
 # returns: 0 on success
@@ -211,7 +242,7 @@ draw_be() {
   if ! selected="$( ${FUZZYSEL} -0 --prompt "BE > " \
       ${expects} ${expects//alt-/ctrl-} ${expects//alt-/ctrl-alt-} \
       --header="${header}" --preview-window="up:${PREVIEW_HEIGHT}" \
-      --preview="/libexec/zfsbootmenu-preview ${BASE} {} ${BOOTFS}" < "${env}" )"; then
+      --preview="/libexec/zfsbootmenu-preview {} ${BOOTFS}" < "${env}" )"; then
     return 1
   fi
 
@@ -245,7 +276,7 @@ draw_kernel() {
   if ! selected="$( HELP_SECTION=KERNEL ${FUZZYSEL} \
      --prompt "${benv} > " --tac --with-nth=2 --header="${header}" \
       ${expects} ${expects//alt-/ctrl-} ${expects//alt-/ctrl-alt-} \
-      --preview="/libexec/zfsbootmenu-preview ${BASE} ${benv} ${BOOTFS}"  \
+      --preview="/libexec/zfsbootmenu-preview ${benv} ${BOOTFS}"  \
       --preview-window="up:${PREVIEW_HEIGHT}" < "${_kernels}" )"; then
     return 1
   fi
@@ -282,7 +313,7 @@ draw_snapshots() {
       HELP_SECTION=SNAPSHOT ${FUZZYSEL} \
         --prompt "Snapshot > " --header="${header}" --tac \
         ${expects} ${expects//alt-/ctrl-} ${expects//alt-/ctrl-alt-} \
-        --preview="/libexec/zfsbootmenu-preview ${BASE} ${benv} ${BOOTFS}" \
+        --preview="/libexec/zfsbootmenu-preview ${benv} ${BOOTFS}" \
         --preview-window="up:${PREVIEW_HEIGHT}" )"; then
     return 1
   fi
@@ -328,7 +359,7 @@ draw_diff() {
   ( zfs diff -F -H "${snapshot}" "${diff_target}" & echo $! >&3 ) 3>/tmp/diff.pid | \
     sed "s,${mnt},," | \
     HELP_SECTION=DIFF ${FUZZYSEL} --prompt "${snapshot} > " \
-      --preview="/libexec/zfsbootmenu-preview ${BASE} ${diff_target} ${BOOTFS}" \
+      --preview="/libexec/zfsbootmenu-preview ${diff_target} ${BOOTFS}" \
       --preview-window="up:${PREVIEW_HEIGHT}" \
       --bind 'esc:execute-silent( kill $( cat /tmp/diff.pid ) )+abort'
 

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -50,6 +50,7 @@ zerror() {
 # returns: nothing
 
 colorize() {
+  local color
   color="${1}"
   shift
   case "${color}" in
@@ -73,6 +74,18 @@ colorize() {
   esac
   echo -e -n "$@"
   echo -e -n '\033[0m'
+}
+
+# arg1: screen width
+# arg2: text to center
+# prints: left-padded text
+# returns: nothing
+
+center_string() {
+  local width
+  width="${1}"
+
+  printf "%*s" $(( (${#2} + width ) / 2)) "${2}"
 }
 
 # arg1: ZFS filesystem name

--- a/90zfsbootmenu/zfsbootmenu-preview.sh
+++ b/90zfsbootmenu/zfsbootmenu-preview.sh
@@ -16,8 +16,7 @@ fi
 
 # shellcheck disable=SC2034
 IFS=' ' read -r _fs selected_kernel _initramfs <<<"$( select_kernel "${ENV}")"
-selected_kernel="${selected_kernel%/*}"
-selected_arguments="$( load_be_cmdline "${ENV}" )"
+selected_kernel="${selected_kernel##*/}"
 
 pool="${ENV%%/*}"
 if is_writable "${pool}" ; then
@@ -34,11 +33,10 @@ else
   _DEFAULT=""
 fi
 
-selected_env_str="${ENV} (${_DEFAULT}${_readonly}) - ${selected_kernel}"
+selected_env_str="$( center_string "${WIDTH}" "${ENV} (${_DEFAULT}${_readonly}) - ${selected_kernel}" )"
 
-# Left pad the strings to center them based on the preview width
-selected_env_str="$( printf "%*s\n" $(( (${#selected_env_str} + WIDTH ) / 2)) "${selected_env_str}" )"
-selected_arguments="$( printf "%*s\n" $(( (${#selected_arguments} + WIDTH ) / 2)) "${selected_arguments}" )"
+selected_arguments="$( load_be_cmdline "${ENV}" )"
+selected_arguments="$( center_string "${WIDTH}" "$( load_be_cmdline "${ENV}" )" )"
 
 # colorize doesn't automatically add a newline
 colorize "${_COLOR}" "${selected_env_str}\n"

--- a/90zfsbootmenu/zfsbootmenu-preview.sh
+++ b/90zfsbootmenu/zfsbootmenu-preview.sh
@@ -1,56 +1,45 @@
 #!/bin/bash
 # vim: softtabstop=2 shiftwidth=2 expandtab
 
-BASE="${1}"
-ENV="${2}"
-BOOTFS="${3}"
-
-# shellcheck disable=SC2034
-BLUE='\033[0;34m'
-GREEN='\033[0;32m'
-RED='\033[0;31m'
-NC='\033[0m' # No Color
-
 # shellcheck disable=SC1091
 [ -r /lib/zfsbootmenu-lib.sh ] && source /lib/zfsbootmenu-lib.sh
 
-while IFS= read -r line
-do
-  selected_kernel="${line}"
-done < "${BASE}/${ENV}/default_kernel"
+ENV="${1}"
+BOOTFS="${2}"
 
-BE_ARGS="$( load_be_cmdline "${ENV}" )"
-
-while IFS= read -r line
-do
-  selected_arguments="${line}"
-done <<< "${BE_ARGS}"
-
-pool="${ENV%%/*}"
-readonly_prop="$( zpool get -H -o value readonly "${pool}" )"
-[[ ${readonly_prop} = "on" ]] && _readonly="r/o" || _readonly="r/w"
-
-if [ "${BOOTFS}" = "${ENV}" ]; then
-  selected_env_str="${ENV} (default, ${_readonly}) - ${selected_kernel}"
-else
-  selected_env_str="${ENV} (${_readonly}) - ${selected_kernel}"
-fi
-
-if [ -z "${FZF_PREVIEW_COLUMNS}" ]
-then
+# Skim doesn't set the environment
+if [ -z "${FZF_PREVIEW_COLUMNS}" ]; then
   WIDTH="$( tput cols )"
 else
   WIDTH="${FZF_PREVIEW_COLUMNS}"
 fi
 
+# shellcheck disable=SC2034
+IFS=' ' read -r _fs selected_kernel _initramfs <<<"$( select_kernel "${ENV}")"
+selected_kernel="${selected_kernel%/*}"
+selected_arguments="$( load_be_cmdline "${ENV}" )"
+
+pool="${ENV%%/*}"
+if is_writable "${pool}" ; then
+  _readonly="r/w"
+  _COLOR="red"
+else
+  _readonly="r/o"
+  _COLOR="green"
+fi
+
+if [ "${BOOTFS}" = "${ENV}" ]; then
+  _DEFAULT="default, "
+else
+  _DEFAULT=""
+fi
+
+selected_env_str="${ENV} (${_DEFAULT}${_readonly}) - ${selected_kernel}"
+
 # Left pad the strings to center them based on the preview width
 selected_env_str="$( printf "%*s\n" $(( (${#selected_env_str} + WIDTH ) / 2)) "${selected_env_str}" )"
 selected_arguments="$( printf "%*s\n" $(( (${#selected_arguments} + WIDTH ) / 2)) "${selected_arguments}" )"
 
-if [ "${_readonly}" = "r/o" ]; then
-  echo -e "${GREEN}${selected_env_str}${NC}"
-else
-  echo -e "${RED}${selected_env_str}${NC}"
-fi
-
+# colorize doesn't automatically add a newline
+colorize "${_COLOR}" "${selected_env_str}\n"
 echo "${selected_arguments}"

--- a/90zfsbootmenu/zfsbootmenu-preview.sh
+++ b/90zfsbootmenu/zfsbootmenu-preview.sh
@@ -7,13 +7,6 @@
 ENV="${1}"
 BOOTFS="${2}"
 
-# Skim doesn't set the environment
-if [ -z "${FZF_PREVIEW_COLUMNS}" ]; then
-  WIDTH="$( tput cols )"
-else
-  WIDTH="${FZF_PREVIEW_COLUMNS}"
-fi
-
 # shellcheck disable=SC2034
 IFS=' ' read -r _fs selected_kernel _initramfs <<<"$( select_kernel "${ENV}")"
 selected_kernel="${selected_kernel##*/}"
@@ -33,10 +26,10 @@ else
   _DEFAULT=""
 fi
 
-selected_env_str="$( center_string "${WIDTH}" "${ENV} (${_DEFAULT}${_readonly}) - ${selected_kernel}" )"
+selected_env_str="$( center_string "${ENV} (${_DEFAULT}${_readonly}) - ${selected_kernel}" )"
 
 selected_arguments="$( load_be_cmdline "${ENV}" )"
-selected_arguments="$( center_string "${WIDTH}" "$( load_be_cmdline "${ENV}" )" )"
+selected_arguments="$( center_string "$( load_be_cmdline "${ENV}" )" )"
 
 # colorize doesn't automatically add a newline
 colorize "${_COLOR}" "${selected_env_str}\n"


### PR DESCRIPTION
Move the helper functions from zfsbootmenu-help.sh:

* center
* colorize

`zfsbootmenu-preview.sh` had a lot of legacy code / procedures in it, before `zfsbootmenu-lib.sh` was as fleshed out as it is now. Clean up the usage / flow dramatically to use helper functions where possible.

`zfs-chroot.sh` now colorizes text when entering the chroot to add 37 pieces of flair to the output.

`timed_prompt`, `resume_prompt`, and the snapshot manipulation user input sections in `zfsbootmenu.sh` could possibly use an update to use `colorize` - but with the possible future use of `dialog`, that might be wasted effort. Thoughts?

Closes #115 