### PR TITLE
Logging lifecycle

### DIFF
--- a/90zfsbootmenu/zfs-chroot.sh
+++ b/90zfsbootmenu/zfs-chroot.sh
@@ -36,7 +36,6 @@ if mountpoint="$( allow_rw=yes mount_zfs "${selected}" )"; then
     _SHELL="/bin/sh"
   else
     zerror "unable to test execute a shell in ${selected}"
-    color=red timed_prompt "Unable to find a working shell in ${selected}"
   fi
 
   if [ -n "${_SHELL}" ]; then
@@ -45,7 +44,6 @@ if mountpoint="$( allow_rw=yes mount_zfs "${selected}" )"; then
     # regardless of shell, set PS1
     if ! env "PS1=$( colorize orange "${selected}") > " chroot "${mountpoint}" "${_SHELL}" ; then
       zerror "unable to execute ${selected}:${_SHELL}"
-      color=red timed_prompt "Unable to chroot in to ${selected}"
     fi
   fi
 

--- a/90zfsbootmenu/zfsbootmenu-countdown.sh
+++ b/90zfsbootmenu/zfsbootmenu-countdown.sh
@@ -60,7 +60,7 @@ fi
 unsupported=0
 while IFS=$'\t' read -r _pool _property; do
   if [[ "${_property}" =~ "unsupported@" ]]; then
-    zdebug "unsupported property: ${_property}"
+    zerror "unsupported property: ${_property}"
     if ! grep -q "${_pool}" "${BASE}/degraded" >/dev/null 2>&1 ; then
       echo "${_pool}" >> "${BASE}/degraded"
     fi
@@ -69,6 +69,7 @@ while IFS=$'\t' read -r _pool _property; do
 done <<<"$( zpool get all -H -o name,property )"
 
 if [ "${unsupported}" -ne 0 ]; then
+  zerror "Unsupported features detected, Upgrade ZFS modules in ZFSBootMenu with generate-zbm"
   color=red timed_prompt "Unsupported features detected" "Upgrade ZFS modules in ZFSBootMenu with generate-zbm"
 fi
 

--- a/90zfsbootmenu/zfsbootmenu-countdown.sh
+++ b/90zfsbootmenu/zfsbootmenu-countdown.sh
@@ -60,6 +60,7 @@ fi
 unsupported=0
 while IFS=$'\t' read -r _pool _property; do
   if [[ "${_property}" =~ "unsupported@" ]]; then
+    zdebug "unsupported property: ${_property}"
     if ! grep -q "${_pool}" "${BASE}/degraded" >/dev/null 2>&1 ; then
       echo "${_pool}" >> "${BASE}/degraded"
     fi

--- a/90zfsbootmenu/zfsbootmenu-exec.sh
+++ b/90zfsbootmenu/zfsbootmenu-exec.sh
@@ -8,12 +8,7 @@ export loglevel
 export root
 export zbm_sort
 
-# store current kernel log level
-read -r PRINTK < /proc/sys/kernel/printk
-PRINTK=${PRINTK:0:1}
-export PRINTK
-
-# Set it to 0
+# Disable all kernel messages to the console
 echo 0 > /proc/sys/kernel/printk
 
 # set the console size, if indicated

--- a/90zfsbootmenu/zfsbootmenu-exec.sh
+++ b/90zfsbootmenu/zfsbootmenu-exec.sh
@@ -31,6 +31,7 @@ fi
 echo "Loading ZFSBootMenu ..."
 
 export BASE="/zfsbootmenu"
+mkdir -p "${BASE}"
 
 modprobe zfs 2>/dev/null
 udevadm settle
@@ -44,7 +45,7 @@ udevadm settle
 #shellcheck disable=SC2154
 if [ -n "${zbm_tmux}" ] && [ -x /bin/tmux ]; then
   tmux new-session -n ZFSBootMenu -d /libexec/zfsbootmenu-countdown
