### PR TITLE
Small quality of life improvements

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -1372,7 +1372,7 @@ load_be_cmdline() {
 # rewind_to_checkpoint=1: enable --rewind-to-checkpoint
 
 import_pool() {
-  local pool import_args
+  local pool import_args import_output
 
   pool="${1}"
 
@@ -1413,7 +1413,9 @@ import_pool() {
 
   zdebug "zpool import arguments: ${import_args[*]} ${pool}"
 
-  zpool import "${import_args[@]}" "${pool}" >/dev/null 2>&1
+  import_output="$(
+    zpool import "${import_args[@]}" "${pool}" 2>&1
+  )"
   ret=$?
 
   if [ "$ret" -eq 0 ]; then
@@ -1421,6 +1423,7 @@ import_pool() {
   else
     spl_hostid="$( get_spl_hostid )"
     zdebug "import process failed with code ${ret}, apparent hostid ${spl_hostid:-unknown}"
+    zdebug "${import_output}"
   fi
 
   return ${ret}

--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -26,8 +26,8 @@ spl_hostid=$(getarg spl_hostid=)
 # Use the last defined console= to control menu output
 control_term=$( getarg console=)
 if [ -n "${control_term}" ]; then
+  control_term="/dev/${control_term%,*}"
   info "ZFSBootMenu: setting controlling terminal to: ${control_term}"
-  control_term="/dev/${control_term}"
 else
   control_term="/dev/tty1"
   info "ZFSBootMenu: defaulting controlling terminal to: ${control_term}"


### PR DESCRIPTION
When console=ttyS0,1152800n8 is passed in to the kernel it does not directly translate to a /dev entry. Simply strip the ,value off of the console=x,y parameter and set that as our /dev entry.

When a pool import fails for some reason, log the text from the zpool import process at the debug log level.