### PR TITLE
Add easy 'takeover' helper

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-init.sh
+++ b/90zfsbootmenu/zfsbootmenu-init.sh
@@ -19,10 +19,6 @@ if ! is_lib_sourced > /dev/null 2>&1 ; then
   exec /bin/bash
 fi
 
-if [ -z "${BASE}" ]; then
-  export BASE="/zfsbootmenu"
-fi
-
 mkdir -p "${BASE}"
 
 # Attempt to load spl normally

--- a/90zfsbootmenu/zfsbootmenu-init.sh
+++ b/90zfsbootmenu/zfsbootmenu-init.sh
@@ -185,11 +185,14 @@ fi
 : > "${BASE}/initialized"
 
 # If BOOTFS is not empty display the fast boot menu
-if [ -n "${BOOTFS}" ]; then
+# shellcheck disable=SC2154
+if [ "${menu_timeout}" -ge 0 ] && [ -n "${BOOTFS}" ]; then
   # Draw a countdown menu
   # shellcheck disable=SC2154
-  if [ "${menu_timeout}" -ge 0 ]; then
-    if delay="${menu_timeout}" prompt="Booting ${BOOTFS} in %0.${#menu_timeout}d seconds" timed_prompt "[ENTER] to boot" "[ESC] boot menu" ; then
+  if delay="${menu_timeout}" prompt="Booting ${BOOTFS} in %0.${#menu_timeout}d seconds" timed_prompt "[ENTER] to boot" "[ESC] boot menu" ; then
+    # This lock file is present if someone has SSH'd to take control
+    # Do not attempt to automatically boot if present
+    if [ ! -e "${BASE}/active" ] ; then
       # Clear screen before a possible password prompt
       tput clear
       if ! NO_CACHE=1 load_key "${BOOTFS}"; then
@@ -200,6 +203,12 @@ if [ -n "${BOOTFS}" ]; then
       fi
     fi
   fi
+fi
+
+# If the lock file is present, drop to a recovery shell to avoid
+# stealing control back from an SSH session
+if [ -e "${BASE}/active" ] ; then
+  emergency_shell "type 'exit' to return to ZFSBootMenu"
 fi
 
 while true; do

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -2121,6 +2121,21 @@ zbmcmdline() {
 }
 
 # prints: nothing