-  tmux new-window -n logs /bin/zlogtail -f -n
+  tmux new-window -n logs /bin/zlogtail -f -n -l 7
   tmux new-window -n shell /bin/bash
   exec tmux attach-session \; select-window -t ZFSBootMenu
 else

--- a/90zfsbootmenu/zfsbootmenu-exec.sh
+++ b/90zfsbootmenu/zfsbootmenu-exec.sh
@@ -45,7 +45,7 @@ udevadm settle
 #shellcheck disable=SC2154
 if [ -n "${zbm_tmux}" ] && [ -x /bin/tmux ]; then
   tmux new-session -n ZFSBootMenu -d /libexec/zfsbootmenu-countdown
-  tmux new-window -n logs /bin/zlogtail -f -n -l 7
+  tmux new-window -n logs /bin/zlogtail -f -n
   tmux new-window -n shell /bin/bash
   exec tmux attach-session \; select-window -t ZFSBootMenu
 else

--- a/90zfsbootmenu/zfsbootmenu-exec.sh
+++ b/90zfsbootmenu/zfsbootmenu-exec.sh
@@ -44,7 +44,7 @@ udevadm settle
 #shellcheck disable=SC2154
 if [ -n "${zbm_tmux}" ] && [ -x /bin/tmux ]; then
   tmux new-session -n ZFSBootMenu -d /libexec/zfsbootmenu-countdown
