### PR TITLE
Support reuse of existing pool images in setup.sh

### DIFF
--- a/testing/.gitignore
+++ b/testing/.gitignore
@@ -9,3 +9,4 @@ dracut
 dracut.conf.d
 generate-zbm
 test.*
+keys

--- a/testing/helpers/chroot-arch.sh
+++ b/testing/helpers/chroot-arch.sh
@@ -20,12 +20,45 @@ EOF
 # Set root password
 echo 'root:zfsbootmenu' | chpasswd -c SHA256
 
+# Space checks in pacman don't work right
+sed -e "/CheckSpace/d" -i /etc/pacman.conf
+
+pacman-key --init
+pacman-key --populate
+
+# Do this in two stages to avoid dracut providing the initramfs virtual
+pacman --noconfirm -Sy linux linux-headers mkinitcpio vi openssh \
+  fakeroot automake autoconf pkg-config gcc make libtool binutils curl
+pacman --noconfirm -Sy dkms git dracut fzf kexec-tools cpanminus
+
+# Install ZFS command-line utilities
+runuser -u nobody -- /bin/sh -c "cd /tmp && \
+  git clone --depth=1 https://aur.archlinux.org/zfs-utils.git && \
+  cd zfs-utils && MAKEFLAGS='-j4' makepkg --skippgpcheck"
+pacman -U --noconfirm /tmp/zfs-utils/*.pkg.*
+rm -rf /tmp/zfs-utils
+
+# Install ZFS DKMS module
+runuser -u nobody -- /bin/sh -c "cd /tmp && \
+  git clone --depth=1 https://aur.archlinux.org/zfs-dkms.git && \
+  cd zfs-dkms && MAKEFLAGS='-j4' makepkg --skippgpcheck"
+pacman -U --noconfirm /tmp/zfs-dkms/*.pkg.*
+rm -rf /tmp/zfs-dkms
+
 ZFILES="/etc/hostid"
 for keyfile in /etc/zfs/*.key; do
   [ -e "${keyfile}" ] && ZFILES="${ZFILES} ${keyfile}"
 done
 
 sed -e "/HOOKS=/s/fsck/zfs/" -e "/FILES=/s@)@${ZFILES})@" -i /etc/mkinitcpio.conf
+
+# The initcpio hook that ships with zfs-dkms do not support encryption
+# Use the hook from archzfs instead
+zfsutils="https://raw.githubusercontent.com/archzfs/archzfs/master/src/zfs-utils"
+cpiolib="/usr/lib/initcpio"
+curl -L -o "${cpiolib}/hooks/zfs" "${zfsutils}/zfs-utils.initcpio.hook"
+curl -L -o "${cpiolib}/install/zfs" "${zfsutils}/zfs-utils.initcpio.install"
+curl -L -o "${cpiolib}/install/zfsencryptssh" "${zfsutils}/zfs-utils.initcpio.zfsncrypt.sshinstall"
 
 # Arch doesn't play nicely with the pre-existing cache
 rm -f /etc/zfs/zpool.cache
@@ -42,3 +75,6 @@ if [ -x /root/network-systemd.sh ]; then
   /root/network-systemd.sh
   rm /root/network-systemd.sh
 fi
+
+# Make sure gpg-agent components die to avoid blocking pool export
+gpgconf --homedir /etc/pacman.d/gnupg --kill all

--- a/testing/helpers/chroot-arch.sh
+++ b/testing/helpers/chroot-arch.sh
@@ -23,6 +23,9 @@ echo 'root:zfsbootmenu' | chpasswd -c SHA256
 # Space checks in pacman don't work right
 sed -e "/CheckSpace/d" -i /etc/pacman.conf
 
+# Make sure gpg-agent components die to avoid blocking pool export
+trap 'gpgconf --homedir /etc/pacman.d/gnupg --kill all; exit' EXIT INT TERM
+
 pacman-key --init
 pacman-key --populate
 
@@ -75,6 +78,3 @@ if [ -x /root/network-systemd.sh ]; then
   /root/network-systemd.sh
   rm /root/network-systemd.sh
 fi
-
-# Make sure gpg-agent components die to avoid blocking pool export
-gpgconf --homedir /etc/pacman.d/gnupg --kill all

--- a/testing/helpers/debootstrap.sh
+++ b/testing/helpers/debootstrap.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# vim: softtabstop=2 shiftwidth=2 expandtab
+
+# Just use a built-in debootstrap if possible
+if command -v debootstrap >/dev/null 2>&1; then
+  exec debootstrap "$@"
+fi
+
+cleanup() {
+  if [ -n "${DEBROOT}" ]; then
+    rm -rf "${DEBROOT}"
+    unset DEBROOT
+  fi
+
+  exit
+}
+
+trap cleanup EXIT INT TERM
+
+if ! DEBROOT="$( mktemp -d )"; then
+  echo "ERROR: unable to create working directory for debootstrap"
+  exit 1
+fi
+
+export DEBROOT
+
+(cd "${DEBROOT}" && \
+  git clone --depth=1 https://salsa.debian.org/installer-team/debootstrap.git)
+
+if [ ! -x "${DEBROOT}/debootstrap/debootstrap" ]; then
+  echo "ERROR: unable to find local clone of debootstrap"
+  exit 1
+fi
+
+export DEBOOTSTRAP_DIR="${DEBROOT}/debootstrap"
+
+DEBARCH=
+case "$(uname -m)" in
+  x86_64) DEBARCH=amd64 ;;
+  i686) DEBARCH=i386 ;;
+  aarch64) DEBARCH=arm64 ;;
+  armv7l) DEBARCH=armhf ;;
+  *) ;;
+esac
+
+if [ -z "${DEBARCH}" ]; then
+  echo "ERROR: unable to find supported architecture"
+  exit 1
+fi
+
+echo "${DEBARCH}" > "${DEBOOTSTRAP_DIR}/arch"
+"${DEBOOTSTRAP_DIR}/debootstrap" "$@"

--- a/testing/helpers/image.sh
+++ b/testing/helpers/image.sh
@@ -192,6 +192,19 @@ mount -t devpts pts "${CHROOT_MNT}/dev/pts"
 mkdir -p "${CHROOT_MNT}/etc/zfs"
 zpool set cachefile="${CHROOT_MNT}/etc/zfs/zpool.cache" "${ZBM_POOL}"
 
+# Pre-populate SSH keys, if available
+if [ -d "./keys/etc/ssh" ]; then
+  mkdir -p "${CHROOT_MNT}/etc"
+  cp -R "./keys/etc/ssh" "${CHROOT_MNT}/etc/"
+fi
+
+# Pre-populate authorized keys, if available
+if [ -r "./keys/authorized_keys" ]; then
+  mkdir -p "${CHROOT_MNT}/root/.ssh"
+  chmod 700 "${CHROOT_MNT}/root/.ssh"
+  cp "./keys/authorized_keys" "${CHROOT_MNT}/root/.ssh/"
+fi
+
 # Launch the chroot script
 if ! chroot "${CHROOT_MNT}" "/root/${CHROOT_SCRIPT##*/}"; then
   echo "ERROR: chroot script '${CHROOT_SCRIPT}' failed"

