### PR TITLE
Release notes and fixes for 1.10

### DIFF
--- a/90zfsbootmenu/help-files/134/zfsbootmenu.7.pod
+++ b/90zfsbootmenu/help-files/134/zfsbootmenu.7.pod
@@ -17,8 +17,15 @@ general systems to boot without setting any values.
     override the value contained within the image.
 
 [1mzbm.prefer=<pool>[0m
-    By default, ZFSBootMenu will look for the [33mbootfs[0m property on the first imported pool (sorted alphabetically) to select the default
-    boot environment. If you have multiple pools, replace [1m<pool>[0m with the name of your preferred pool to override the default.
+    ZFSBootMenu will attempt to import as many pools as possible to identify boot environments and will, by default, look for the
+    [33mbootfs[0m property on the first imported pool (sorted alphabetically) to select the default boot environment. If you have multiple
+    pools, replace [1m<pool>[0m with the name of your preferred pool to override the default. If [1m<pool>[0m is the name of a pool followed by a
+    literal [33m![0m character, ZFSBootMenu will insist on successfully importing the named pool before attempting to import any others.
+
+[1mzbm.import_delay=<time>[0m
+    Should ZFSBootMenu fail to successfully import any pool, it will repeat import attempts indefinitely until at least one pool can
+    be imported or the user chooses to drop to a recovery shell. Each subsequent attempt will proceed after a delay of [1m<time>[0m seconds.
+    When [1m<time>[0m is unspecified or is anything other than a positive integer, a default value of 5 seconds will be used.
 
 [1mzbm.import_policy[0m
     This option controls how the pool import process should take place.
@@ -28,12 +35,11 @@ general systems to boot without setting any values.
       be imported with a preconfigured hostid, the system will attempt to adopt the hostid of the system that last imported the pool.
       If a preferred pool is not set and no pools can be imported using a preconfigured hostid, the system will adopt the hostid of
       the first otherwise-importable pool. After adopting a detected hostid, ZFSBootMenu will subsequently attempt to import as many
-      pools as possible. This option is forbidden on big-endian systems.
+      pools as possible. This option is forbidden on big-endian systems. This is the default import policy.
 
     [1mzbm.import_policy=strict[0m
       Set this option to only import pools that match the SPL hostid configured in ZFSBootMenu. If none can be imported, an emergency
-      shell will be invoked. The [33mstrict[0m policy is consistent with the behavior of earlier versions of ZFSBootMenu and is the default
-      import policy.
+      shell will be invoked. The [33mstrict[0m policy is consistent with the behavior of earlier versions of ZFSBootMenu.
 
     [1mzbm.import_policy=force[0m
       Set this option to attempt to force pool imports. When set, this invokes [33mzpool import -f[0m in place of the regular [33mzpool import[0m
@@ -44,9 +50,14 @@ general systems to boot without setting any values.
     selected boot environment to the hostid used to import its pool. The SPL kernel module will use this value as the hostid of the
     booted environment regardless of the contents of [33m/etc/hostid[0m. As a special case, if the hostid to be set is zero, ZFSBootMenu will
     instead set [33mspl_hostid=00000000[0m, which should be used by dracut-based initramfs images to write an all-zero [33m/etc/hostid[0m in the
-    initramfs prior to importing the boot pool.
+    initramfs prior to importing the boot pool. This option is on by default.
 
     This option has no effect on big-endian systems.
+
+    [1mNote:[0m Setting [33mspl.spl_hostid[0m to a non-zero value on the kernel commandline will make the ZFS kernel modules [1mignore[0m any value set
+    in [33m/etc/hostid[0m. To restore standard ZFS behavior on a running system, execute
+
+        echo 0 > /sys/module/spl/paramters/spl_hostid
 
 [1mzbm.sort_key[0m
     This option accepts a ZFS property name by which the boot environment and snapshot lists will be sorted.
@@ -120,8 +131,9 @@ The following properties can be set at any level of the boot-environment hierarc
     This specifies the prefix added to the ZFS filesystem provided as the root filesystem on the kernel command line. For example, the
     command-line argument [33mroot=zfs:zroot/ROOT/void[0m has root prefix [33mroot=zfs:[0m.
 
-    The default prefix is [33mroot=zfs:[0m on all systems except those that appear to be Arch Linux. For Arch, the default root prefix is
-    [33mzfs=[0m.
+    The default prefix is [33mroot=zfs:[0m for most boot environments. Environments that appear to be Arch Linux will use [33mzfs=[0m by default,
+    while those that appear to be Gentoo will use a default of [33mroot=ZFS=[0m. The root prefix is generally determined by the initramfs
+    generator, and the default is selected to match the expectation of the preferred initramfs generator on each distribution.
 
     Set this property to override the value determined from inspecting the boot environment.
 

--- a/90zfsbootmenu/help-files/54/zfsbootmenu.7.pod
+++ b/90zfsbootmenu/help-files/54/zfsbootmenu.7.pod
@@ -25,12 +25,27 @@ setting any values.
     contained within the image.
 
 [1mzbm.prefer=<pool>[0m
-    By default, ZFSBootMenu will look for the [33mbootfs[0m
-    property on the first imported pool (sorted
-    alphabetically) to select the default boot
-    environment. If you have multiple pools, replace
-    [1m<pool>[0m with the name of your preferred pool to
-    override the default.
+    ZFSBootMenu will attempt to import as many pools
+    as possible to identify boot environments and
+    will, by default, look for the [33mbootfs[0m property on
+    the first imported pool (sorted alphabetically) to
+    select the default boot environment. If you have
+    multiple pools, replace [1m<pool>[0m with the name of
+    your preferred pool to override the default. If
+    [1m<pool>[0m is the name of a pool followed by a literal
+    [33m![0m character, ZFSBootMenu will insist on
+    successfully importing the named pool before
+    attempting to import any others.
+
+[1mzbm.import_delay=<time>[0m
+    Should ZFSBootMenu fail to successfully import any
+    pool, it will repeat import attempts indefinitely
+    until at least one pool can be imported or the
+    user chooses to drop to a recovery shell. Each
+    subsequent attempt will proceed after a delay of
+    [1m<time>[0m seconds. When [1m<time>[0m is unspecified or is
+    anything other than a positive integer, a default
+    value of 5 seconds will be used.
 
 [1mzbm.import_policy[0m
     This option controls how the pool import process
@@ -49,15 +64,15 @@ setting any values.
       After adopting a detected hostid, ZFSBootMenu
       will subsequently attempt to import as many
       pools as possible. This option is forbidden on
-      big-endian systems.
+      big-endian systems. This is the default import
+      policy.
 
     [1mzbm.import_policy=strict[0m
       Set this option to only import pools that match
       the SPL hostid configured in ZFSBootMenu. If
       none can be imported, an emergency shell will be
       invoked. The [33mstrict[0m policy is consistent with
-      the behavior of earlier versions of ZFSBootMenu
-      and is the default import policy.
+      the behavior of earlier versions of ZFSBootMenu.
 
     [1mzbm.import_policy=force[0m
       Set this option to attempt to force pool
@@ -79,9 +94,17 @@ setting any values.
     set [33mspl_hostid=00000000[0m, which should be used by
     dracut-based initramfs images to write an all-zero
     [33m/etc/hostid[0m in the initramfs prior to importing
-    the boot pool.
+    the boot pool. This option is on by default.
 
     This option has no effect on big-endian systems.
+
+    [1mNote:[0m Setting [33mspl.spl_hostid[0m to a non-zero value
+    on the kernel commandline will make the ZFS kernel
+    modules [1mignore[0m any value set in [33m/etc/hostid[0m. To
+    restore standard ZFS behavior on a running system,
+    execute
+
+        echo 0 > /sys/module/spl/paramters/spl_hostid
 
 [1mzbm.sort_key[0m
     This option accepts a ZFS property name by which
@@ -186,9 +209,14 @@ behavior.
     argument [33mroot=zfs:zroot/ROOT/void[0m has root prefix
     [33mroot=zfs:[0m.
 
-    The default prefix is [33mroot=zfs:[0m on all systems
-    except those that appear to be Arch Linux. For
-    Arch, the default root prefix is [33mzfs=[0m.
+    The default prefix is [33mroot=zfs:[0m for most boot
+    environments. Environments that appear to be Arch
+    Linux will use [33mzfs=[0m by default, while those that
+    appear to be Gentoo will use a default of
+    [33mroot=ZFS=[0m. The root prefix is generally determined
+    by the initramfs generator, and the default is
+    selected to match the expectation of the preferred
+    initramfs generator on each distribution.
 
     Set this property to override the value determined
     from inspecting the boot environment.

--- a/90zfsbootmenu/help-files/94/zfsbootmenu.7.pod
+++ b/90zfsbootmenu/help-files/94/zfsbootmenu.7.pod
@@ -19,9 +19,19 @@ Default options were chosen to allow general systems to boot without setting any
     value contained within the image.
 
 [1mzbm.prefer=<pool>[0m
-    By default, ZFSBootMenu will look for the [33mbootfs[0m property on the first imported pool
-    (sorted alphabetically) to select the default boot environment. If you have multiple
-    pools, replace [1m<pool>[0m with the name of your preferred pool to override the default.
+    ZFSBootMenu will attempt to import as many pools as possible to identify boot environments
+    and will, by default, look for the [33mbootfs[0m property on the first imported pool (sorted
+    alphabetically) to select the default boot environment. If you have multiple pools,
+    replace [1m<pool>[0m with the name of your preferred pool to override the default. If [1m<pool>[0m is
+    the name of a pool followed by a literal [33m![0m character, ZFSBootMenu will insist on
+    successfully importing the named pool before attempting to import any others.
+
+[1mzbm.import_delay=<time>[0m
+    Should ZFSBootMenu fail to successfully import any pool, it will repeat import attempts
+    indefinitely until at least one pool can be imported or the user chooses to drop to a
+    recovery shell. Each subsequent attempt will proceed after a delay of [1m<time>[0m seconds. When
+    [1m<time>[0m is unspecified or is anything other than a positive integer, a default value of 5
+    seconds will be used.
 
 [1mzbm.import_policy[0m
     This option controls how the pool import process should take place.
@@ -33,13 +43,13 @@ Default options were chosen to allow general systems to boot without setting any
       If a preferred pool is not set and no pools can be imported using a preconfigured
       hostid, the system will adopt the hostid of the first otherwise-importable pool. After
       adopting a detected hostid, ZFSBootMenu will subsequently attempt to import as many
-      pools as possible. This option is forbidden on big-endian systems.
+      pools as possible. This option is forbidden on big-endian systems. This is the default
+      import policy.
 
     [1mzbm.import_policy=strict[0m
       Set this option to only import pools that match the SPL hostid configured in
       ZFSBootMenu. If none can be imported, an emergency shell will be invoked. The [33mstrict[0m
-      policy is consistent with the behavior of earlier versions of ZFSBootMenu and is the
-      default import policy.
+      policy is consistent with the behavior of earlier versions of ZFSBootMenu.
 
     [1mzbm.import_policy=force[0m
       Set this option to attempt to force pool imports. When set, this invokes [33mzpool import -f[0m
@@ -53,9 +63,15 @@ Default options were chosen to allow general systems to boot without setting any
     environment regardless of the contents of [33m/etc/hostid[0m. As a special case, if the hostid to
     be set is zero, ZFSBootMenu will instead set [33mspl_hostid=00000000[0m, which should be used by
     dracut-based initramfs images to write an all-zero [33m/etc/hostid[0m in the initramfs prior to
-    importing the boot pool.
+    importing the boot pool. This option is on by default.
 
     This option has no effect on big-endian systems.
+
+    [1mNote:[0m Setting [33mspl.spl_hostid[0m to a non-zero value on the kernel commandline will make the
+    ZFS kernel modules [1mignore[0m any value set in [33m/etc/hostid[0m. To restore standard ZFS behavior
+    on a running system, execute
+
+        echo 0 > /sys/module/spl/paramters/spl_hostid
 
 [1mzbm.sort_key[0m
     This option accepts a ZFS property name by which the boot environment and snapshot lists
@@ -141,8 +157,11 @@ boot behavior.
     the kernel command line. For example, the command-line argument [33mroot=zfs:zroot/ROOT/void[0m
     has root prefix [33mroot=zfs:[0m.
 
-    The default prefix is [33mroot=zfs:[0m on all systems except those that appear to be Arch Linux.
-    For Arch, the default root prefix is [33mzfs=[0m.
+    The default prefix is [33mroot=zfs:[0m for most boot environments. Environments that appear to be
+    Arch Linux will use [33mzfs=[0m by default, while those that appear to be Gentoo will use a
+    default of [33mroot=ZFS=[0m. The root prefix is generally determined by the initramfs generator,
+    and the default is selected to match the expectation of the preferred initramfs generator
+    on each distribution.
 
     Set this property to override the value determined from inspecting the boot environment.
 

--- a/90zfsbootmenu/zfsbootmenu-init.sh
+++ b/90zfsbootmenu/zfsbootmenu-init.sh
@@ -42,14 +42,17 @@ elif [ ! -e /etc/hostid ]; then
   write_hostid "${default_hostid}"
 fi
 
-# Capture the filename for spl.ko
-_modfilename="$( modinfo -F filename spl )"
-zinfo "loading ${_modfilename}"
+# only load spl.ko if it isn't already loaded
+if ! lsmod | grep -E -q "^spl" ; then
+  # Capture the filename for spl.ko
+  _modfilename="$( modinfo -F filename spl )"
+  zinfo "loading ${_modfilename}"
 
-# Load with a hostid of 0, so that /etc/hostid takes precedence
-if ! _modload="$( insmod "${_modfilename}" "spl_hostid=0" 2>&1 )" ; then
-  zdebug "${_modload}"
-  emergency_shell "unable to load SPL kernel module"
+  # Load with a hostid of 0, so that /etc/hostid takes precedence
+  if ! _modload="$( insmod "${_modfilename}" "spl_hostid=0" 2>&1 )" ; then
+    zdebug "${_modload}"
+    emergency_shell "unable to load SPL kernel module"
+  fi
 fi
 
 if ! _modload="$( modprobe zfs 2>&1 )" ; then

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -163,6 +163,9 @@ while true; do
       IFS=, read subkey selected_kernel <<< "${selection}"
       zdebug "selected kernel: ${selected_kernel}"
 
+      # shellcheck disable=SC2034
+      IFS=' ' read -r fs kpath initrd <<< "${selected_kernel}"
+
       case "${subkey}" in
         "enter")
           if ! kexec_kernel "${selected_kernel}"; then
@@ -172,8 +175,6 @@ while true; do
           exit
           ;;
         "mod-d")
-          # shellcheck disable=SC2034
-          IFS=' ' read -r fs kpath initrd <<< "${selected_kernel}"
           set_default_kernel "${fs}" "${kpath}"
           ;;
         "mod-u")

--- a/man/generate-zbm.5
+++ b/man/generate-zbm.5
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "generate-zbm 5"
-.TH generate-zbm 5 "2020-11-05" "1.9.0" "config.yaml"
+.TH generate-zbm 5 "2020-10-03" "1.10.0" "config.yaml"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l

--- a/man/generate-zbm.8
+++ b/man/generate-zbm.8
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "generate-zbm 8"
-.TH generate-zbm 8 "2021-04-13" "1.9.0" "generate-zbm"
+.TH generate-zbm 8 "2021-04-17" "1.10.0" "generate-zbm"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l

--- a/man/zfsbootmenu.7
+++ b/man/zfsbootmenu.7
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "zfsbootmenu 7"
-.TH zfsbootmenu 7 "2021-06-03" "1.9.0" "ZFSBootMenu"
+.TH zfsbootmenu 7 "2021-06-30" "1.10.0" "ZFSBootMenu"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -151,23 +151,20 @@ These options are set on the kernel command line when booting the initramfs or \
 When creating an initramfs or \s-1UEFI\s0 bundle, the \fI/etc/hostid\fR from the system is copied into the target. If this image will be used on another system with a different hostid, replace \fB<hostid>\fR with the desired hostid, as an eight-digit hexadecimal number, to override the value contained within the image.
 .IP "\fBzbm.prefer=<pool>\fR" 4
 .IX Item "zbm.prefer=<pool>"
-By default, ZFSBootMenu will look for the \fIbootfs\fR property on the first imported pool (sorted alphabetically) to select the default boot environment. If you have multiple pools, replace \fB<pool>\fR with the name of your preferred pool to override the default.
-.IP "\fBzbm.import_retries=<count>\fR" 4
-.IX Item "zbm.import_retries=<count>"
-If ZFSBootMenu fails to import a pool and \fB<count>\fR is a positive integer, the import will be attempted up to \fB<count>\fR times before dropping to an emergency shell to facilitate recovery. By default or if \fB<count>\fR is anything besides a positive integer, imports will not be retried.
+ZFSBootMenu will attempt to import as many pools as possible to identify boot environments and will, by default, look for the \fIbootfs\fR property on the first imported pool (sorted alphabetically) to select the default boot environment. If you have multiple pools, replace \fB<pool>\fR with the name of your preferred pool to override the default. If \fB<pool>\fR is the name of a pool followed by a literal \fI!\fR character, ZFSBootMenu will insist on successfully importing the named pool before attempting to import any others.
 .IP "\fBzbm.import_delay=<time>\fR" 4
 .IX Item "zbm.import_delay=<time>"
-If ZFSBootMenu is configured to retry imports via \fBzbm.import_retries\fR, each retried attempt will proceed after a delay of \fB<time>\fR seconds. When \fB<time>\fR is unspecified or is anything other than a positive integer, a default value of 5 seconds will be used.
+Should ZFSBootMenu fail to successfully import any pool, it will repeat import attempts indefinitely until at least one pool can be imported or the user chooses to drop to a recovery shell. Each subsequent attempt will proceed after a delay of \fB<time>\fR seconds. When \fB<time>\fR is unspecified or is anything other than a positive integer, a default value of 5 seconds will be used.
 .IP "\fBzbm.import_policy\fR" 4
 .IX Item "zbm.import_policy"
 This option controls how the pool import process should take place.
 .RS 4
 .IP "\fBzbm.import_policy=hostid\fR" 2
 .IX Item "zbm.import_policy=hostid"
-Set this option to allow run-time reconfiguration of the \s-1SPL\s0 hostid. If a pool is preferred via \fBzbm.prefer\fR and the pool can not be imported with a preconfigured hostid, the system will attempt to adopt the hostid of the system that last imported the pool. If a preferred pool is not set and no pools can be imported using a preconfigured hostid, the system will adopt the hostid of the first otherwise-importable pool. After adopting a detected hostid, ZFSBootMenu will subsequently attempt to import as many pools as possible. This option is forbidden on big-endian systems.
+Set this option to allow run-time reconfiguration of the \s-1SPL\s0 hostid. If a pool is preferred via \fBzbm.prefer\fR and the pool can not be imported with a preconfigured hostid, the system will attempt to adopt the hostid of the system that last imported the pool. If a preferred pool is not set and no pools can be imported using a preconfigured hostid, the system will adopt the hostid of the first otherwise-importable pool. After adopting a detected hostid, ZFSBootMenu will subsequently attempt to import as many pools as possible. This option is forbidden on big-endian systems. This is the default import policy.
 .IP "\fBzbm.import_policy=strict\fR" 2
 .IX Item "zbm.import_policy=strict"
-Set this option to only import pools that match the \s-1SPL\s0 hostid configured in ZFSBootMenu. If none can be imported, an emergency shell will be invoked. The \fIstrict\fR policy is consistent with the behavior of earlier versions of ZFSBootMenu and is the default import policy.
+Set this option to only import pools that match the \s-1SPL\s0 hostid configured in ZFSBootMenu. If none can be imported, an emergency shell will be invoked. The \fIstrict\fR policy is consistent with the behavior of earlier versions of ZFSBootMenu.
 .IP "\fBzbm.import_policy=force\fR" 2
 .IX Item "zbm.import_policy=force"
 Set this option to attempt to force pool imports. When set, this invokes \fIzpool import \-f\fR in place of the regular \fIzpool import\fR command, which will attempt to import a pool that's potentially in use on another system. Use this option with caution!
@@ -176,9 +173,19 @@ Set this option to attempt to force pool imports. When set, this invokes \fIzpoo
 .RE
 .IP "\fBzbm.set_hostid\fR" 4
 .IX Item "zbm.set_hostid"
-On little-endian systems, setting this option will cause ZFSBootMenu to set the \fIspl.spl_hostid\fR command-line parameter for the selected boot environment to the hostid used to import its pool. The \s-1SPL\s0 kernel module will use this value as the hostid of the booted environment regardless of the contents of \fI/etc/hostid\fR. As a special case, if the hostid to be set is zero, ZFSBootMenu will instead set \fIspl_hostid=00000000\fR, which should be used by dracut-based initramfs images to write an all-zero \fI/etc/hostid\fR in the initramfs prior to importing the boot pool.
+On little-endian systems, setting this option will cause ZFSBootMenu to set the \fIspl.spl_hostid\fR command-line parameter for the selected boot environment to the hostid used to import its pool. The \s-1SPL\s0 kernel module will use this value as the hostid of the booted environment regardless of the contents of \fI/etc/hostid\fR. As a special case, if the hostid to be set is zero, ZFSBootMenu will instead set \fIspl_hostid=00000000\fR, which should be used by dracut-based initramfs images to write an all-zero \fI/etc/hostid\fR in the initramfs prior to importing the boot pool. This option is on by default.
 .Sp
 This option has no effect on big-endian systems.
+.Sp
+\&\fBNote:\fR Setting \fIspl.spl_hostid\fR to a non-zero value on the kernel commandline will make the \s-1ZFS\s0 kernel modules \fBignore\fR any value set in \fI/etc/hostid\fR. To restore standard \s-1ZFS\s0 behavior on a running system, execute
+.RS 4
+.Sp
+.RS 4
+echo 0 > /sys/module/spl/paramters/spl_hostid
+.RE
+.RE
+.RS 4
+.RE
 .IP "\fBzbm.sort_key\fR" 4
 .IX Item "zbm.sort_key"
 This option accepts a \s-1ZFS\s0 property name by which the boot environment and snapshot lists will be sorted.
@@ -260,7 +267,7 @@ By default, ZFSBootMenu only shows boot environments with the property \fImountp
 .IX Item "org.zfsbootmenu:rootprefix"
 This specifies the prefix added to the \s-1ZFS\s0 filesystem provided as the root filesystem on the kernel command line. For example, the command-line argument \fIroot=zfs:zroot/ROOT/void\fR has root prefix \fIroot=zfs:\fR.
 .Sp
-The default prefix is \fIroot=zfs:\fR on all systems except those that appear to be Arch Linux. For Arch, the default root prefix is \fIzfs=\fR.
+The default prefix is \fIroot=zfs:\fR for most boot environments. Environments that appear to be Arch Linux will use \fIzfs=\fR by default, while those that appear to be Gentoo will use a default of \fIroot=ZFS=\fR. The root prefix is generally determined by the initramfs generator, and the default is selected to match the expectation of the preferred initramfs generator on each distribution.
 .Sp
 Set this property to override the value determined from inspecting the boot environment.
 .IP "\fBorg.zfsbootmenu:keysource=<filesystem>\fR" 4

--- a/pod/zfsbootmenu.7.pod
+++ b/pod/zfsbootmenu.7.pod
@@ -20,15 +20,11 @@ When creating an initramfs or UEFI bundle, the I</etc/hostid> from the system is
 
 =item B<zbm.prefer=E<lt>poolE<gt>>
 
-By default, ZFSBootMenu will look for the I<bootfs> property on the first imported pool (sorted alphabetically) to select the default boot environment. If you have multiple pools, replace B<E<lt>poolE<gt>> with the name of your preferred pool to override the default.
-
-=item B<zbm.import_retries=E<lt>countE<gt>>
-
-If ZFSBootMenu fails to import a pool and B<E<lt>countE<gt>> is a positive integer, the import will be attempted up to B<E<lt>countE<gt>> times before dropping to an emergency shell to facilitate recovery. By default or if B<E<lt>countE<gt>> is anything besides a positive integer, imports will not be retried.
+ZFSBootMenu will attempt to import as many pools as possible to identify boot environments and will, by default, look for the I<bootfs> property on the first imported pool (sorted alphabetically) to select the default boot environment. If you have multiple pools, replace B<E<lt>poolE<gt>> with the name of your preferred pool to override the default. If B<E<lt>poolE<gt>> is the name of a pool followed by a literal I<!> character, ZFSBootMenu will insist on successfully importing the named pool before attempting to import any others.
 
 =item B<zbm.import_delay=E<lt>timeE<gt>>
 
-If ZFSBootMenu is configured to retry imports via B<zbm.import_retries>, each retried attempt will proceed after a delay of B<E<lt>timeE<gt>> seconds. When B<E<lt>timeE<gt>> is unspecified or is anything other than a positive integer, a default value of 5 seconds will be used.
+Should ZFSBootMenu fail to successfully import any pool, it will repeat import attempts indefinitely until at least one pool can be imported or the user chooses to drop to a recovery shell. Each subsequent attempt will proceed after a delay of B<E<lt>timeE<gt>> seconds. When B<E<lt>timeE<gt>> is unspecified or is anything other than a positive integer, a default value of 5 seconds will be used.
 
 =item B<zbm.import_policy>
 
@@ -55,6 +51,14 @@ Set this option to attempt to force pool imports. When set, this invokes I<zpool
 On little-endian systems, setting this option will cause ZFSBootMenu to set the I<spl.spl_hostid> command-line parameter for the selected boot environment to the hostid used to import its pool. The SPL kernel module will use this value as the hostid of the booted environment regardless of the contents of I</etc/hostid>. As a special case, if the hostid to be set is zero, ZFSBootMenu will instead set I<spl_hostid=00000000>, which should be used by dracut-based initramfs images to write an all-zero I</etc/hostid> in the initramfs prior to importing the boot pool. This option is on by default.
 
 This option has no effect on big-endian systems.
+
+B<Note:> Setting I<spl.spl_hostid> to a non-zero value on the kernel commandline will make the ZFS kernel modules B<ignore> any value set in I</etc/hostid>. To restore standard ZFS behavior on a running system, execute
+
+=over 4
+
+echo 0 > /sys/module/spl/paramters/spl_hostid
+
+=back
 
 =item B<zbm.sort_key>
 
@@ -164,7 +168,7 @@ By default, ZFSBootMenu only shows boot environments with the property I<mountpo
 
 This specifies the prefix added to the ZFS filesystem provided as the root filesystem on the kernel command line. For example, the command-line argument I<root=zfs:zroot/ROOT/void> has root prefix I<root=zfs:>.
 
-The default prefix is I<root=zfs:> on all systems except those that appear to be Arch Linux. For Arch, the default root prefix is I<zfs=>.
+The default prefix is I<root=zfs:> for most boot environments. Environments that appear to be Arch Linux will use I<zfs=> by default, while those that appear to be Gentoo will use a default of I<root=ZFS=>. The root prefix is generally determined by the initramfs generator, and the default is selected to match the expectation of the preferred initramfs generator on each distribution.
 
 Set this property to override the value determined from inspecting the boot environment.
 

--- a/releng/make-binary.sh
+++ b/releng/make-binary.sh
@@ -36,7 +36,7 @@ cp -Rp etc/zfsbootmenu/dracut.conf.d "${temp}"
 cat << EOF > "${temp}/dracut.conf.d/release.conf"
 omit_drivers+=" amdgpu radeon nvidia nouveau i915 "
 omit_dracutmodules+=" qemu qemu-net crypt-ssh nfs lunmask network network-legacy kernel-network-modules "
-embedded_kcl="zbm.import_policy=hostid zbm.set_hostid rd.hostonly=0"
+embedded_kcl="rd.hostonly=0"
 release_build=1
 zfsbootmenu_teardown+=" $( realpath contrib/xhci-teardown.sh ) "
 EOF


### PR DESCRIPTION
* `insmod` doesn't gracefully fail if a module is already loaded. An initramfs generated on Arch loads `spl.ko` before our insmod attempts it, so check if it's not loaded and then load it.
* Split the filesystem/kernel/initramfs before the subkey handler under the kernel selection handler, so that it's available for pinning and unpinning kernels.
* Remove documentation for `zbm.import_retries` and regenerate the online help pages for that section.
* First pass at release notes for 1.10.