### PR TITLE
Use fzf's execute[] function to render the zfs diff

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -140,6 +140,7 @@ install() {
   inst_simple "${moddir}/zfsbootmenu-preview.sh" "/libexec/zfsbootmenu-preview" || _ret=$?
   inst_simple "${moddir}/zfsbootmenu-input.sh" "/libexec/zfsbootmenu-input" || _ret=$?
   inst_simple "${moddir}/zfsbootmenu-help.sh" "/libexec/zfsbootmenu-help" || _ret=$?
+  inst_simple "${moddir}/zfsbootmenu-func-wrapper.sh" "/libexec/zfunc" || _ret=$?
   inst_simple "${moddir}/zfs-chroot.sh" "/bin/zfs-chroot" || _ret=$?
   inst_simple "${moddir}/zfsbootmenu.sh" "/bin/zfsbootmenu" || _ret=$?
   inst_simple "${moddir}/zlogtail.sh" "/bin/zlogtail" || _ret=$?

--- a/90zfsbootmenu/zfsbootmenu-func-wrapper.sh
+++ b/90zfsbootmenu/zfsbootmenu-func-wrapper.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# vim: softtabstop=2 shiftwidth=2 expandtab
+
+# shellcheck disable=SC1091
+[ -r /lib/zfsbootmenu-lib.sh ] && source /lib/zfsbootmenu-lib.sh
+
+# First argument is the function name
+# the rest are positional params
+func="${1}"
+shift
+
+zdebug "Calling ${func} with $*"
+
+$func "$@"

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -552,12 +552,15 @@ draw_snapshots() {
     "[CTRL+I] interactive chroot" "[CTRL+D] show diff" "" \
     "[CTRL+L] view logs" "[CTRL+H] help" )"
 
-  expects="--expect=alt-x,alt-c,alt-d,alt-i,alt-o"
+  expects="--expect=alt-x,alt-c,alt-i,alt-o"
 
   if ! selected="$( zfs list -t snapshot -H -o name "${benv}" -S "${sort_key}" |
       HELP_SECTION=SNAPSHOT ${FUZZYSEL} \
         --prompt "Snapshot > " --header="${header}" --tac \
         ${expects} ${expects//alt-/ctrl-} ${expects//alt-/ctrl-alt-} \
+        --bind='alt-d:execute[ /libexec/zfunc draw_diff {} ]' \
+        --bind='ctrl-d:execute[ /libexec/zfunc draw_diff {} ]' \
+        --bind='ctrl-alt-d:execute[ /libexec/zfunc draw_diff {} ]' \
         --preview="/libexec/zfsbootmenu-preview ${benv} ${BOOTFS}" \
         --preview-window="up:${PREVIEW_HEIGHT}" )"; then
     return 1

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -207,12 +207,6 @@ while true; do
       tput cnorm
 
       case "${subkey}" in
-        "mod-d")
-          draw_diff "${selected_snap}"
-          # Return to snapshot submenu, don't redraw main menu
-          BE_SELECTED=1
-          continue
-        ;;
         "mod-i")
           zfs_chroot "${selected_snap}"
           BE_SELECTED=1


### PR DESCRIPTION
Instead of exiting the `fzf` snapshot browser, bind a key combination to the `execute[]` function in `fzf`, allowing you to keep your place in the list after viewing a diff.  zfs-chroot does not correctly function here, because it loses access to the backing TTY. Bash/dash will not write command output to the fzf alternate screen. Discovering the tty is easy for local consoles (control_term from -exec), but is much more difficult for connections over SSH.