--- a/testing/helpers/install-arch.sh
+++ b/testing/helpers/install-arch.sh
@@ -24,9 +24,7 @@ mkdir -p "${PACROOT}"/{db,cache,gnupg,hooks}
 
 cat >> "${PACROOT}/pacman.conf" << EOF
 [options]
-DBPath = ${PACROOT}/db
 CacheDir = ${PACROOT}/cache
-LogFile = ${PACROOT}/pacman.log
 GPGDir = ${PACROOT}/gnupg
 HookDir = ${PACROOT}/hooks
 HoldPkg = pacman glibc
@@ -42,9 +40,6 @@ Include = ${PACROOT}/mirrorlist
 
 [community]
 Include = ${PACROOT}/mirrorlist
-
-[archzfs]
-Include = ${PACROOT}/zfsmirrors
 EOF
 
 cat >> "${PACROOT}/mirrorlist" << 'EOF'
@@ -54,43 +49,17 @@ Server = http://mirror.arizona.edu/archlinux/$repo/os/$arch
 Server = http://mirrors.rit.edu/archlinux/$repo/os/$arch
 EOF
 
-cat >> "${PACROOT}/zfsmirrors" << 'EOF'
-Server = http://archzfs.com/$repo/x86_64
-Server = http://mirror.sum7.eu/archlinux/archzfs/$repo/x86_64
-Server = https://mirror.biocrafting.net/archlinux/archzfs/$repo/x86_64
-Server = https://mirror.in.themindsmaze.com/archzfs/$repo/x86_64
-Server = https://zxcvfdsa.com/archzfs/$repo/$arch
-EOF
+"${PACROOT}/arch-install-scripts/pacstrap" \
+  -C "${PACROOT}/pacman.conf" "${CHROOT_MNT}" base
 
