### PR TITLE
Preserve selected item

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -140,6 +140,7 @@ install() {
   inst_simple "${moddir}/zfsbootmenu-preview.sh" "/libexec/zfsbootmenu-preview" || _ret=$?
   inst_simple "${moddir}/zfsbootmenu-input.sh" "/libexec/zfsbootmenu-input" || _ret=$?
   inst_simple "${moddir}/zfsbootmenu-help.sh" "/libexec/zfsbootmenu-help" || _ret=$?
+  inst_simple "${moddir}/zfsbootmenu-diff.sh" "/libexec/zfsbootmenu-diff" || _ret=$?
   inst_simple "${moddir}/zfs-chroot.sh" "/bin/zfs-chroot" || _ret=$?
   inst_simple "${moddir}/zfsbootmenu.sh" "/bin/zfsbootmenu" || _ret=$?
   inst_simple "${moddir}/zlogtail.sh" "/bin/zlogtail" || _ret=$?

--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -140,7 +140,7 @@ install() {
   inst_simple "${moddir}/zfsbootmenu-preview.sh" "/libexec/zfsbootmenu-preview" || _ret=$?
   inst_simple "${moddir}/zfsbootmenu-input.sh" "/libexec/zfsbootmenu-input" || _ret=$?
   inst_simple "${moddir}/zfsbootmenu-help.sh" "/libexec/zfsbootmenu-help" || _ret=$?
-  inst_simple "${moddir}/zfsbootmenu-diff.sh" "/libexec/zfsbootmenu-diff" || _ret=$?
+  inst_simple "${moddir}/zfsbootmenu-func-wrapper.sh" "/libexec/zfunc" || _ret=$?
   inst_simple "${moddir}/zfs-chroot.sh" "/bin/zfs-chroot" || _ret=$?
   inst_simple "${moddir}/zfsbootmenu.sh" "/bin/zfsbootmenu" || _ret=$?
   inst_simple "${moddir}/zlogtail.sh" "/bin/zlogtail" || _ret=$?

--- a/90zfsbootmenu/zfsbootmenu-diff.sh
+++ b/90zfsbootmenu/zfsbootmenu-diff.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# vim: softtabstop=2 shiftwidth=2 expandtab
+
+# shellcheck disable=SC1091
+[ -r /lib/zfsbootmenu-lib.sh ] && source /lib/zfsbootmenu-lib.sh
+
+zdebug "argv[1]: ${1}"
+
+draw_diff "${1}"

--- a/90zfsbootmenu/zfsbootmenu-func-wrapper.sh
+++ b/90zfsbootmenu/zfsbootmenu-func-wrapper.sh
@@ -4,6 +4,11 @@
 # shellcheck disable=SC1091
 [ -r /lib/zfsbootmenu-lib.sh ] && source /lib/zfsbootmenu-lib.sh
 
-zdebug "argv[1]: ${1}"
+# First argument is the function name
+# the rest are positional params
+func="${1}"
+shift
 
-draw_diff "${1}"
+zdebug "Calling ${1} with $*"
+
+$func "$@"

--- a/90zfsbootmenu/zfsbootmenu-func-wrapper.sh
+++ b/90zfsbootmenu/zfsbootmenu-func-wrapper.sh
@@ -9,6 +9,6 @@
 func="${1}"
 shift
 
-zdebug "Calling ${1} with $*"
+zdebug "Calling ${func} with $*"
 
 $func "$@"

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -552,16 +552,19 @@ draw_snapshots() {
     "[CTRL+I] interactive chroot" "[CTRL+D] show diff" "" \
     "[CTRL+L] view logs" "[CTRL+H] help" )"
 
-  expects="--expect=alt-x,alt-c,alt-i,alt-o"
+  expects="--expect=alt-x,alt-c,alt-o"
 
   # shellcheck disable=SC2086,SC2090
   if ! selected="$( zfs list -t snapshot -H -o name "${benv}" -S "${sort_key}" |
       HELP_SECTION=SNAPSHOT ${FUZZYSEL} \
         --prompt "Snapshot > " --header="${header}" --tac \
         ${expects} ${expects//alt-/ctrl-} ${expects//alt-/ctrl-alt-} \
-        --bind='alt-d:execute[ /libexec/zfsbootmenu-diff {} ]' \
-        --bind='ctrl-d:execute[ /libexec/zfsbootmenu-diff {} ]' \
-        --bind='ctrl-alt-d:execute[ /libexec/zfsbootmenu-diff {} ]' \
+        --bind='alt-d:execute[ /libexec/zfunc draw_diff {} ]' \
+        --bind='ctrl-d:execute[ /libexec/zfunc draw_diff {} ]' \
+        --bind='ctrl-alt-d:execute[ /libexec/zfunc draw_diff {} ]' \
+        --bind='alt-i:execute[ /libexec/zfunc zfs_chroot {} ]' \
+        --bind='ctrl-i:execute[ /libexec/zfunc zfs_chroot {} ]' \
+        --bind='ctrl-alt-i:execute[ /libexec/zfunc zfs_chroot {} ]' \
         --preview="/libexec/zfsbootmenu-preview ${benv} ${BOOTFS}" \
         --preview-window="up:${PREVIEW_HEIGHT}" )"; then
     return 1

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -552,12 +552,16 @@ draw_snapshots() {
     "[CTRL+I] interactive chroot" "[CTRL+D] show diff" "" \
     "[CTRL+L] view logs" "[CTRL+H] help" )"
 
-  expects="--expect=alt-x,alt-c,alt-d,alt-i,alt-o"
+  expects="--expect=alt-x,alt-c,alt-i,alt-o"
 
+  # shellcheck disable=SC2086,SC2090
   if ! selected="$( zfs list -t snapshot -H -o name "${benv}" -S "${sort_key}" |
       HELP_SECTION=SNAPSHOT ${FUZZYSEL} \
         --prompt "Snapshot > " --header="${header}" --tac \
         ${expects} ${expects//alt-/ctrl-} ${expects//alt-/ctrl-alt-} \
+        --bind='alt-d:execute[ /libexec/zfsbootmenu-diff {} ]' \
+        --bind='ctrl-d:execute[ /libexec/zfsbootmenu-diff {} ]' \
+        --bind='ctrl-alt-d:execute[ /libexec/zfsbootmenu-diff {} ]' \
         --preview="/libexec/zfsbootmenu-preview ${benv} ${BOOTFS}" \
         --preview-window="up:${PREVIEW_HEIGHT}" )"; then
     return 1

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -472,10 +472,13 @@ draw_be() {
     "[CTRL+E] edit kcl" "[CTRL+I] interactive chroot" "[CTRL+R] recovery shell" "" \
     "[CTRL+L] view logs" " " "[CTRL+H] help" )"
 
-  expects="--expect=alt-e,alt-k,alt-d,alt-s,alt-c,alt-r,alt-p,alt-w,alt-i,alt-o"
+  expects="--expect=alt-e,alt-k,alt-d,alt-s,alt-c,alt-r,alt-p,alt-w,alt-o"
 
   if ! selected="$( ${FUZZYSEL} -0 --prompt "BE > " \
       ${expects} ${expects//alt-/ctrl-} ${expects//alt-/ctrl-alt-} \
+      --bind='alt-i:execute[ /libexec/zfunc zfs_chroot {} ]' \
+      --bind='ctrl-i:execute[ /libexec/zfunc zfs_chroot {} ]' \
+      --bind='ctrl-alt-i:execute[ /libexec/zfunc zfs_chroot {} ]' \
       --header="${header}" --preview-window="up:${PREVIEW_HEIGHT}" \
       --preview="/libexec/zfsbootmenu-preview {} ${BOOTFS}" < "${env}" )"; then
     return 1

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -279,7 +279,7 @@ while true; do
       else
         set_rw_pool "${pool}"
       fi
-    
+
       # Clear the screen ahead of a potential password prompt from populate_be_list
       tput clear
       tput cnorm
@@ -303,9 +303,6 @@ while true; do
         echo "${cmdline}" > "${BASE}/cmdline"
       fi
       ;;
-    "mod-i")
-      zfs_chroot "${selected_be}"
-    ;;
     "mod-o")
       change_sort
     ;;

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -200,12 +200,6 @@ while true; do
       tput cnorm
 
       case "${subkey}" in
-        "mod-d")
-          draw_diff "${selected_snap}"
-          # Return to snapshot submenu, don't redraw main menu
-          BE_SELECTED=1
-          continue
-        ;;
         "mod-i")
           zfs_chroot "${selected_snap}"
           BE_SELECTED=1

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -200,11 +200,6 @@ while true; do
       tput cnorm
 
       case "${subkey}" in
-        "mod-i")
-          zfs_chroot "${selected_snap}"
-          BE_SELECTED=1
-          continue
-        ;;
         "mod-o")
           change_sort
           BE_SELECTED=1


### PR DESCRIPTION
When entering a chroot or the diff browser on the snapshot selection screen, preserve the snapshot selection when exiting back out of that action. 

This is accomplished by creating a simple shell script that accepts two or more arguments - the first is the name of the zfsbotmenu-lib.sh function, the rest of the arguments are passed on to that function. This shell script is then executed via `--bind` actions. When the script exits, the original fzf snapshot browser is still running, with the snapshot still selected.

I opted to write out the explicit list of binds for the chroot and diff actions; I wasn't able to get the quoting to work correctly when trying to represent the entire string as a variable for key regexps. 