### PR TITLE
Allow references to parent properties in org.zfsbootmenu:commandline

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -1149,6 +1149,53 @@ find_root_prefix() {
 }
 
 # arg1: ZFS filesystem
+# prints: value of org.zfsbootmenu:commandline, with %{parent} recursively expanded
+# returns: 0 on success
+
+read_kcl_prop() {
+  local zfsbe args parfs par_args
+
+  zfsbe="${1}"
+  if [ -z "${zfsbe}" ]; then
+    zerror "zfsbe is undefined"
+    return 1
+  fi
+
+  if ! args="$( zfs get -H -o value org.zfsbootmenu:commandline "${zfsbe}" )"; then
+    zerror "unable to read org.zfsbootmenu:commandline on ${zfsbe}"
+    return 1
+  fi
+
+  # KCL is empty, nothing to see
+  if [ "${args}" = "-" ]; then
+    echo ""
+    return 0
+  fi
+
+  # KCL does not specify parent inheritance, just return the args
+  if ! [[ "${args}" =~ "%{parent}" ]]; then
+    echo "${args}"
+    return 0
+  fi
+
+  # Need to recursively expand "%{parent}"
+
+  parfs="${zfsbe%/*}"
+  if [ -z "${parfs}" ] || [ "${parfs}" = "${zfsbe}" ]; then
+    # There is no parent, par_args is empty
+    par_args=""
+  else
+    # Query the parent for kcl properties
+    if ! par_args="$( read_kcl_prop "${parfs}" )"; then
+      par_args=""
+    fi
+  fi
+
+  echo "${args//%\{parent\}/${par_args}}"
+  return 0
+}
+
+# arg1: ZFS filesystem
 # arg2: path for a mounted filesystem
 # prints: nothing
 # returns: 0 on success
@@ -1172,13 +1219,10 @@ preload_be_cmdline() {
 
   args_file="${BASE}/${zfsbe_fs}/cmdline"
 
-  if [ -n "${zfsbe_fs}" ]; then
-    zfsbe_args="$( zfs get -H -o value org.zfsbootmenu:commandline "${zfsbe_fs}" )"
-    if [ "${zfsbe_args}" != "-" ]; then
-      zdebug "using org.zfsbootmenu:commandline"
-      echo "${zfsbe_args}" > "${args_file}"
-      return
-    fi
+  if zfsbe_args="$( read_kcl_prop "${zfsbe_fs}" )" && [ -n "${zfsbe_args}" ]; then
+    zdebug "using org.zfsbootmenu:commandline"
+    echo "${zfsbe_args}" > "${args_file}"
+    return
   fi
 
   if [ -n "${zfsbe_mnt}" ] && [ -r "${zfsbe_mnt}/etc/default/zfsbootmenu" ]; then


### PR DESCRIPTION
Any reference to `%{parent}` in `org.zfsbootmenu:commandline` will be replaced with the value of the same property on the parent filesystem (with parent references above recursively expanded), allowing easy specification of common options at a mutual parent of two BEs and overrides or additions of individual options per-BE. The value of `%{parent}` is always an empty string on a root filesystem.

This is not intended to be sophisticated, and `%{parent}` appearing within other words will be replaced regardless. The assumption is that `%{parent}` is unique enough and will not conflict with real KCL options, so dumb global replacement is sufficient.

Tested with the following setup:
```
# zfs list -o name,org.zfsbootmenu:commandline
NAME             ORG.ZFSBOOTMENU:COMMANDLINE
ztest            loglevel=4 spl_hostid=43b06f17 %{parent}
ztest/ROOT       %{parent} rw console=tty1 console=ttyS0
ztest/ROOT/void  %{parent} loglevel=7
```
The command-line as parsed by ZBM appears in the preview pane as
```
loglevel=4 spl_hostid=43b06f17  rw console=tty1 console=ttyS0 loglevel=7
```
which is the expected value. (Note the double space after the `spl_hostid` argument, from the space before the empty `%{parent}` on `ztest` and the space following the expanded `%{parent}` on `ztest/ROOT`.