-pacman-key --config "${PACROOT}/pacman.conf" --init
-
-ARCHZFS_KEY=DDF7DB817396A49B2A2723F7403BD972F75D9D76
-pacman-key --config "${PACROOT}/pacman.conf" -r "${ARCHZFS_KEY}"
-pacman-key --config "${PACROOT}/pacman.conf" --lsign-key "${ARCHZFS_KEY}"
-
-pacstrap() {
-  yes | "${PACROOT}/arch-install-scripts/pacstrap" \
-    -C "${PACROOT}/pacman.conf" "${CHROOT_MNT}" "$@"
-}
-
-# This is done in two stages to avoid dracut satisfying initramfs
-pacstrap base archzfs-linux
-pacstrap openssh vi git dracut fzf kexec-tools cpanminus gcc make
+cp /etc/hostid "${CHROOT_MNT}/etc/"
+cp /etc/resolv.conf "${CHROOT_MNT}/etc/"
+cp "${PACROOT}/mirrorlist" "${CHROOT_MNT}/etc/pacman.d/"
 
 if [ -r "${ENCRYPT_KEYFILE}" ]; then
   mkdir -p "${CHROOT_MNT}/etc/zfs"
   cp "${ENCRYPT_KEYFILE}" "${CHROOT_MNT}/etc/zfs/"
 fi
-
-cp /etc/hostid "${CHROOT_MNT}/etc/"
-cp /etc/resolv.conf "${CHROOT_MNT}/etc/"
-cp "${PACROOT}/mirrorlist" "${CHROOT_MNT}/etc/pacman.d/"
-cp "${PACROOT}/zfsmirrors" "${CHROOT_MNT}/etc/pacman.d/"
-
-cat >> "${CHROOT_MNT}/etc/pacman.conf" << EOF
-[archzfs]
-Include = /etc/pacman.d/zfsmirrors
-EOF
 
 # Add network configuration script
 if [ -x ./helpers/network-systemd.sh ]; then

--- a/testing/helpers/install-arch.sh
+++ b/testing/helpers/install-arch.sh
@@ -1,6 +1,31 @@
 #!/bin/bash
 # vim: softtabstop=2 shiftwidth=2 expandtab
 
+cleanup () {
+  if [ -n "${PACROOT}" ]; then
+    # Tear down the root, first unmounting any special filesystems
+    mounted=
+    for fs in dev sys proc mnt; do
+      if mountpoint -q "${PACROOT}/root.x86_64/${fs}"; then
+        umount -R "${PACROOT}/root.x86_64/${fs}"
+
+        # Make sure the mount succeeded
+        if mountpoint -q "${PACROOT}/root.x86_64/${fs}"; then
+          mounted=yes
+        fi
+      fi
+    done
+
+    if [ -z "${mounted}" ]; then
+      rm -rf "${PACROOT}"
+    fi
+
+    unset PACROOT
+  fi
+
+  exit
+}
+
 if [ -z "${CHROOT_MNT}" ] || [ ! -d "${CHROOT_MNT}" ]; then
   echo "ERROR: chroot mountpoint must be specified and must exist"
   exit 1
