### PR TITLE
Change ZBM defaults

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -160,7 +160,7 @@ fi
 if [ "${BYTE_ORDER}" = "be" ]; then
   zbm_set_hostid=0
   info "ZFSBootMenu: big endian detected, disabling automatic replacement of spl_hostid"
-elif getargbool 0 zbm.set_hostid ; then
+elif getargbool 1 zbm.set_hostid ; then
   zbm_set_hostid=1
   info "ZFSBootMenu: enabling automatic replacement of spl_hostid"
 else

--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -67,16 +67,16 @@ if [ -n "${import_policy}" ]; then
       info "ZFSBootMenu: setting import_policy to strict"
       ;;
     *)
-      info "ZFSBootMenu: unknown import policy ${import_policy}, defaulting to strict"
-      import_policy="strict"
+      info "ZFSBootMenu: unknown import policy ${import_policy}, defaulting to hostid"
+      import_policy="hostid"
       ;;
   esac
 elif getargbool 0 zbm.force_import -d force_import ; then
   import_policy="force"
   info "ZFSBootMenu: setting import_policy to force"
 else
-  info "ZFSBootMenu: defaulting import_policy to strict"
-  import_policy="strict"
+  info "ZFSBootMenu: defaulting import_policy to hostid"
+  import_policy="hostid"
 fi
 
 # zbm.timeout= overrides timeout=

--- a/pod/zfsbootmenu.7.pod
+++ b/pod/zfsbootmenu.7.pod
@@ -38,11 +38,11 @@ This option controls how the pool import process should take place.
 
 =item B<zbm.import_policy=hostid>
 
-Set this option to allow run-time reconfiguration of the SPL hostid. If a pool is preferred via B<zbm.prefer> and the pool can not be imported with a preconfigured hostid, the system will attempt to adopt the hostid of the system that last imported the pool. If a preferred pool is not set and no pools can be imported using a preconfigured hostid, the system will adopt the hostid of the first otherwise-importable pool. After adopting a detected hostid, ZFSBootMenu will subsequently attempt to import as many pools as possible. This option is forbidden on big-endian systems.
+Set this option to allow run-time reconfiguration of the SPL hostid. If a pool is preferred via B<zbm.prefer> and the pool can not be imported with a preconfigured hostid, the system will attempt to adopt the hostid of the system that last imported the pool. If a preferred pool is not set and no pools can be imported using a preconfigured hostid, the system will adopt the hostid of the first otherwise-importable pool. After adopting a detected hostid, ZFSBootMenu will subsequently attempt to import as many pools as possible. This option is forbidden on big-endian systems. This is the default import policy.
 
 =item B<zbm.import_policy=strict>
 
-Set this option to only import pools that match the SPL hostid configured in ZFSBootMenu. If none can be imported, an emergency shell will be invoked. The I<strict> policy is consistent with the behavior of earlier versions of ZFSBootMenu and is the default import policy.
+Set this option to only import pools that match the SPL hostid configured in ZFSBootMenu. If none can be imported, an emergency shell will be invoked. The I<strict> policy is consistent with the behavior of earlier versions of ZFSBootMenu.
 
 =item B<zbm.import_policy=force>
 
@@ -52,7 +52,7 @@ Set this option to attempt to force pool imports. When set, this invokes I<zpool
 
 =item B<zbm.set_hostid>
 
-On little-endian systems, setting this option will cause ZFSBootMenu to set the I<spl.spl_hostid> command-line parameter for the selected boot environment to the hostid used to import its pool. The SPL kernel module will use this value as the hostid of the booted environment regardless of the contents of I</etc/hostid>. As a special case, if the hostid to be set is zero, ZFSBootMenu will instead set I<spl_hostid=00000000>, which should be used by dracut-based initramfs images to write an all-zero I</etc/hostid> in the initramfs prior to importing the boot pool.
+On little-endian systems, setting this option will cause ZFSBootMenu to set the I<spl.spl_hostid> command-line parameter for the selected boot environment to the hostid used to import its pool. The SPL kernel module will use this value as the hostid of the booted environment regardless of the contents of I</etc/hostid>. As a special case, if the hostid to be set is zero, ZFSBootMenu will instead set I<spl_hostid=00000000>, which should be used by dracut-based initramfs images to write an all-zero I</etc/hostid> in the initramfs prior to importing the boot pool. This option is on by default.
 
 This option has no effect on big-endian systems.
 


### PR DESCRIPTION
After a few months of testing, the `zbm.import_policy=hostid` and `zbm.set_hostid=on` have been tested enough to be the new default behaviors. Enable them and then update documentation to note that they're on by default.