-  tmux new-window -n logs /bin/zlogtail
+  tmux new-window -n logs /bin/zlogtail -f -n
   tmux new-window -n shell /bin/bash
   exec tmux attach-session \; select-window -t ZFSBootMenu
 else

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -850,7 +850,7 @@ select_kernel() {
     done <<<"$( tac "${BASE}/${zfsbe}/kernels" )"
   fi
 
-  zdebug "using kexec args: ${spec_kexec_args}"
+  zdebug "using kexec args: ${kexec_args}"
   echo "${kexec_args}"
 }
 

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -22,7 +22,6 @@ zlog() {
   _func="${FUNCNAME[2]}"
 
   WIDTH="$( tput cols )"
-
   echo -e "<${1}>ZBM:\033[0;33m${_script}[$$]\033[0;31m:${_func}()\033[0m: ${2}" | fold -s -w "${WIDTH}" > /dev/kmsg
 }
 

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -42,6 +42,7 @@ zwarn() {
 }
 
 zerror() {
+  : > "${BASE}/have_errors"
   zlog 3 "$@"
 }
 

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -516,17 +516,9 @@ kexec_kernel() {
     unset tdhook
   fi
 
-  # restore kernel log level just before we kexec
-  # shellcheck disable=SC2154
-  if [ -n "${PRINTK}" ] ; then
-    echo "${PRINTK}" > /proc/sys/kernel/printk
-    zdebug "restored kernel log level to ${PRINTK}"
-  fi
-
   if ! output="$( kexec -e -i 2>&1 )"; then
     zerror "kexec -e -i failed!"
     zerror "${output}"
-    echo 0 > /proc/sys/kernel/printk
     color=red delay=10 timed_prompt "kexec run of ${kernel} failed!"
     return 1
   fi

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -270,7 +270,7 @@ draw_be() {
 
   zdebug "using environment file: ${env}"
 
-  header="$( header_wrap "[ENTER] boot" "[ESC] refresh view" "[CTRL+H] help" "[CTRL-L] error log" "" \
+  header="$( header_wrap "[ENTER] boot" "[ESC] refresh view" "[CTRL+H] help" "[CTRL+L] error log" "" \
     "[CTRL+E] edit kcl" "[CTRL+K] kernels" "[CTRL+D] set bootfs" "[CTRL+S] snapshots" "" \
     "[CTRL+I] interactive chroot" "[CTRL+R] recovery shell" "[CTRL+P] pool status" )"
 
@@ -313,7 +313,7 @@ draw_kernel() {
   zdebug "using kernels file: ${_kernels}"
 
   header="$( header_wrap \
-    "[ENTER] boot" "[ESC] back" "" "[CTRL+D] set default" "[CTRL+H] help" "[CTRL-L] error log" )"
+    "[ENTER] boot" "[ESC] back" "" "[CTRL+D] set default" "[CTRL+H] help" "[CTRL+L] error log" )"
 
   expects="--expect=alt-d"
 
@@ -350,7 +350,7 @@ draw_snapshots() {
   sort_key="$( get_sort_key )"
 
   header="$( header_wrap \
-    "[ENTER] duplicate" "[ESC] back" "[CTRL+H] help" "[CTRL-L] error log" "" \
+    "[ENTER] duplicate" "[ESC] back" "[CTRL+H] help" "[CTRL+L] error log" "" \
     "[CTRL+X] clone and promote" "[CTRL+C] clone only" "" \
     "[CTRL+I] interactive chroot" "[CTRL+D] show diff" )"
 
@@ -430,7 +430,7 @@ draw_pool_status() {
   # Wrap to half width to avoid the preview window
   hdr_width="$(( ( $( tput cols ) / 2 ) - 4 ))"
   header="$( wrap_width="$hdr_width" header_wrap \
-    "[ESC] back" "" "[CTRL+R] rewind checkpoint" "" "[CTRL+H] help" "[CTRL-L] error log" )"
+    "[ESC] back" "" "[CTRL+R] rewind checkpoint" "" "[CTRL+H] help" "[CTRL+L] error log" )"
 
   if ! selected="$( zpool list -H -o name |
       HELP_SECTION=POOL ${FUZZYSEL} \

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -487,6 +487,10 @@ kexec_kernel() {
     zerror "unable to load ${mnt}${kernel} and ${mnt}${initramfs} into memory"
     zerror "${output}"
     umount "${mnt}"
+    color=red delay=10 timed_prompt "Unable to load kernel or initramfs into memory" \
+      "${mnt}${kernel}" \
+      "${mnt}${initramfs}"
+
     return 1
   else
     zdebug "loaded ${mnt}${kernel} and ${mnt}${initramfs} into memory"
@@ -523,6 +527,7 @@ kexec_kernel() {
     zerror "kexec -e -i failed!"
     zerror "${output}"
     echo 0 > /proc/sys/kernel/printk
+    color=red delay=10 timed_prompt "kexec run of ${kernel} failed!"
     return 1
   fi
 }

--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -29,6 +29,8 @@ fi
 # Use loglevel to determine logging to /dev/kmsg
 loglevel=$( getarg loglevel=)
 if [ -n "${loglevel}" ]; then
+  # minimum log level of 3, so we never lose error messages
+  [ "${loglevel}" -ge 3 ] || loglevel=3
   info "ZFSBootMenu: setting log level from command line: ${loglevel}"
 else
   loglevel=3

--- a/90zfsbootmenu/zfsbootmenu-preview.sh
+++ b/90zfsbootmenu/zfsbootmenu-preview.sh
@@ -26,11 +26,16 @@ else
   _DEFAULT=""
 fi
 
-selected_env_str="$( center_string "${ENV} (${_DEFAULT}${_readonly}) - ${selected_kernel}" )"
-
 selected_arguments="$( load_be_cmdline "${ENV}" )"
 selected_arguments="$( center_string "$( load_be_cmdline "${ENV}" )" )"
 
+selected_env_str="$( center_string "${ENV} (${_DEFAULT}${_readonly}) - ${selected_kernel}" )"
+
 # colorize doesn't automatically add a newline
+if [ -f "${BASE}/have_errors" ]; then
+  selected_env_str="${selected_env_str:3}"
+  colorize "red" "[!]"
+fi
+
 colorize "${_COLOR}" "${selected_env_str}\n"
 echo "${selected_arguments}"

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -60,7 +60,10 @@ fuzzy_default_options=( "--ansi" "--no-clear"
   "--layout=reverse-list" "--inline-info" "--tac" "--color=16"
   "--bind" '"alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
   "--bind" '"ctrl-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
-  "--bind" '"ctrl-alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"' )
+  "--bind" '"ctrl-alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
+  "--bind" '"alt-l:execute[ /bin/zlogtail -l err ]"'
+  "--bind" '"ctrl-l:execute[ /bin/zlogtail -l err ]"'
+  "--bind" '"ctrl-alt-l:execute[ /bin/zlogtail -l err ]"' )
 if command -v fzf >/dev/null 2>&1; then
   zdebug "using fzf for pager"
   export FUZZYSEL=fzf

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -61,9 +61,9 @@ fuzzy_default_options=( "--ansi" "--no-clear"
   "--bind" '"alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
   "--bind" '"ctrl-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
   "--bind" '"ctrl-alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
-  "--bind" '"alt-l:execute[ /bin/zlogtail -l err ]"'
-  "--bind" '"ctrl-l:execute[ /bin/zlogtail -l err ]"'
-  "--bind" '"ctrl-alt-l:execute[ /bin/zlogtail -l err ]"' )
+  "--bind" '"alt-l:execute[ /bin/zlogtail -l err -c ]+refresh-preview"'
+  "--bind" '"ctrl-l:execute[ /bin/zlogtail -l err -c ]+refresh-preview"'
+  "--bind" '"ctrl-alt-l:execute[ /bin/zlogtail -l err -c ]+refresh-preview"' )
 if command -v fzf >/dev/null 2>&1; then
   zdebug "using fzf for pager"
   export FUZZYSEL=fzf

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -61,9 +61,9 @@ fuzzy_default_options=( "--ansi" "--no-clear"
   "--bind" '"alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
   "--bind" '"ctrl-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
   "--bind" '"ctrl-alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
-  "--bind" '"alt-l:execute[ /bin/zlogtail -l err -c ]+refresh-preview"'
-  "--bind" '"ctrl-l:execute[ /bin/zlogtail -l err -c ]+refresh-preview"'
-  "--bind" '"ctrl-alt-l:execute[ /bin/zlogtail -l err -c ]+refresh-preview"' )
+  "--bind" '"alt-l:execute[ /bin/zlogtail -l err -F user -c ]+refresh-preview"'
+  "--bind" '"ctrl-l:execute[ /bin/zlogtail -l err -F user -c ]+refresh-preview"'
+  "--bind" '"ctrl-alt-l:execute[ /bin/zlogtail -l err -F user -c ]+refresh-preview"' )
 if command -v fzf >/dev/null 2>&1; then
   zdebug "using fzf for pager"
   export FUZZYSEL=fzf

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -212,6 +212,7 @@ while true; do
           if [ "${leftover_space}" -le 0 ]; then
             avail_space="$( zfs list -H -o available "${parent_ds}" )"
             be_size="$( zfs list -H -o refer "${selected_snap}" )"
+            zerror "Insufficient space for duplication, ${parent_ds}' has ${avail_space} free but needs ${be_size}"
             color=red delay=10 timed_prompt "Insufficient space for duplication" \
               "'${parent_ds}' has ${avail_space} free but needs ${be_size}"
             continue

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -284,7 +284,7 @@ while true; do
       tput cnorm
 
       echo ""
-      /libexec/zfsbootmenu-preview "${BASE}" "${selected_be}" "${BOOTFS}"
+      /libexec/zfsbootmenu-preview "${selected_be}" "${BOOTFS}"
 
       BE_ARGS="$( load_be_cmdline "${selected_be}" )"
       while IFS= read -r line; do

--- a/90zfsbootmenu/zlogtail.sh
+++ b/90zfsbootmenu/zlogtail.sh
@@ -1,14 +1,50 @@
 #!/bin/bash
 
-# Ignore keys in a future release
-# --bind "ctrl-c:ignore,ctrl-g:ignore,esc:ignore,enter:ignore"
+PID_FILE="$( mktemp --tmpdir="${BASE}" )"
+export PID_FILE
+trap 'rm -f ${PID_FILE}' EXIT
+
+#shellcheck disable=SC2154
+LOG_LEVEL="${loglevel:-err}"
+FOLLOW=""
+ALLOW_EXIT=1
+while getopts "fnl:" opt; do
+  case "${opt}" in
+    l)
+      LOG_LEVEL="${OPTARG}"
+      ;;
+    n)
+      ALLOW_EXIT=0
+      ;;
+    f)
+      FOLLOW="-w"
+      ;;
+    *)
+      ;;
+  esac
+done
+
+fuzzy_default_options+=("--bind")
+fuzzy_default_options+=('"ctrl-q:ignore,ctrl-c:ignore,ctrl-g:ignore,enter:ignore"')
+
+if ((ALLOW_EXIT)) ; then
+  fuzzy_default_options+=("--bind")
+  # shellcheck disable=SC2016
+  fuzzy_default_options+=('"esc:execute-silent[ kill $( cat ${PID_FILE} ) ]+abort"')
+else
+  fuzzy_default_options+=("--bind")
+  fuzzy_default_options+=('"esc:ignore"')
+fi
 
 if command -v fzf >/dev/null 2>&1; then
   FUZZYSEL=fzf