@@ -9,38 +34,36 @@ fi
 if ! PACROOT="$( mktemp -d )"; then
   echo "ERROR: cannot make directory to clone arch-install-scripts"
   exit 1
+else
+  export PACROOT
 fi
 
-# shellcheck disable=SC2064
-trap "rm -rf '${PACROOT}'" EXIT
+trap cleanup EXIT INT TERM
 
-( 
-  cd "${PACROOT}" && \
-  git clone --depth=1 https://git.archlinux.org/arch-install-scripts.git && \
-  cd "${PACROOT}/arch-install-scripts" && make pacstrap 
-)
+archmirror="https://mirrors.edge.kernel.org/archlinux/iso/latest"
+archpattern="archlinux-bootstrap-[-_.A-Za-z0-9]\+-x86_64\.tar\.gz"
+archimg="$( curl -L "${archmirror}" | \
+  grep -o "${archpattern}" | sort -Vr | head -n 1 | tr -d '\n')"
 
-mkdir -p "${PACROOT}"/{db,cache,gnupg,hooks}
+if [ -z "${archimg}" ]; then
+  echo "ERROR: cannot identify Arch bootstrap image"
+  exit 1
+fi
 
-cat >> "${PACROOT}/pacman.conf" << EOF
-[options]
-CacheDir = ${PACROOT}/cache
-GPGDir = ${PACROOT}/gnupg
-HookDir = ${PACROOT}/hooks
-HoldPkg = pacman glibc
-Architecture = auto
+if ! curl -L -o "${PACROOT}/${archimg}" "${archmirror}/${archimg}"; then
+  echo "ERROR: failed to fetch Arch bootstrap image"
+  echo "Check URL at ${archmirror}/${archimg}"
+  exit 1
+fi
 
-SigLevel = Never
+# Unpack the bootstrap image
+tar xf "${PACROOT}/${archimg}" -C "${PACROOT}"
 
-[core]
-Include = ${PACROOT}/mirrorlist
-
-[extra]
-Include = ${PACROOT}/mirrorlist
-
-[community]
-Include = ${PACROOT}/mirrorlist
-EOF
+PACSTRAP="${PACROOT}/root.x86_64"
+if [ ! -d "${PACSTRAP}" ]; then
+  echo "ERROR: did not find expected Arch bootstrap directory"
+  exit 1
+fi
 
 cat >> "${PACROOT}/mirrorlist" << 'EOF'
 Server = http://mirrors.mit.edu/archlinux/$repo/os/$arch
@@ -49,11 +72,26 @@ Server = http://mirror.arizona.edu/archlinux/$repo/os/$arch
 Server = http://mirrors.rit.edu/archlinux/$repo/os/$arch
 EOF
 
-"${PACROOT}/arch-install-scripts/pacstrap" \
-  -C "${PACROOT}/pacman.conf" "${CHROOT_MNT}" base
+mount --bind "${CHROOT_MNT}" "${PACSTRAP}/mnt"
+mount --rbind /dev "${PACSTRAP}/dev" && mount --make-rslave "${PACSTRAP}/dev"
+mount -t sysfs sys "${PACSTRAP}/sys"
+mount -t proc proc "${PACSTRAP}/proc"
 
+cp "${PACROOT}/mirrorlist" "${PACSTRAP}/etc/pacman.d/"
+cp "/etc/resolv.conf" "${PACSTRAP}/etc/"
+
+unshare --fork --pid chroot "${PACSTRAP}" /bin/bash <<-EOF
+trap 'gpgconf --homedir /etc/pacman.d/gnupg --kill all; exit' EXIT INT TERM
+pacman-key --init
+pacman-key --populate
+pacstrap /mnt base
+EOF
+
+mkdir -p "${CHROOT_MNT}/etc"
 cp /etc/hostid "${CHROOT_MNT}/etc/"
 cp /etc/resolv.conf "${CHROOT_MNT}/etc/"
+
+mkdir -p "${CHROOT_MNT}/etc/pacman.d"
 cp "${PACROOT}/mirrorlist" "${CHROOT_MNT}/etc/pacman.d/"
 
 if [ -r "${ENCRYPT_KEYFILE}" ]; then

