### PR TITLE
Force spl.spl_hostid=0 when matching hostid

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -122,7 +122,8 @@ center_string() {
 # returns: 0 on successful write, 1 on error
 
 write_hostid() {
-  local hostid ret
+  local hostid ret splmod
+  splmod="/sys/module/spl/parameters/spl_hostid"
 
   # Normalize the hostid
   if ! hostid="$( printf "%08x" "0x${1:-0}" 2>/dev/null )"; then
@@ -140,6 +141,10 @@ write_hostid() {
     zdebug "writing hostid ${hostid} to /etc/hostid (little-endian)"
     echo -ne "\\x${hostid:6:2}\\x${hostid:4:2}\\x${hostid:2:2}\\x${hostid:0:2}" > "/etc/hostid"
     ret=$?
+  fi
+
+  if [ "${ret}" -eq 0 ] && [ -w "${splmod}" ]; then
+    echo 0 > "${splmod}" || zwarn "failed to force spl.spl_hostid=0 for host ID matching"
   fi
 
   return ${ret}


### PR DESCRIPTION
If the SPL kmod has a non-zero `spl_hostid` parameter, nothing we write to `/etc/hostid` will have any effect. Forcing the module parameter to zero will cause ZFS to look to `/etc/hostid` for a value regardless of the initial state.

Needs testing to confirm that the parameter is writable on all systems, especially on the geriatric Ubuntu ZFS.