### PR TITLE
Make sure wrapped log lines have a ZBM/tracing prefix

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -9,7 +9,7 @@
 # returns: nothing
 
 zlog() {
-  local _script _func
+  local _script _func prefix offset join
   [ -z "${1}" ] && return
   [ -z "${2}" ] && return
 
@@ -25,12 +25,22 @@ zlog() {
 
   # Only add script/function tracing to debug messages
   if [ "${1}" -eq 7 ] && [ -n "${HAS_NOESCAPE}" ] ; then
-    echo -e "<${1}>ZBM:\033[0;33m${_script}[$$]\033[0;31m:${_func}()\033[0m: ${2}" | fold -s -w "${WIDTH}" > /dev/kmsg
+    prefix="<${1}>ZBM:\033[0;33m${_script}[$$]\033[0;31m:${_func}()\033[0m"
   elif [ "${1}" -eq 7 ]; then
-    echo -e "<${1}>ZBM:${_script}[$$]:${_func}(): ${2}" | fold -s -w "${WIDTH}" > /dev/kmsg
+    prefix="<${1}>ZBM:${_script}[$$]:${_func}()"
   else
-    echo -e "<${1}>ZFSBootMenu: ${2}" | fold -s -w "${WIDTH}" > /dev/kmsg
+    prefix="<${1}>ZFSBootMenu"
   fi
+
+  # account for the fzf gutter and kernel timestamp
+  offset="${#prefix}"
+  WIDTH=$(( WIDTH - ( offset - 15 ) ))
+
+  join=': '
+  while read -r line; do
+    echo -e "${prefix}${join}${line}" > /dev/kmsg
+    join='+ '
+  done <<<"$( echo "${2}" | fold -s -w "${WIDTH}" )"
 }
 
 # arg1: log line

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -9,7 +9,7 @@
 # returns: nothing
 
 zlog() {
-  local _script _func prefix offset join
+  local _script _func prefix offset join _WIDTH
   [ -z "${1}" ] && return
   [ -z "${2}" ] && return
 
@@ -21,8 +21,6 @@ zlog() {
   _script="$( basename $0 )"
   _func="${FUNCNAME[2]}"
 
-  WIDTH="$( tput cols )"
-
   # Only add script/function tracing to debug messages
   if [ "${1}" -eq 7 ] && [ -n "${HAS_NOESCAPE}" ] ; then
     prefix="<${1}>ZBM:\033[0;33m${_script}[$$]\033[0;31m:${_func}()\033[0m"
@@ -32,15 +30,16 @@ zlog() {
     prefix="<${1}>ZFSBootMenu"
   fi
 
-  # account for the fzf gutter and kernel timestamp
   offset="${#prefix}"
-  WIDTH=$(( WIDTH - ( offset - 15 ) ))
+
+  # account for the fzf gutter and kernel timestamp
+  _WIDTH=$(( $( tput cols ) - ( offset - 15 ) ))
 
   join=': '
   while read -r line; do
     echo -e "${prefix}${join}${line}" > /dev/kmsg
     join='+   '
-  done <<<"$( echo "${2}" | fold -s -w "${WIDTH}" )"
+  done <<<"$( echo "${2}" | fold -s -w "${_WIDTH}" )"
 }
 
 # arg1: log line

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -39,7 +39,7 @@ zlog() {
   join=': '
   while read -r line; do
     echo -e "${prefix}${join}${line}" > /dev/kmsg
-    join='+ '
+    join='+   '
   done <<<"$( echo "${2}" | fold -s -w "${WIDTH}" )"
 }
 


### PR DESCRIPTION
Long messages, particularly debug messages, were naively wrapped on the
screen width boundary. While this worked, all tracing information was
lost in the wrapped lines.

A log line prefix (based on the message level and dmesg capabilities) is
created and then prepended to all log lines after they've been wrapped.

Wrapping uses the screen width minus the prefix length minus the kernel
timestamp and fzf gutter.

Wrapped lines have '+   ' after the prefix to indicate that they're wrapped.
Non-wrapped lines have ': ' after the prefix.