--- a/testing/helpers/install-debian.sh
+++ b/testing/helpers/install-debian.sh
@@ -11,7 +11,7 @@ if [ -r "${ENCRYPT_KEYFILE}" ]; then
   cp "${ENCRYPT_KEYFILE}" "${CHROOT_MNT}/etc/zfs/"
 fi
 
-debootstrap buster "${CHROOT_MNT}"
+./helpers/debootstrap.sh buster "${CHROOT_MNT}"
 
 cp /etc/hostid "${CHROOT_MNT}/etc/"
 cp /etc/resolv.conf "${CHROOT_MNT}/etc/"

--- a/testing/helpers/install-ubuntu.sh
+++ b/testing/helpers/install-ubuntu.sh
@@ -11,7 +11,7 @@ if [ -r "${ENCRYPT_KEYFILE}" ]; then
   cp "${ENCRYPT_KEYFILE}" "${CHROOT_MNT}/etc/zfs/"
 fi
 
-debootstrap focal "${CHROOT_MNT}" http://us.archive.ubuntu.com/ubuntu/
+./helpers/debootstrap.sh focal "${CHROOT_MNT}" http://us.archive.ubuntu.com/ubuntu/
 
 cp /etc/hostid "${CHROOT_MNT}/etc/"
 cp /etc/resolv.conf "${CHROOT_MNT}/etc/"

--- a/testing/setup.sh
+++ b/testing/setup.sh
@@ -28,6 +28,7 @@ Usage: $0 [options]
   -l  Disable features for legacy (zfs<2.0.0) support
   -p  Specify a pool name
   -r  Use a randomized pool name
+  -x  Use an existing pool image
   -o  Specify another distribution
       [ void, void-musl, arch, debian, ubuntu ]
 EOF
@@ -48,7 +49,7 @@ if [ $# -eq 0 ]; then
   exit
 fi
 
-while getopts "heycgdaiD:s:o:lp:r" opt; do
+while getopts "heycgdaiD:s:o:lp:rx" opt; do
   case "${opt}" in
     e)
       ENCRYPT=1
@@ -94,6 +95,9 @@ while getopts "heycgdaiD:s:o:lp:r" opt; do
       if [ -r "${dictfile}" ]; then
         RANDOM_NAME=1
       fi
+      ;;
+    x)
+      EXISTING_POOL=1
       ;;
     *)
       usage
@@ -168,7 +172,7 @@ else
   idx=0
 fi
 
-while true; do
+while [ -z "${EXISTING_POOL}" ]; do
   # Check that a file doesn't exist with this name, or that
   # a currently-imported pool doesn't have this name
   if [ ! -r "${TESTDIR}/${POOL_NAME}-pool.img" ] \
@@ -198,6 +202,7 @@ if ((IMAGE)); then
   sudo env \
     ENCRYPT="${ENCRYPT}" \
     LEGACY_POOL="${LEGACY_POOL}" \
+    EXISTING_POOL="${EXISTING_POOL}" \
     PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin" \
     "${IMAGE_SCRIPT}" "${TESTDIR}" "${SIZE}" "${DISTRO}" "${POOL_NAME}"
 fi

--- a/testing/setup.sh
+++ b/testing/setup.sh
@@ -215,7 +215,7 @@ if ((IMAGE)); then
     IMAGE_SCRIPT="./helpers/image.sh"
   fi
 
-  sudo env \
+  sudo unshare --fork --pid --mount env \
     ENCRYPT="${ENCRYPT}" \
     LEGACY_POOL="${LEGACY_POOL}" \
     EXISTING_POOL="${EXISTING_POOL}" \


### PR DESCRIPTION
It is now easy to combine multiple distributions into a single test image:
```bash
./setup.sh -a
./setup.sh -i -x -o arch
./setup.sh -i -x -o debian
```

I haven't tested the encryption path yet, but the basic setup seems to work. I'm open to alternative implementations that are a bit cleaner.