### PR TITLE
Add keyboard shortcut to remove pinned kernel

### DIFF
--- a/90zfsbootmenu/help-files/134/kernel-management.pod
+++ b/90zfsbootmenu/help-files/134/kernel-management.pod
@@ -14,6 +14,11 @@
 
   The operation will fail gracefully if the pool can not be set [33mread/write[0m.
 
+[33m[MOD+U][0m [1munset default[0m
+  Inherit the ZFS property [33morg.zfsbootmenu:kernel[0m from a parent if present, otherwise unset the property.
+
+  The operation will fail gracefully if the pool can not be set [33mread/write[0m.
+
 [33m[MOD+L][0m [1mview logs[0m
   View logs, as indicated by [33m[!][0m. The indicator will be yellow for warning conditions and red for errors.
 

--- a/90zfsbootmenu/help-files/54/kernel-management.pod
+++ b/90zfsbootmenu/help-files/54/kernel-management.pod
@@ -19,6 +19,13 @@
   The operation will fail gracefully if the pool can
   not be set [33mread/write[0m.
 
+[33m[MOD+U][0m [1munset default[0m
+  Inherit the ZFS property [33morg.zfsbootmenu:kernel[0m from
+  a parent if present, otherwise unset the property.
+
+  The operation will fail gracefully if the pool can
+  not be set [33mread/write[0m.
+
 [33m[MOD+L][0m [1mview logs[0m
   View logs, as indicated by [33m[!][0m. The indicator will
   be yellow for warning conditions and red for errors.

--- a/90zfsbootmenu/help-files/94/kernel-management.pod
+++ b/90zfsbootmenu/help-files/94/kernel-management.pod
@@ -16,6 +16,12 @@
 
   The operation will fail gracefully if the pool can not be set [33mread/write[0m.
 
+[33m[MOD+U][0m [1munset default[0m
+  Inherit the ZFS property [33morg.zfsbootmenu:kernel[0m from a parent if present, otherwise unset
+  the property.
+
+  The operation will fail gracefully if the pool can not be set [33mread/write[0m.
+
 [33m[MOD+L][0m [1mview logs[0m
   View logs, as indicated by [33m[!][0m. The indicator will be yellow for warning conditions and red
   for errors.

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -524,8 +524,9 @@ draw_kernel() {
 
   zdebug "using kernels file: ${_kernels}"
 
-  header="$( header_wrap "[RETURN] boot" "[ESCAPE] back" "[CTRL+D] set default" "" \
-      "[CTRL+L] view logs" "[CTRL+U] unset default" "[CTRL+H] help" )"
+  header="$( header_wrap "[RETURN] boot" "[ESCAPE] back" "" \
+    "[CTRL+D] set default" "[CTRL+U] unset default" "" \
+    "[CTRL+L] view logs" "[CTRL+H] help" )"
 
   expects="--expect=alt-d,alt-u"
 

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -525,9 +525,9 @@ draw_kernel() {
   zdebug "using kernels file: ${_kernels}"
 
   header="$( header_wrap "[RETURN] boot" "[ESCAPE] back" "[CTRL+D] set default" "" \
-      "[CTRL+L] view logs" " " "[CTRL+H] help" )"
+      "[CTRL+L] view logs" "[CTRL+U] unset default" "[CTRL+H] help" )"
 
-  expects="--expect=alt-d"
+  expects="--expect=alt-d,alt-u"
 
   if ! selected="$( HELP_SECTION=kernel-management ${FUZZYSEL} \
      --prompt "${benv} > " --tac --with-nth=2 --header="${header}" \

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -176,6 +176,9 @@ while true; do
           IFS=' ' read -r fs kpath initrd <<< "${selected_kernel}"
           set_default_kernel "${fs}" "${kpath}"
           ;;
+        "mod-u")
+          set_default_kernel "${fs}"
+          ;;
       esac
       ;;
     "mod-p")

--- a/pod/online/kernel-management.pod
+++ b/pod/online/kernel-management.pod
@@ -20,6 +20,12 @@ The ZFS property I<org.zfsbootmenu:kernel> is used to store the default kernel f
 
 The operation will fail gracefully if the pool can not be set I<read/write>.
 
+=item I<[MOD+U]> B<unset default>
+
+Inherit the ZFS property I<org.zfsbootmenu:kernel> from a parent if present, otherwise unset the property.
+
+The operation will fail gracefully if the pool can not be set I<read/write>.
+
 =item I<[MOD+L]> B<view logs>
 
 View logs, as indicated by I<[!]>. The indicator will be yellow for warning conditions and red for errors.


### PR DESCRIPTION
Add the `MOD+U` keyboard shortcut to allow 'unsetting' a pinned kernel, by way of inheriting the `org.zfsbootmenu:kernel` property. Under normal conditions (kernels pinned by ZBM), it'll simply remove the pin. The code to handle this was already present in the `set_default_kernel` function, it was just never glued to the user interface.