### PR TITLE
Remove dracut-ism, replace with an internal check

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-countdown.sh
+++ b/90zfsbootmenu/zfsbootmenu-countdown.sh
@@ -7,6 +7,10 @@ trap '' SIGINT
 # shellcheck disable=SC1091
 [ -r /lib/zfsbootmenu-lib.sh ] && source /lib/zfsbootmenu-lib.sh
 
+
+# Make sure /dev/zfs exists, otherwise drop to a recovery shell
+[ -e /dev/zfs ] || emergency_shell "/dev/zfs missing, check that kernel modules are loaded"
+
 if [ -z "${BASE}" ]; then
   export BASE="/zfsbootmenu"
 fi

--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -178,12 +178,7 @@ case "${root}" in
     ;;
 esac
 
-# Make sure Dracut is happy that we have a root and will wait for ZFS
-# modules to settle before mounting.
+# Make sure Dracut is happy that we have a root
 if [ ${wait_for_zfs} -eq 1 ]; then
   ln -s /dev/null /dev/root 2>/dev/null
-  # shellcheck disable=SC2154
-  initqueuedir="${hookdir}/initqueue/finished"
-  [ -d "${initqueuedir}" ] || initqueuedir="${hookdir}/initqueue-finished"
-  echo '[ -e /dev/zfs ]' > "${initqueuedir}/zfs.sh"
 fi


### PR DESCRIPTION
/lib/dracut/hooks/initqueue/finished is not created when rd.hostonly=0
is set. Additionally, if for some reason /dev/zfs is not present, a
dracut initqueue timeout would happen and you'd drop down to a limited
dracut shell. If instead we loop and check for /dev/zfs, we can fail to
a nicer recovery shell if it is absent.

https://pastebin.stratumzero.date/u/p/67d7b4adb6/stream