### PR TITLE
Create and use /etc/profile everywhere

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -307,9 +307,9 @@ EOF
 
   # Setup a default environment for all login shells
   cat << EOF >> "${initdir}/etc/profile"
+[ -f /lib/zfsbootmenu-lib.sh ] && source /lib/zfsbootmenu-lib.sh
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 export TERM=vt220
-[ -f /lib/zfsbootmenu-lib.sh ] && source /lib/zfsbootmenu-lib.sh
 export PS1="\033[0;33mzfsbootmenu\033[0m \w > "
 EOF
 }

--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -304,4 +304,12 @@ EOF
   if [ -n "${release_build}" ]; then
     echo "rd.hostonly=0" > "${initdir}/etc/cmdline.d/hostonly.conf"
   fi
+
+  # Setup a default environment for all login shells
+  cat << EOF >> "${initdir}/etc/profile"
+export PATH=/usr/sbin:/usr/bin:/sbin:/bin
+export TERM=vt220
+[ -f /lib/zfsbootmenu-lib.sh ] && source /lib/zfsbootmenu-lib.sh
+export PS1="\033[0;33mzfsbootmenu\033[0m \w > "
+EOF
 }

--- a/90zfsbootmenu/zfsbootmenu-countdown.sh
+++ b/90zfsbootmenu/zfsbootmenu-countdown.sh
@@ -9,8 +9,14 @@ if [ -r "/etc/profile" ]; then
   source /etc/profile
 else
   # shellcheck disable=SC1091
-  [ -r /lib/zfsbootmenu-lib.sh ] && source /lib/zfsbootmenu-lib.sh
+  source /lib/zfsbootmenu-lib.sh
   zwarn "failed to source ZBM environment"
+fi
+
+# Prove that /lib/zfsbootmenu-lib.sh was sourced, or hard fail
+if ! is_lib_sourced > /dev/null 2>&1 ; then
+  echo -e "\033[0;31mWARNING: /lib/zfsbootmenu-lib.sh was not sourced; unable to proceed\033[0m"
+  exec /bin/bash
 fi
 
 # Make sure /dev/zfs exists, otherwise drop to a recovery shell

--- a/90zfsbootmenu/zfsbootmenu-countdown.sh
+++ b/90zfsbootmenu/zfsbootmenu-countdown.sh
@@ -4,8 +4,14 @@
 # disable ctrl-c (SIGINT)
 trap '' SIGINT
 
-# shellcheck disable=SC1091
-[ -r /lib/zfsbootmenu-lib.sh ] && source /lib/zfsbootmenu-lib.sh
+if [ -r "/etc/profile" ]; then
+  # shellcheck disable=SC1091
+  source /etc/profile
+else
+  # shellcheck disable=SC1091
+  [ -r /lib/zfsbootmenu-lib.sh ] && source /lib/zfsbootmenu-lib.sh
+  zwarn "failed to source ZBM environment"
+fi
 
 # Make sure /dev/zfs exists, otherwise drop to a recovery shell
 [ -e /dev/zfs ] || emergency_shell "/dev/zfs missing, check that kernel modules are loaded"
@@ -15,13 +21,6 @@ if [ -z "${BASE}" ]; then
 fi
 
 mkdir -p "${BASE}"
-
-if [ -r "${BASE}/environment" ]; then
-  # shellcheck disable=SC1090
-  source "${BASE}/environment"
-else
-  zwarn "failed to source ZBM environment"
-fi
 
 # Write out a default or overridden hostid
 if [ -n "${spl_hostid}" ] ; then

--- a/90zfsbootmenu/zfsbootmenu-exec.sh
+++ b/90zfsbootmenu/zfsbootmenu-exec.sh
@@ -22,7 +22,8 @@ export BASE="/zfsbootmenu"
 mkdir -p "${BASE}"
 
 # shellcheck disable=SC2154
-cat > "${BASE}/environment" <<EOF
+cat >> "/etc/profile" <<EOF
+# Added by zfsbootmenu-exec.sh
 export endian="${endian}"
 export spl_hostid="${spl_hostid}"
 export import_policy="${import_policy}"

--- a/90zfsbootmenu/zfsbootmenu-exec.sh
+++ b/90zfsbootmenu/zfsbootmenu-exec.sh
@@ -51,7 +51,7 @@ udevadm settle
 if [ -n "${zbm_tmux}" ] && [ -x /bin/tmux ]; then
   tmux new-session -n ZFSBootMenu -d /libexec/zfsbootmenu-countdown
   tmux new-window -n logs /bin/zlogtail -f -n
