### PR TITLE
Store options from KCL in a file for easy sourcing

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-countdown.sh
+++ b/90zfsbootmenu/zfsbootmenu-countdown.sh
@@ -16,6 +16,13 @@ fi
 
 mkdir -p "${BASE}"
 
+if [ -r "${BASE}/environment" ]; then
+  # shellcheck disable=SC1090
+  source "${BASE}/environment"
+else
+  zwarn "failed to source ZBM environment"
+fi
+
 # Write out a default or overridden hostid
 if [ -n "${spl_hostid}" ] ; then
   zinfo "writing /etc/hostid from command line: ${spl_hostid}"

--- a/90zfsbootmenu/zfsbootmenu-exec.sh
+++ b/90zfsbootmenu/zfsbootmenu-exec.sh
@@ -1,15 +1,6 @@
 #!/bin/bash
 # vim: softtabstop=2 shiftwidth=2 expandtab
 
-export endian
-export spl_hostid
-export import_policy
-export menu_timeout
-export loglevel
-export root
-export zbm_sort
-export zbm_set_hostid
-
 # Disable all kernel messages to the console
 echo 0 > /proc/sys/kernel/printk
 
@@ -29,6 +20,18 @@ echo "Loading ZFSBootMenu ..."
 
 export BASE="/zfsbootmenu"
 mkdir -p "${BASE}"
+
+# shellcheck disable=SC2154
+cat > "${BASE}/environment" <<EOF
+export endian="${endian}"
+export spl_hostid="${spl_hostid}"
+export import_policy="${import_policy}"
+export menu_timeout="${menu_timeout}"
+export loglevel="${loglevel}"
+export root="${root}"
+export zbm_sort="${zbm_sort}"
+export zbm_set_hostid="${zbm_set_hostid}"
+EOF
 
 getcmdline > "${BASE}/zbm.cmdline"
 

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -12,6 +12,13 @@ if [ -z "${BASE}" ]; then
   export BASE="/zfsbootmenu"
 fi
 
+if [ -r "${BASE}/environment" ]; then
+  # shellcheck disable=SC1090
+  source "${BASE}/environment"
+else
+  zwarn "failed to source ZBM environment"
+fi
+
 while [ ! -e "${BASE}/initialized" ]; do
   if ! delay=5 prompt="Press [ESC] to cancel" timed_prompt "Waiting for ZFSBootMenu initialization"; then
     zdebug "exited while waiting for initialization"
@@ -107,9 +114,9 @@ while true; do
   if [ "${BE_SELECTED}" -eq 0 ]; then
     # Populate the BE list, load any keys as necessary
     # If no BEs were found, remove the empty environment file
-    populate_be_list "${BASE}/env" || rm -f "${BASE}/env"
+    populate_be_list "${BASE}/bootenvs" || rm -f "${BASE}/bootenvs"
 
-    bootenv="$( draw_be "${BASE}/env" )"
+    bootenv="$( draw_be "${BASE}/bootenvs" )"
     ret=$?
 
     if [ "${ret}" -eq 130 ]; then


### PR DESCRIPTION
`zfsbootmenu-parse-commandline.sh` defines several configuration variables based on KCL arguments; `zfsbootmenu-exec.sh` originally exported those to the environment for use by `zfsbootmenu-countdown.sh` and `zfsbootmenu.sh`. This works fine if `zfsbootmenu.sh` is only ever run in a local session.

When connecting via SSH and launching `zfsbootmenu` from the shell, these configuration variables are not accessible. The simple solution is to write the configuration into a file that can be sourced by both `zfsbootmenu-countdown.sh` and `zfsbootmenu.sh` to populate their environments regardless of the way they are called.

The boot-environment list has been renamed from `env` to `bootenvs` to avoid confusion with the `environment` file.