### PR TITLE
Create SSH includes for running VMs

### DIFF
--- a/testing/run.sh
+++ b/testing/run.sh
@@ -197,6 +197,9 @@ Host ${TESTDIR}
   HostName localhost
   Port ${SSH_PORT}
   User root
+  UserKnownHostsFile /dev/null
+  StrictHostKeyChecking no
+  LogLevel error
 EOF
 
   chmod 0600 "${SSH_CONF_DIR}/${TESTDIR}"

--- a/testing/run.sh
+++ b/testing/run.sh
@@ -188,9 +188,13 @@ while true; do
   fi
 done
 
-if ((SSH_INCLUDE)) ; then
-  SSH_CONF_DIR="${HOME}/.ssh/zfsbootmenu.d"
+SSH_CONF_DIR="${HOME}/.ssh/zfsbootmenu.d"
+[ -d "${SSH_CONF_DIR}" ] && SSH_INCLUDE=1
+
+if ((SSH_INCLUDE)); then
   [ -d "${SSH_CONF_DIR}" ] || mkdir "${SSH_CONF_DIR}" && chmod 700 "${SSH_CONF_DIR}"
+
+  echo "Creating host records in ${SSH_CONF_DIR}"
 
   cat << EOF > "${SSH_CONF_DIR}/${TESTDIR}"
 Host ${TESTDIR}


### PR DESCRIPTION
SSH'ing into a running VM was greatly improved with key additions to each BE. This should help even more by doing the following:

* Creates an SSH config file for the running VM that records the test name and configured SSH port forward
* Sets the remote username to `root`
* Host key checks are disabled, and the host key is no longer stored in `known_hosts`

With this in place, you can `ssh test.void` and have an immediate shell in the running test VM with out needing to accept any host keys, etc.