### PR TITLE
Validate module parameters, verify that kernel modules are loaded

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -84,6 +84,10 @@ install() {
     "chmod"
     "od"
     "stty"
+    "insmod"
+    "modinfo"
+    "lsmod"
+    "depmod"
   )
 
   for _exec in "${essential_execs[@]}"; do

--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -21,10 +21,33 @@ fi
 
 # Let the command line override our host id.
 # shellcheck disable=SC2034
-spl_hostid=$(getarg spl_hostid=)
+cli_spl_hostid=$( getarg spl.spl_hostid ) || cli_spl_hostid=$( getarg spl_hostid )
+if [ -n "${cli_spl_hostid}" ] ; then
+  # Start empty so only valid hostids are set for future use
+  spl_hostid=
+
+  # Test for decimal
+  if (( 10#${cli_spl_hostid} )) >/dev/null 2>&1 ; then
+    spl_hostid="$( printf "%08x" "${cli_spl_hostid}" )"
+  # Test for hex. Requires 0x, if present, to be stripped
+  # The change to cli_spl_hostid isn't saved outside of the test
+  elif (( 16#${cli_spl_hostid#0x} )) >/dev/null 2>&1 ; then
+    spl_hostid="${cli_spl_hostid#0x}"
+    # printf will strip leading 0s if there are more than 8 hex digits
+    # normalize to a maximum of 8, then run through printf to fill in
+    # if there are fewer than 8 digits.
+    spl_hostid="$( printf "%08x" "0x${spl_hostid:0:8}" )"
+  # base 10 / base 16 tests fail on 0
+  elif [ "${cli_spl_hostid#0x}" -eq "0" ] >/dev/null 2>&1 ; then
+    spl_hostid=0
+  # Not valid hex or dec, log
+  else
+    warn "ZFSBootMenu: invalid hostid value ${cli_spl_hostid}, ignoring"
+  fi
+fi
 
 # Use the last defined console= to control menu output
-control_term=$( getarg console=)
+control_term=$( getarg console )
 if [ -n "${control_term}" ]; then
   control_term="/dev/${control_term%,*}"
   info "ZFSBootMenu: setting controlling terminal to: ${control_term}"
@@ -35,7 +58,7 @@ fi
 
 # Use loglevel to determine logging to /dev/kmsg
 min_logging=4
-loglevel=$( getarg loglevel=)
+loglevel=$( getarg loglevel )
 if [ -n "${loglevel}" ]; then
   # minimum log level of 4, so we never lose error or warning messages
   [ "${loglevel}" -ge ${min_logging} ] || loglevel=${min_logging}
@@ -94,7 +117,7 @@ else
 fi
 
 zbm_import_delay=$( getarg zbm.import_delay )
-if [ "${zbm_import_delay:-0}" -gt 0 ] 2>/dev/null ; then 
+if [ "${zbm_import_delay:-0}" -gt 0 ] 2>/dev/null ; then
   # Again, this validates that zbm_import_delay is numeric in addition to logging
   info "ZFSBootMenu: import retry delay is ${zbm_import_delay} seconds"
 else
@@ -103,13 +126,13 @@ fi
 
 # Allow setting of console size; there are no defaults here
 # shellcheck disable=SC2034
-zbm_lines=$( getarg zbm.lines=)
+zbm_lines=$( getarg zbm.lines )
 # shellcheck disable=SC2034
-zbm_columns=$( getarg zbm.columns=)
+zbm_columns=$( getarg zbm.columns )
 
 # Allow sorting based on a key
 zbm_sort=
-sort_key=$( getarg zbm.sort_key=)
+sort_key=$( getarg zbm.sort_key )
 if [ -n "${sort_key}" ] ; then
   valid_keys=( "name" "creation" "used" )
   for key in "${valid_keys[@]}"; do

--- a/90zfsbootmenu/zfsbootmenu-preinit.sh
+++ b/90zfsbootmenu/zfsbootmenu-preinit.sh
@@ -31,6 +31,7 @@ export menu_timeout="${menu_timeout}"
 export loglevel="${loglevel}"
 export root="${root}"
 export zbm_require_bpool="${zbm_require_bpool}"
+export default_hostid=00bab10c
 export zbm_sort="${zbm_sort}"
 export zbm_set_hostid="${zbm_set_hostid}"
 export zbm_import_delay="${zbm_import_delay}"
@@ -40,9 +41,6 @@ getcmdline > "${BASE}/zbm.cmdline"
 
 # Set a non-empty hostname so we show up in zpool history correctly
 echo "ZFSBootMenu" > /proc/sys/kernel/hostname
-
-modprobe zfs 2>/dev/null
-udevadm settle
 
 # try to set console options for display and interaction
 # this is sometimes run as an initqueue hook, but cannot be guaranteed


### PR DESCRIPTION
It was relatively easy to break ZFSBootMenu to the point that it was almost unrecoverable by passing an invalid `spl.spl_hostid` parameter. When an invalid parameter is set on the kernel command line it can't be overridden except by directly calling `insmod` with the full path to the kernel module and the fixed argument to the parameter.

Additionally, if `spl.spl_hostid` was passed into ZBM, incorrect default-hostid logic was applied because `spl_hostid` wasn't detected on the kernel command line, nor is `/etc/hostid` part of the release builds. Both forms of passing the hostid are now accepted and the argument is normalized when possible to an 8 character hex value. If it can't be normalized, `spl_hostid` is unset and the global default of `00bab10c` is used.

In `zfsbootmenu-init.sh`,  find the on-disk path for `spl.ko` and manually load it with `insmod` and `spl_hostid=0`. This accomplishes two things - it bypasses bad `spl.spl_hostid` values set on the kernel command line, and it immediately switches the module to use `/etc/hostid` as the `hostid` source, which we already do in `write_hostid`.

Loading the `zfs` kernel module has also been moved to `zfsbootmenu-init.sh` so that all of the helper functions are available. If `modprobe zfs` fails, the error output is logged. A recovery shell is invoked so that users can look at logs to determine what happened.