-  tmux new-window -n shell /bin/bash
+  tmux new-window -n shell
   exec tmux attach-session \; select-window -t ZFSBootMenu
 else
   # https://busybox.net/FAQ.html#job_control

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -2030,7 +2030,7 @@ emergency_shell() {
 
   echo -n "Launching emergency shell: "
   echo -e "${message}\n"
-  env "PS1=$( colorize orange "zfsbootmenu") \w > " /bin/bash --rcfile <( test -f /lib/zfsbootmenu-lib.sh && echo "source /lib/zfsbootmenu-lib.sh" )
+  /bin/bash -l
 }
 
 # prints: nothing

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -2051,3 +2051,10 @@ change_sort() {
 zbmcmdline() {
   [ -f "${BASE}/zbm.cmdline" ] && echo | cat "${BASE}/zbm.cmdline" -
 }
+
+# prints: nothing
+# returns: 0
+
+is_lib_sourced() {
+  return 0
+}

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -3,12 +3,21 @@
 
 if [ -r "/etc/profile" ]; then
   # shellcheck disable=SC1091
-  source "/etc/profile"
+  source /etc/profile
 else
   # shellcheck disable=SC1091
-  [ -r /lib/zfsbootmenu-lib.sh ] && source /lib/zfsbootmenu-lib.sh
+  source /lib/zfsbootmenu-lib.sh
   zwarn "failed to source ZBM environment"
 fi
+
+# Prove that /lib/zfsbootmenu-lib.sh was sourced, or hard fail
+if ! is_lib_sourced > /dev/null 2>&1 ; then
+  echo -e "\033[0;31mWARNING: /lib/zfsbootmenu-lib.sh was not sourced; unable to proceed\033[0m"
+  exec /bin/bash
+fi
+
+# Make sure /dev/zfs exists, otherwise drop to a recovery shell
+[ -e /dev/zfs ] || emergency_shell "/dev/zfs missing, check that kernel modules are loaded"
 
 if [ -z "${BASE}" ]; then
   export BASE="/zfsbootmenu"

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -1,23 +1,20 @@
 #!/bin/bash
 # vim: softtabstop=2 shiftwidth=2 expandtab
 
-##
-# Look for BEs with kernels and present a selection menu
-##
-
-# shellcheck disable=SC1091
-[ -r /lib/zfsbootmenu-lib.sh ] && source /lib/zfsbootmenu-lib.sh
+if [ -r "/etc/profile" ]; then
+  # shellcheck disable=SC1091
+  source "/etc/profile"
+else
+  # shellcheck disable=SC1091
+  [ -r /lib/zfsbootmenu-lib.sh ] && source /lib/zfsbootmenu-lib.sh
+  zwarn "failed to source ZBM environment"
+fi
 
 if [ -z "${BASE}" ]; then
   export BASE="/zfsbootmenu"
 fi
 
-if [ -r "${BASE}/environment" ]; then
-  # shellcheck disable=SC1090
-  source "${BASE}/environment"
-else
-  zwarn "failed to source ZBM environment"
-fi
+mkdir -p "${BASE}"
 
 while [ ! -e "${BASE}/initialized" ]; do
   if ! delay=5 prompt="Press [ESC] to cancel" timed_prompt "Waiting for ZFSBootMenu initialization"; then
@@ -291,7 +288,7 @@ while true; do
       else
         set_rw_pool "${pool}"
       fi
-    
+
       # Clear the screen ahead of a potential password prompt from populate_be_list
       tput clear
       tput cnorm


### PR DESCRIPTION
`bash` login shells automagically source `/etc/profile` . 

* `dropbear` invokes bash as a login shell 
* `tmux` invokes bash as a login shell. 
* Switch the recovery shell to launch bash as a login shell.

Set a universal path, a generic terminal type, PS1, and source `/lib/zfsbootmenu-lib.sh`. Write all variables defined/controlled by the command line to this file. In both main ZBM entry point scripts (`zfsbootmenu.sh`, `zfsbootmenu-countdown.sh`),  source this file or source `/lib/zfsbootmenu-lib.sh` and warn that the environment file couldn't be sourced.

Any shell - tmux, recovery, or SSH should now have an identical environment. 