-  export FZF_DEFAULT_OPTS='--no-mouse --no-sort --ansi --tac --no-info'
+  export FZF_DEFAULT_OPTS="--no-mouse --no-sort --ansi --tac --no-info ${fuzzy_default_options[*]}"
 elif command -v sk >/dev/null 2>&1; then
   FUZZYSEL=sk
-  export SKIM_DEFAULT_OPTIONS='--no-sort --ansi --tac'
+  export SKIM_DEFAULT_OPTIONS="--no-sort --ansi --tac ${fuzzy_default_options[*]}"
 fi
 
-dmesg -T --time-format reltime --noescape -w | ${FUZZYSEL}
+ # shellcheck disable=SC2086
+( dmesg -T --time-format reltime --noescape -l ${LOG_LEVEL} ${FOLLOW} & echo $! >&3 ) \
+  3>"${PID_FILE}" \
+  | ${FUZZYSEL}

--- a/90zfsbootmenu/zlogtail.sh
+++ b/90zfsbootmenu/zlogtail.sh
@@ -5,7 +5,7 @@ export PID_FILE
 trap 'rm -f ${PID_FILE}' EXIT
 
 #shellcheck disable=SC2154
-LOG_LEVEL="${loglevel:-err}"
+LOG_LEVEL="${loglevel:-7}"
 FOLLOW=""
 ALLOW_EXIT=1
 while getopts "fnl:" opt; do
