### PR TITLE
Testing pool name/file conflict enhancements

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -8,6 +8,14 @@ The testing environment setup and runtime depends on the following tools:
 * ZFS
 * kvm kernel module
 
+## Arch
+* m4
+* pacman
+* gpg
+
+## Ubuntu, Debian
+* debootstrap
+
 # Creating a ZFSBootMenu Test Pool for QEMU
 
 First, run `./setup.sh -a`; this will create, if necessary, a test directory

--- a/testing/setup.sh
+++ b/testing/setup.sh
@@ -34,13 +34,13 @@ EOF
 }
 
 random_dict_value() {
-  sed -n "$(shuf -i 1-"$( wc -l "${1}" | cut -d ' ' -f 1)" -n 1)"p "${1}" \
+  sed -n "$(shuf -i 1-"$( wc -l "${dictfile}" | cut -d ' ' -f 1)" -n 1)"p "${dictfile}" \
     | sed s/\'s// \
     | tr '[:upper:]' '[:lower:]'
 }
 
 random_name() {
-  echo "$( random_dict_value "${dictfile}" )$( random_dict_value "${dictfile}" | sed -e 's/\b./\u\0/' )"
+  echo "$( random_dict_value )$( random_dict_value | sed -e 's/\b./\u\0/' )"
 }
 
 if [ $# -eq 0 ]; then

--- a/testing/setup.sh
+++ b/testing/setup.sh
@@ -169,7 +169,11 @@ else
 fi
 
 while true; do
-  if [ ! -r "${TESTDIR}/${POOL_NAME}-pool.img" ]; then
+  # Check that a file doesn't exist with this name, or that
+  # a currently-imported pool doesn't have this name
+  if [ ! -r "${TESTDIR}/${POOL_NAME}-pool.img" ] \
+    && ! zpool list -o name -H "${POOL_NAME}" >/dev/null 2>&1
+  then
     break
   fi
 


### PR DESCRIPTION
- Add a `-r` randomized name option, which creates Docker-style (roughly) random names from a dictionary file (`words-en`). 
- Add the `-p` option to allow setting a pool name from the command line.
- Instead of naming the qemu-img file `zfsbootmenu-pool.img`, create the file as `<pool name>-pool.img`. This works cleanly with the default `*-pool.img` glob with `./run.sh -D <test setup`.
- Check for imported pools that match the randomized or user-provided name, or files on disk that match either. If a file is detected with that pool name, or an imported pool matches that name:
  * Append an indexed number to the pool name / file OR
  * Generate a new randomized name

All pool name / file selection logic has been pushed into `setup.sh`; `helpers/image.sh` is now strictly responsible for creating a qemu image / pool.