### PR TITLE
Improved pool imports

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-init.sh
+++ b/90zfsbootmenu/zfsbootmenu-init.sh
@@ -91,7 +91,7 @@ while true; do
   zinfo "unable to import a pool on attempt ${zbm_import_attempt}"
 
   # Just keep retrying after a delay until the user presses ESC
-  if delay="${zbm_import_delay:-5}" prompt="Unable to import pool, retrying in %0.2d seconds" \
+  if delay="${zbm_import_delay:-5}" prompt="Unable to import ${try_pool:-pool}, retrying in %0.2d seconds" \
     timed_prompt "[RETURN] to retry immediately" "[ESCAPE] for a recovery shell"; then
       continue
   fi

--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -93,20 +93,10 @@ else
   menu_timeout=10
 fi
 
-zbm_import_retries=$( getarg zbm.import_retries )
-if [ "${zbm_import_retries:-0}" -gt 0 ] 2>/dev/null ; then 
-  # Beyond logging, this validates that zbm_import_retries is a number
-  info "ZFSBootMenu: will attempt up to ${zbm_import_retries} import retries"
-else
-  zbm_import_retries=0
-fi
-
 zbm_import_delay=$( getarg zbm.import_delay )
 if [ "${zbm_import_delay:-0}" -gt 0 ] 2>/dev/null ; then 
   # Again, this validates that zbm_import_delay is numeric in addition to logging
-  if [ "${zbm_import_retries}" -gt 0 ]; then
-    info "ZFSBootMenu: import retry delay is ${zbm_import_delay} seconds"
-  fi
+  info "ZFSBootMenu: import retry delay is ${zbm_import_delay} seconds"
 else
   zbm_import_delay=5
 fi
@@ -195,6 +185,14 @@ case "${root}" in
     info "ZFSBootMenu: preferring ${root} for bootfs"
     ;;
 esac
+
+# Pool preference ending in ! indicates a hard requirement
+bpool="${root%\!}"
+if [ "${bpool}" != "${root}" ]; then
+  # shellcheck disable=SC2034
+  zbm_require_bpool=1
+  root="${bpool}"
+fi
 
 # Make sure Dracut is happy that we have a root
 if [ ${wait_for_zfs} -eq 1 ]; then

--- a/90zfsbootmenu/zfsbootmenu-preinit.sh
+++ b/90zfsbootmenu/zfsbootmenu-preinit.sh
@@ -30,10 +30,10 @@ export import_policy="${import_policy}"
 export menu_timeout="${menu_timeout}"
 export loglevel="${loglevel}"
 export root="${root}"
+export zbm_require_bpool="${zbm_require_bpool}"
 export zbm_sort="${zbm_sort}"
 export zbm_set_hostid="${zbm_set_hostid}"
 export zbm_import_delay="${zbm_import_delay}"
-export zbm_import_retries="${zbm_import_retries}"
 EOF
 
 getcmdline > "${BASE}/zbm.cmdline"


### PR DESCRIPTION
1. Allow `zbm.prefer=<pool>!` syntax for a *mandatory* preference; a mandatory poll must be imported before other pools will be attempted and ZBM continues.

2. Eliminate limits on import retries; the loop will continue indefinitely, displaying a countdown that the user can interrupt to drop to an emergency shell.

I need some help thinking through the logic to make sure the overhauled import loop will terminate properly, and this needs some real testing. My assumptions are:
- [ ] If we have a boot pool preference, we try that first; otherwise, the preference is empty to try any import.
- [ ] If an import attempt succeeds, then either:
    - A preference was indicated, so the preferred pool *must* have succeeded; in this case, try again with no preference to pick up any other importables. (This should happen exactly once.)
    - A preference was not indicated (because it never existed or we are retrying after dropping it); we are done because we have found at least one pool.
- [ ] If the import attempt fails but host matching is desired, attempt to match the hostid.
    - When hostid matching succeeds, it means *exactly one* pool has been imported with an ID match. If this succeeds when we requested a specific preference, that means we have imported our preference and can try again (exactly once) with no preference to pick up other pools if possible. If this succeeds when we requested no specific preference, we still wish to try again (with no preference) to make sure to grab other pools with a (possibly new) hostid.
    - When hostid matching fails, we should have never have imported pools.
- [ ] If we have asked for a specific pool but failed to import it, and the pool is not hard required, just drop the preference and make another import attempt.
- [ ] Otherwise, we exist in an error state---either we have asked for any pool but imported nothing, or we ask for a specific pool and it is not available. Show the countdown before trying again to throttle retries and allow the user to interrupt.

Please confirm that my assumptions are reasonable and that the reworked loop conforms to my assumption. I believe there are no cases where the loop can continue indefinitely *without* a countdown timer between iterations---any continue without a timer should jump to the final iteration in all cases---but would like additional validation.