### PR TITLE
Use rootfs tarball and preinstall ZBM in Void testbeds

### DIFF
--- a/testing/helpers/install-void.sh
+++ b/testing/helpers/install-void.sh
@@ -1,57 +1,78 @@
 #!/bin/bash
 # vim: softtabstop=2 shiftwidth=2 expandtab
 
+cleanup() {
+  if [ -n "${VOIDROOT}" ]; then
+    rm -rf "${VOIDROOT}"
+    unset VOIDROOT
+  fi
+
+  exit
+}
+
 if [ -z "${CHROOT_MNT}" ] || [ ! -d "${CHROOT_MNT}" ]; then
   echo "ERROR: chroot mountpoint must be specified and must exist"
   exit 1
 fi
 
-if echo "$0" | grep -q "musl"; then
-  MUSL="yes"
-fi
-
 XBPS_ARCH="$(uname -m)"
 
-case "${XBPS_ARCH}" in
-  ppc64le)
-    URL="https://mirrors.servercentral.com/void-ppc/current"
-    ;;
-  x86_64)
-    URL="https://mirrors.servercentral.com/voidlinux/current"
-    ;;
-  *)
-    echo "ERROR: unsupported architecture"
-    exit 1
-    ;;
-esac
-
-if [ -n "${MUSL}" ]; then
-  URL="${URL}/musl"
+if [[ "$0" =~ "musl" ]]; then
   XBPS_ARCH="${XBPS_ARCH}-musl"
+  REPO_SUFFIX="/musl"
 fi
 
 export XBPS_ARCH
 
-# https://github.com/project-trident/trident-installer/blob/master/src-sh/void-install-zfs.sh#L541
-mkdir -p "${CHROOT_MNT}/var/db/xbps/keys"
-cp /var/db/xbps/keys/*.plist "${CHROOT_MNT}/var/db/xbps/keys/."
+# Default repo for all official architectures
+REPO="https://mirrors.servercentral.com/voidlinux/current"
 
-mkdir -p "${CHROOT_MNT}/etc/xbps.d"
-cp /etc/xbps.d/*.conf "${CHROOT_MNT}/etc/xbps.d/."
+# Custom overrrides for specific archictures
+case "${XBPS_ARCH}" in
+  aarch64*) REPO_SUFFIX="/aarch64" ;;
+  ppc*) REPO="https://mirrors.servercentral.com/void-ppc/current" ;;
+  *) ;;
+esac
 
-if [ -r "${ENCRYPT_KEYFILE}" ]; then
-  mkdir -p "${CHROOT_MNT}/etc/zfs"
-  cp "${ENCRYPT_KEYFILE}" "${CHROOT_MNT}/etc/zfs/"
+LIVE="${REPO/current/live}/current"
+REPO="${REPO}${REPO_SUFFIX}"
+
+PATTERN="void-${XBPS_ARCH}-ROOTFS-[-_.A-Za-z0-9]\+\.tar\.xz"
+IMAGE="$( curl -L "${LIVE}" | \
+  grep -o "${PATTERN}" | sort -Vr | head -n 1 | tr -d '\n' )"
+
+if [ -z "${IMAGE}" ]; then
+  echo "ERROR: cannot identify Void ROOTFS image"
+  exit 1
 fi
 
-# /etc/runit/core-services/03-console-setup.sh depends on loadkeys from kbd
-# /etc/runit/core-services/05-misc.sh depends on ip from iproute2
-xbps-install -y -M -r "${CHROOT_MNT}" -C "${CHROOT_MNT}/etc/xbps.d" \
-  --repository="${URL}" base-minimal dracut ncurses-base kbd iproute2 dhclient openssh
+if ! VOIDROOT="$( mktemp -d )"; then
+  echo "ERROR: cannot make temporary directory for Void installation"
+  exit 1
+else
+  export VOIDROOT
+fi
+
+trap cleanup EXIT INT TERM
+
+if ! curl -L -o "${VOIDROOT}/${IMAGE}" "${LIVE}/${IMAGE}"; then
+  echo "ERROR: failed to fetch Void ROOTFS image"
+  echo "Check URL at ${LIVE}/${IMAGE}"
+  exit 1
+fi
+
+tar xf "${VOIDROOT}/${IMAGE}" -C "${CHROOT_MNT}"
+
+mkdir -p "${CHROOT_MNT}/etc/xbps.d"
 
 cp /etc/hostid "${CHROOT_MNT}/etc/"
 cp /etc/resolv.conf "${CHROOT_MNT}/etc/"
 cp /etc/rc.conf "${CHROOT_MNT}/etc/"
 
-mkdir -p "${CHROOT_MNT}/etc/xbps.d"
-echo "repository=${URL}" > "${CHROOT_MNT}/etc/xbps.d/00-repository-main.conf"
+echo "repository=${REPO}" > "${CHROOT_MNT}/etc/xbps.d/00-repository-main.conf"
+
+# Add ZFSBootMenu population script
+if [ -x ./helpers/zbm-populate.sh ]; then
+  mkdir -p "${CHROOT_MNT}/root"
+  cp ./helpers/zbm-populate.sh "${CHROOT_MNT}/root/"
+fi

--- a/testing/helpers/zbm-populate.sh
+++ b/testing/helpers/zbm-populate.sh
@@ -1,17 +1,23 @@
 #!/bin/bash
 
-# Pre-populate ZFSBootMenu and all Perl dependencies
+# Pre-populate ZFSBootMenu
 ( cd / && git clone https://github.com/zbm-dev/zfsbootmenu.git )
-( cd /zfsbootmenu && cpanm --notest --installdeps . && make install )
+( cd /zfsbootmenu && make install )
+
+# Install perl dependencies if necessary
+if [ -z "${SKIP_PERL}" ]; then
+  ( cd /zfsbootmenu && cpanm --notest --installdeps . )
+fi
 
 # Adjust the configuration for convenient builds
 if [ -f /etc/zfsbootmenu/config.yaml ]; then
   sed -e 's/Versions:.*/Versions: false/' \
-	  -e 's/ManageImages:.*/ManageImages: true/' \
-	  -e 's@ImageDir:.*@ImageDir: /zfsbootmenu/build@' \
-	  -e '/BootMountPoint:/d' -i /etc/zfsbootmenu/config.yaml
+      -e 's/ManageImages:.*/ManageImages: true/' \
+      -e 's@ImageDir:.*@ImageDir: /zfsbootmenu/build@' \
+      -e '/BootMountPoint:/d' -i /etc/zfsbootmenu/config.yaml
 fi
 
+# Replace key parts with symlinks to reflect source changes
 rm -f /usr/bin/generate-zbm
 ln -s /zfsbootmenu/bin/generate-zbm /usr/bin/
 


### PR DESCRIPTION
In keeping with earlier changes to Arch, Debian and Ubuntu, the Void images should be installable without any specific packaging tools available on the host. Using a rootfs tarball allows us to populate Void testbeds from any host. I've also disabled architecture limitations since the only XBPS magic happens within a chroot now, and if the host can chroot into the target, everything should work fine.