@@ -24,6 +24,10 @@ while getopts "fnl:" opt; do
   esac
 done
 
+fuzzy_default_options+=("--no-sort")
+fuzzy_default_options+=("--ansi")
+fuzzy_default_options+=("--tac")
+
 fuzzy_default_options+=("--bind")
 fuzzy_default_options+=('"ctrl-q:ignore,ctrl-c:ignore,ctrl-g:ignore,enter:ignore"')
 
@@ -38,10 +42,10 @@ fi
 
 if command -v fzf >/dev/null 2>&1; then
   FUZZYSEL=fzf
-  export FZF_DEFAULT_OPTS="--no-mouse --no-sort --ansi --tac --no-info ${fuzzy_default_options[*]}"
+  export FZF_DEFAULT_OPTS="--no-mouse --no-info ${fuzzy_default_options[*]}"
 elif command -v sk >/dev/null 2>&1; then
   FUZZYSEL=sk
-  export SKIM_DEFAULT_OPTIONS="--no-sort --ansi --tac ${fuzzy_default_options[*]}"
+  export SKIM_DEFAULT_OPTIONS="${fuzzy_default_options[*]}"
 fi
 
  # shellcheck disable=SC2086

--- a/90zfsbootmenu/zlogtail.sh
+++ b/90zfsbootmenu/zlogtail.sh
@@ -6,9 +6,10 @@ trap 'rm -f ${PID_FILE}' EXIT
 
 #shellcheck disable=SC2154
 LOG_LEVEL="${loglevel:-7}"
