### PR TITLE
Support old versions of craaaaap

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -94,7 +94,11 @@ install() {
   done
 
   # sk can be used as a substitute for fzf
-  if ! dracut_install fzf && ! dracut_install sk; then
+  if dracut_install fzf; then
+    FUZZY_FIND="fzf"
+  elif dracut_install sk; then
+    FUZZY_FIND="sk"
+  else
     dfatal "failed to install fzf or sk"
     exit 1
   fi
@@ -259,10 +263,10 @@ install() {
     has_escape=
   fi
 
-  # Check if fzf supports the refresh-preview flag
+  # Check if fuzzy finder supports the refresh-preview flag
   # Added in fzf 0.22.0
-  if command -v fzf >/dev/null 2>&1 && \
-    echo "abc" | fzf -f "abc" --bind "alt-l:refresh-preview" --exit-0 >/dev/null 2>&1 
+  if command -v "${FUZZY_FIND}" >/dev/null 2>&1 && \
+    echo "abc" | "${FUZZY_FIND}" -f "abc" --bind "alt-l:refresh-preview" --exit-0 >/dev/null 2>&1
   then
     has_refresh=1
   else

--- a/90zfsbootmenu/zfsbootmenu-help.sh
+++ b/90zfsbootmenu/zfsbootmenu-help.sh
@@ -39,7 +39,7 @@ help_pager() {
     --with-nth=2.. \
     --bind pgup:preview-up,pgdn:preview-down \
     --preview="$0 -s {1}" \
-    --preview-window="right:${PREVIEW_SIZE}:sharp:wrap" \
+    --preview-window="right:${PREVIEW_SIZE}:wrap" \
     --header="$( colorize green "[ESC]" ) $( colorize lightblue "back" )" \
     --tac \
     --color='border:6'

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -24,8 +24,10 @@ zlog() {
   WIDTH="$( tput cols )"
 
   # Only add script/function tracing to debug messages
-  if [ "${1}" -eq 7 ]; then
+  if [ "${1}" -eq 7 ] && [ -n "${HAS_NOESCAPE}" ] ; then
     echo -e "<${1}>ZBM:\033[0;33m${_script}[$$]\033[0;31m:${_func}()\033[0m: ${2}" | fold -s -w "${WIDTH}" > /dev/kmsg
+  elif [ "${1}" -eq 7 ]; then
+    echo -e "<${1}>ZBM:${_script}[$$]:${_func}(): ${2}" | fold -s -w "${WIDTH}" > /dev/kmsg
   else
     echo -e "<${1}>ZFSBootMenu: ${2}" | fold -s -w "${WIDTH}" > /dev/kmsg
   fi

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -636,7 +636,7 @@ draw_pool_status() {
   if ! selected="$( zpool list -H -o name |
       HELP_SECTION=POOL ${FUZZYSEL} \
       --prompt "Pool > " --tac --expect=alt-r,ctrl-r,ctrl-alt-r \
-      --preview-window="right:${psize}:sharp" \
+      --preview-window="right:${psize}" \
       --preview="zpool status -v {}" --header="${header}" )"; then
     return 1
   fi

--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -4,13 +4,13 @@
 # shellcheck disable=SC1091
 . /lib/dracut-lib.sh
 
-if [ -r "/etc/byte-order" ]; then
-  read -r endian < "/etc/byte-order"
-fi
+# Source options detected at build time
+# shellcheck disable=SC1091
+[ -r /etc/zfsbootmenu.conf ] && source /etc/zfsbootmenu.conf
 
-if [ -z "${endian}" ]; then
+if [ -z "${BYTE_ORDER}" ]; then
   warn "unable to determine platform endianness; assuming little-endian"
-  endian="le"
+  BYTE_ORDER="le"
 fi
 
 # Let the command line override our host id.
@@ -46,7 +46,7 @@ import_policy=$( getarg zbm.import_policy )
 if [ -n "${import_policy}" ]; then
   case "${import_policy}" in
     hostid)
-      if [ "${endian}" = "be" ]; then
+      if [ "${BYTE_ORDER}" = "be" ]; then
         info "ZFSBootMenu: invalid option for big endian systems"
         info "ZFSBootMenu: setting import_policy to strict"
         import_policy="strict"
@@ -133,7 +133,7 @@ if getargbool 0 zbm.tmux ; then
 fi
 
 # shellcheck disable=SC2034
-if [ "${endian}" = "be" ]; then
+if [ "${BYTE_ORDER}" = "be" ]; then
   zbm_set_hostid=0
   info "ZFSBootMenu: big endian detected, disabling automatic replacement of spl_hostid"
 elif getargbool 0 zbm.set_hostid ; then

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -60,10 +60,22 @@ fuzzy_default_options=( "--ansi" "--no-clear"
   "--layout=reverse-list" "--inline-info" "--tac" "--color=16"
   "--bind" '"alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
   "--bind" '"ctrl-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
-  "--bind" '"ctrl-alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"'
-  "--bind" '"alt-l:execute[ /bin/zlogtail -l warn -F user,daemon -c ]+refresh-preview"'
-  "--bind" '"ctrl-l:execute[ /bin/zlogtail -l warn -F user,daemon -c ]+refresh-preview"'
-  "--bind" '"ctrl-alt-l:execute[ /bin/zlogtail -l warn -F user,daemon -c ]+refresh-preview"' )
+  "--bind" '"ctrl-alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-MAIN} ]"' )
+
+if [ -n "${HAS_REFRESH}" ] ; then
+  fuzzy_default_options+=(
+    "--bind" '"alt-l:execute[ /bin/zlogtail -l warn -F user,daemon -c ]+refresh-preview"'
+    "--bind" '"ctrl-l:execute[ /bin/zlogtail -l warn -F user,daemon -c ]+refresh-preview"'
+    "--bind" '"ctrl-alt-l:execute[ /bin/zlogtail -l warn -F user,daemon -c ]+refresh-preview"'
+  )
+else
+  fuzzy_default_options+=(
+    "--bind" '"alt-l:execute[ /bin/zlogtail -l warn -F user,daemon -c ]"'
+    "--bind" '"ctrl-l:execute[ /bin/zlogtail -l warn -F user,daemon -c ]"'
+    "--bind" '"ctrl-alt-l:execute[ /bin/zlogtail -l warn -F user,daemon -c ]"'
+  )
+fi
+
 if command -v fzf >/dev/null 2>&1; then
   zdebug "using fzf for pager"
   export FUZZYSEL=fzf

--- a/90zfsbootmenu/zlogtail.sh
+++ b/90zfsbootmenu/zlogtail.sh
@@ -49,7 +49,7 @@ fi
 
 if command -v fzf >/dev/null 2>&1; then
   FUZZYSEL=fzf
-  export FZF_DEFAULT_OPTS="--no-mouse --no-info ${fuzzy_default_options[*]}"
+  export FZF_DEFAULT_OPTS="--no-mouse --inline-info ${fuzzy_default_options[*]}"
 elif command -v sk >/dev/null 2>&1; then
   FUZZYSEL=sk
   export SKIM_DEFAULT_OPTIONS="${fuzzy_default_options[*]}"


### PR DESCRIPTION
Check if dmesg supports the '--noescape' flag
Check if fzf supports the 'refresh-preview' action

Create /etc/zfsbootmenu.conf in the initramfs with exports, so the file can be sourced in the initramfs. Variables in here should be considered feature flags - if the variable is defined with any value, the flag is set to true. If the variable is undefined, consider the feature disabled.

BYTE_ORDER: influence how /etc/hostid is written
HAS_NOESCAPE: enable color escape codes in debug-level messages / parse them in zlogtail
HAS_REFRESH: fzf is new enough to support the refresh-preview action. This has the added benefit of un-breaking skim support, again

Fixes #149 