### PR TITLE
Set a hostname in ZBM, check if spl.spl_hostid matches /etc/hostid

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-exec.sh
+++ b/90zfsbootmenu/zfsbootmenu-exec.sh
@@ -35,6 +35,9 @@ EOF
 
 getcmdline > "${BASE}/zbm.cmdline"
 
+# Set a non-empty hostname so we show up in zpool history correctly
+echo "ZFSBootMenu" > /proc/sys/kernel/hostname
+
 modprobe zfs 2>/dev/null
 udevadm settle
 

--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -15,6 +15,7 @@ use File::stat;
 use File::Path qw(make_path remove_tree);
 use File::Glob qw(:globally :nocase);
 use Sort::Versions;
+use Config;
 
 use Pod::Usage qw(pod2usage);
 
@@ -293,17 +294,21 @@ printf "Creating ZFSBootMenu %s from kernel %s\n", $runConf{version}, $runConf{k
 my $spl_hostid = "/sys/module/spl/parameters/spl_hostid";
 if ( -f $spl_hostid ) {
   open PROC, $spl_hostid;
-  $runConf{hostid}{module} = lc(sprintf("%X", <PROC>));
+  $runConf{hostid}{module} = sprintf("%08x", <PROC>);
   close PROC;
+}
 
-  my @hostid  = execute(qw(hostid));
-  my $status = pop(@hostid);
-  if ( $status eq 0 and scalar @hostid ) {
-    chomp($runConf{hostid}{command} = pop(@hostid));
-  }
+my $etc_hostid = "/etc/hostid";
+if ( $runConf{hostid}{module} ne 0 and -f $etc_hostid ) {
+  open SPL, '<:raw', $etc_hostid;
+  read SPL, my $hostid, 4;
+  close SPL;
 
-  if ($runConf{hostid}{module} ne $runConf{hostid}{command}) {
-    print "SPL ($runConf{hostid}{module}) and system ($runConf{hostid}{command}) hostids do not match!\n";
+  # There must be a better way to do this
+  $runConf{hostid}{etc} = reverse(unpack('h8', $hostid));
+
+  if ($runConf{hostid}{module} ne $runConf{hostid}{etc}) {
+    print "SPL ($runConf{hostid}{module}) and system ($runConf{hostid}{etc}) hostids do not match!\n";
   }
 }
 

--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -290,6 +290,23 @@ unless ( nonempty $runConf{kernel_prefix} and nonempty $runConf{kernel_version} 
 
 printf "Creating ZFSBootMenu %s from kernel %s\n", $runConf{version}, $runConf{kernel};
 
+my $spl_hostid = "/sys/module/spl/parameters/spl_hostid";
+if ( -f $spl_hostid ) {
+  open PROC, $spl_hostid;
+  $runConf{hostid}{module} = lc(sprintf("%X", <PROC>));
+  close PROC;
+
+  my @hostid  = execute(qw(hostid));
+  my $status = pop(@hostid);
+  if ( $status eq 0 and scalar @hostid ) {
+    chomp($runConf{hostid}{command} = pop(@hostid));
+  }
+
+  if ($runConf{hostid}{module} ne $runConf{hostid}{command}) {
+    print "SPL ($runConf{hostid}{module}) and system ($runConf{hostid}{command}) hostids do not match!\n";
+  }
+}
+
 # Create a unified kernel/initramfs/command line EFI file
 if ( enabled $config{EFI} ) {
   my $unified_efi = createInitramfs( $tempdir, $runConf{kernel_version}, $runConf{kernel} );

--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -15,7 +15,6 @@ use File::stat;
 use File::Path qw(make_path remove_tree);
 use File::Glob qw(:globally :nocase);
 use Sort::Versions;
-use Config;
 
 use Pod::Usage qw(pod2usage);
 
@@ -304,8 +303,13 @@ if ( $runConf{hostid}{module} ne 0 and -f $etc_hostid ) {
   read SPL, my $hostid, 4;
   close SPL;
 
-  # There must be a better way to do this
-  $runConf{hostid}{etc} = reverse(unpack('h8', $hostid));
+  if ( unpack( 'c', pack( 's', 1 ) ) eq 1 ) {
+    # little endian
+    $runConf{hostid}{etc} = sprintf("%08x", unpack('L<4', $hostid));
+  } else {
+    # big endian
+    $runConf{hostid}{etc} = sprintf("%08x", unpack('L>4', $hostid));
+  }
 
   if ($runConf{hostid}{module} ne $runConf{hostid}{etc}) {
     print "SPL ($runConf{hostid}{module}) and system ($runConf{hostid}{etc}) hostids do not match!\n";


### PR DESCRIPTION
* Set a hostname in ZBM, so that when a pool is imported read/write, `(ZFSBootMenu)` is recorded instead of `(none)`

* In generate-zbm, warn if  `/sys/module/spl/parameters/spl_hostid`and the output of `hostid` do not match. This needs additional logic, since very few people set their hostid via `spl.spl_hostid`, ZFS's brain-dead logic of setting the sysfs entry to 0 by default makes it very challenging to detect what the source of truth actually is. Thoughts?