+FACILITY="kern,user"
 FOLLOW=""
 ALLOW_EXIT=1
-while getopts "cfnl:" opt; do
+while getopts "cfnl:F:" opt; do
   case "${opt}" in
     l)
       LOG_LEVEL="${OPTARG}"
@@ -21,6 +22,9 @@ while getopts "cfnl:" opt; do
       ;;
     c)
       [ -f "${BASE}/have_errors" ] && rm "${BASE}/have_errors"
+      ;;
+    F)
+      FACILITY="${OPTARG}"
       ;;
     *)
       ;;
@@ -52,6 +56,6 @@ elif command -v sk >/dev/null 2>&1; then
 fi
 
  # shellcheck disable=SC2086
-( dmesg -T --time-format reltime --noescape -l ${LOG_LEVEL} ${FOLLOW} & echo $! >&3 ) \
+( dmesg -T --time-format reltime --noescape -f ${FACILITY} -l ${LOG_LEVEL} ${FOLLOW} & echo $! >&3 ) \
   3>"${PID_FILE}" \
   | ${FUZZYSEL}

--- a/90zfsbootmenu/zlogtail.sh
+++ b/90zfsbootmenu/zlogtail.sh
@@ -5,7 +5,7 @@ export PID_FILE
 trap 'rm -f ${PID_FILE}' EXIT
 
 #shellcheck disable=SC2154
-LOG_LEVEL="${loglevel:-7}"
+LOG_LEVEL="0,1,2,3,4,5,6,7"
 FACILITY="kern,user"
 FOLLOW=""
 ALLOW_EXIT=1

--- a/90zfsbootmenu/zlogtail.sh
+++ b/90zfsbootmenu/zlogtail.sh
@@ -8,7 +8,7 @@ trap 'rm -f ${PID_FILE}' EXIT
 LOG_LEVEL="${loglevel:-7}"
 FOLLOW=""
 ALLOW_EXIT=1
-while getopts "fnl:" opt; do
+while getopts "cfnl:" opt; do
   case "${opt}" in
     l)
       LOG_LEVEL="${OPTARG}"
@@ -18,6 +18,9 @@ while getopts "fnl:" opt; do
       ;;
     f)
       FOLLOW="-w"
+      ;;
+    c)
+      [ -f "${BASE}/have_errors" ] && rm "${BASE}/have_errors"
       ;;
     *)
       ;;


### PR DESCRIPTION
This PR is an attempt to make logging play a more focused role in the ZBM ecosystem.  Various components would correctly catch and log an error through `zerror()`, but unless you know how to look for them, they were entirely hidden from view. As such, I attempted to meet the following goals:

* Where an error is critical, (kexec, duplicating a BE), show a prompt and log an error
* For all other error conditions, log an error with enough contextual information
* When an error is generated, show an indicator on the main screen
* Allow the error log to be viewed on any selector screen via `MOD-L`

In addition to the error log integrations, I made a pass through virtually every function in `zfsbootmenu-lib.sh`.  Where positional parameters are non-optional in a function call, a test for empty is performed for each parameter. If the parameter is empty, an error is logged and and the function returns. Some functions had a check / silent return, others did not. They've all been normalized.

I've tested the behavior with an x86_64 BE in a ppc64le VM to confirm kexec and chroot error handling.  

Are there any other error conditions that should warrant a `timed_prompt`, or should the current usage be pared back?

One side effect of this work is that the heavy usage of `zdebug()` does have a performance impact, so booting ZBM with `loglevel=7`should now only be done if you actually need debug level logging. Nothing is free.