+# returns: nothing
+
+takeover() {
+  local pid
+
+  # Kill the other running instance
+  if [ -f "${BASE}/active" ] ; then
+    read -r pid < "${BASE}/active"
+    [ -n "${pid}" ] && kill "${pid}"
+  fi
+
+  exec /bin/zfsbootmenu
+}
+
+# prints: nothing
 # returns: 0
 
 is_lib_sourced() {

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -18,7 +18,7 @@ zlog() {
   [ "${1}" -le "${loglevel:=4}" ] || return
 
   # shellcheck disable=SC2086
-  _script="$( basename $0 )"
+  _script="$( basename -- $0 )"
   _func="${FUNCNAME[2]}"
 
   # Only add script/function tracing to debug messages
@@ -2120,18 +2120,61 @@ zbmcmdline() {
   [ -f "${BASE}/zbm.cmdline" ] && echo | cat "${BASE}/zbm.cmdline" -
 }
 
+# arg1: pid
+# prints: child pid
+# returns: 0 if a child pid was found, 1 if there are no children
+
+find_child_pid() {
+  local pid child
+
+  pid="${1}"
+  if [ -z "${pid}" ]; then
+    zdebug "empty pid"
+    return 1
+  fi
+
+  if [ -e "/proc/${pid}/task/${pid}/children" ] ; then
+    read -r child < "/proc/${pid}/task/${pid}/children"
+
+    if [ -n "${child}" ] ; then
+      echo "${child}"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
 # prints: nothing
 # returns: nothing
 
 takeover() {
-  local pid
-  echo "Starting takeover"
+  local pid child
 
   # Kill the other running instance
   if [ -e "${BASE}/active" ] ; then
     read -r pid < "${BASE}/active"
-    [ -n "${pid}" ] && kill "${pid}"
-    zinfo "Killing active zfsbootmenu with a PID of ${pid}"
+    parent=${pid}
+
+    echo "Stopping active zfsbootmenu with a PID of ${pid}"
+
+    # Trip the USR1 handler in /bin/zfsbootmenu - 'exit 0'
+    kill -USR1 "${parent}"
+
+    # find the last child process of the active /bin/zfsbootmenu
+    while child="$( find_child_pid "${parent}" )" ; do
+      zdebug "Child pid of ${parent} is ${child}"
+      if [ -n "${child}" ] ; then
+        parent=${child}
+        continue
+      fi
+      break
+    done
+
+    zdebug "Final child pid is ${parent}"
+
+    # Kill the blocking child so that the USR1 handler actually executes
+    [ -n "${parent}" ] && kill "${parent}"
   fi
 
   /bin/zfsbootmenu

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -2160,12 +2160,11 @@ takeover() {
     echo "Stopping active zfsbootmenu with a PID of ${pid}"
 
     # Trip the USR1 handler in /bin/zfsbootmenu - 'exit 0'
-    zdebug "Sending USR1 to ${parent}"
+    zdebug "sending USR1 to ${parent}"
     kill -USR1 "${parent}"
 
     # find the last child process of the active /bin/zfsbootmenu
     while child="$( find_child_pid "${parent}" )" ; do
-      zdebug "Child pid of ${parent} is ${child}"
       if [ -n "${child}" ] ; then
         parent=${child}
         continue
@@ -2173,9 +2172,8 @@ takeover() {
       break
     done
 
-    zdebug "Final child pid is ${parent}"
-
     # Kill the blocking child so that the USR1 handler actually executes
+    zdebug "killing child process ${parent}"
     [ -n "${parent}" ] && kill "${parent}"
   fi
 

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -2160,6 +2160,7 @@ takeover() {
     echo "Stopping active zfsbootmenu with a PID of ${pid}"
 
     # Trip the USR1 handler in /bin/zfsbootmenu - 'exit 0'
+    zdebug "Sending USR1 to ${parent}"
     kill -USR1 "${parent}"
 
     # find the last child process of the active /bin/zfsbootmenu

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -2125,14 +2125,16 @@ zbmcmdline() {
 
 takeover() {
   local pid
+  echo "Starting takeover"
 
   # Kill the other running instance
-  if [ -f "${BASE}/active" ] ; then
+  if [ -e "${BASE}/active" ] ; then
     read -r pid < "${BASE}/active"
     [ -n "${pid}" ] && kill "${pid}"
+    zinfo "Killing active zfsbootmenu with a PID of ${pid}"
   fi
 
-  exec /bin/zfsbootmenu
+  /bin/zfsbootmenu
 }
 
 # prints: nothing

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -2095,6 +2095,7 @@ emergency_shell() {
 
   tput clear
   tput cnorm
+  stty echo
 
   echo -n "Launching emergency shell: "
   echo -e "${message}\n"

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -2152,12 +2152,11 @@ find_child_pid() {
 takeover() {
   local pid child
 
-  # Kill the other running instance
   if [ -e "${BASE}/active" ] ; then
     read -r pid < "${BASE}/active"
     parent=${pid}
 
-    echo "Stopping active zfsbootmenu with a PID of ${pid}"
+    zinfo "Stopping active zfsbootmenu with a PID of ${pid}"
 
     # Trip the USR1 handler in /bin/zfsbootmenu - 'exit 0'
     zdebug "sending USR1 to ${parent}"
@@ -2176,8 +2175,6 @@ takeover() {
     zdebug "killing child process ${parent}"
     [ -n "${parent}" ] && kill "${parent}"
   fi
-
-  /bin/zfsbootmenu
 }
 
 # prints: nothing

--- a/90zfsbootmenu/zfsbootmenu-preinit.sh
+++ b/90zfsbootmenu/zfsbootmenu-preinit.sh
@@ -24,6 +24,7 @@ mkdir -p "${BASE}"
 # shellcheck disable=SC2154
 cat >> "/etc/profile" <<EOF
 # Added by zfsbootmenu-preinit.sh
+export BASE="/zfsbootmenu"
 export endian="${endian}"
 export spl_hostid="${spl_hostid}"
 export import_policy="${import_policy}"

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -45,7 +45,7 @@ zdebug "creating ${BASE}/active"
 
 # shellcheck disable=SC2064
 trap "rm -f '${BASE}/active'" EXIT
-trap "exit 0" SIGUSR1
+trap "zdebug 'In the USR1 signal handler' ; exit 0" SIGUSR1
 
 if [ -r "${BASE}/bootfs" ]; then
   read -r BOOTFS < "${BASE}/bootfs"

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -35,7 +35,7 @@ while [ ! -e "${BASE}/initialized" ]; do
 done
 
 while [ -e "${BASE}/active" ]; do
-  if ! delay=5 prompt="Press [ESC] to cancel" timed_prompt "Waiting for other ZFSBootMenu instace to terminate"; then
+  if ! delay=5 prompt="Press [ESC] to cancel" timed_prompt "Waiting for other ZFSBootMenu instance to terminate"; then
     zdebug "exited while waiting to own ${BASE}/active"
     tput cnorm
     tput clear
@@ -44,7 +44,7 @@ while [ -e "${BASE}/active" ]; do
 done
 
 # Prevent conflicting use of the boot menu
-: > "${BASE}/active"
+echo "$$" > "${BASE}/active"
 zdebug "creating ${BASE}/active"
 
 # shellcheck disable=SC2064

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -19,10 +19,6 @@ fi
 # Make sure /dev/zfs exists, otherwise drop to a recovery shell
 [ -e /dev/zfs ] || emergency_shell "/dev/zfs missing, check that kernel modules are loaded"
 
-if [ -z "${BASE}" ]; then
-  export BASE="/zfsbootmenu"
-fi
-
 mkdir -p "${BASE}"
 
 while [ ! -e "${BASE}/initialized" ]; do

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -45,6 +45,7 @@ zdebug "creating ${BASE}/active"
 
 # shellcheck disable=SC2064
 trap "rm -f '${BASE}/active'" EXIT
+trap "exit 0" SIGUSR1
 
 if [ -r "${BASE}/bootfs" ]; then
   read -r BOOTFS < "${BASE}/bootfs"

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -45,7 +45,8 @@ zdebug "creating ${BASE}/active"
 
 # shellcheck disable=SC2064
 trap "rm -f '${BASE}/active'" EXIT
-trap "zdebug 'In the USR1 signal handler' ; exit 0" SIGUSR1
+trap "zdebug 'exiting via USR1 signal' ; exit 0" SIGUSR1
+trap '' SIGINT
 
 if [ -r "${BASE}/bootfs" ]; then
   read -r BOOTFS < "${BASE}/bootfs"
@@ -62,8 +63,6 @@ if [ -d /libexec/setup.d ]; then
   done
   unset _hook
 fi
-
-trap '' SIGINT
 
 # shellcheck disable=SC2016
 fuzzy_default_options=( "--ansi" "--no-clear"

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -30,8 +30,11 @@ while [ ! -e "${BASE}/initialized" ]; do
   fi
 done
 
+[ -e "${BASE}/active" ] && takeover
+
+# If the takeover fails for some reason, spin until it ends
 while [ -e "${BASE}/active" ]; do
-  if ! delay=5 prompt="Press [ESC] to cancel" timed_prompt "Waiting for other ZFSBootMenu instance to terminate"; then
+  if ! delay=1 prompt="Press [ESC] to cancel" timed_prompt "Waiting for other ZFSBootMenu instance to terminate"; then
     zdebug "exited while waiting to own ${BASE}/active"
     tput cnorm
     tput clear

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -48,7 +48,7 @@ zdebug "creating ${BASE}/active"
 
 # shellcheck disable=SC2064
 trap "rm -f '${BASE}/active'" EXIT
-trap "zdebug 'exiting via USR1 signal' ; exit 0" SIGUSR1
+trap "zdebug 'exiting via USR1 signal' ; tput clear ; exit 0" SIGUSR1
 trap '' SIGINT
 
 if [ -r "${BASE}/bootfs" ]; then


### PR DESCRIPTION
To facilitate easily taking over a running ZFSBootMenu instance, regardless of where it is (ZFS password prompt, at the main menu, etc), the 'takeover' function has been created. 

In broad strokes, this works as follows:
##### `/bin/zfsbootmenu`
* `/bin/zfsbootmenu` writes it's PID to `/zfsbootmenu/active`
* `/bin/zfsbootmenu` Installs a `USR1` handler that runs `exit 0`

##### `takeover()`
* reads the pid out of `/zfsbootmenu/active` if it exists, sends it a `USR1` signal (which won't be processed until child processes are killed)
* Walks down the list of child PIDs for the active `/bin/zfsbootmenu` process; stops at the last child
* Kills the last child (typically either `fzf` or `zfs` password prompt)
* The `SIGUSR1` trap now executes, causing the running `zfsbootmenu` instance to exit
* On exit, `/zfsbootmenu/active` is removed
* A new `/bin/zfsbootmenu` is exec'd out of the `takeover()` function

A couple small changes were made to help out with this:

`BASE` is now added to `/etc/profile` and exported from it so all subsequent shells inherit it. The duplicate defines in a few different script entrypoints were removed.

`emergency_shell()` now runs `stty echo` to re-enable input echoing if something like a ZFS password prompt has disabled it.

zlog has a fixed `basename` usage for when it has a `$0` of `-sh`. 

I've tested this by booting a VM and leaving it at the password prompt for the zpool, then SSH'ing in and running `takeover`. This results in the instance attached to ttyS0 dropping to an emergency shell and the password prompt migrating to the SSH connection. Additionally, I've tested entering a password on ttyS0 such that it gets to the main menu and then taking it over via SSH. This also causes ttyS0 to drop to a shell.

In both cases, running `takeover` on the serial console results in the SSH session dropping to a recovery shell again.