### PR TITLE
Dockerfile for creating the EFI image

### DIFF
--- a/contrib/docker/.gitignore
+++ b/contrib/docker/.gitignore
@@ -1,0 +1,2 @@
+config.yaml
+build

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,0 +1,26 @@
+# This Dockerfile creates a container that will create an EFI executable and
+# separate kernel/initramfs components from a ZFSBootMenu repository. The
+# container will pre-populate its /zbm directory with a clone of the master
+# branch of the upstream ZFSBootMenu branch and build the images from that.
+#
+# To use a different ZFSBootMenu repository or version, bind-mound the
+# repository you want on /zbm inside the container.
+
+# Use the official Void Linux container
+FROM voidlinux/voidlinux:latest
+
+# Ensure everything is up-to-date
+RUN xbps-install -Suy xbps && xbps-install -uy
+
+# Install components necessary to build the image
+RUN xbps-query -Rp run_depends zfsbootmenu | xargs xbps-install -y
+RUN xbps-install -y linux linux-headers zfs gummiboot-efistub
+
+# Copy the build script
+COPY zbm-build.sh /zbm-build.sh
+
+# To replace the default ZFSBootMenu tree, bind-mount over /zbm
+VOLUME /zbm
+
+# Make sure a configuration exists or copy the default, then create the images
+CMD /zbm-build.sh

--- a/contrib/docker/config.yaml.default
+++ b/contrib/docker/config.yaml.default
@@ -1,0 +1,22 @@
+Global:
+  # Enable image creation
+  ManageImages: true
+  # Make sure to look for dracut configuration in the repo
+  DracutConfDir: /zbm/etc/zfsbootmenu/dracut.conf.d
+Components:
+  # Dump kernel/initramfs components in the tree;
+  # generate-zbm creates this directory if necessary
+  ImageDir: /zbm/contrib/docker/build
+  Enabled: true
+  # Disable versioning, this is usually a one-off creation
+  Versions: false
+  syslinux:
+    Enabled: false
+EFI:
+  ImageDir: /zbm/contrib/docker/build
+  Versions: false
+  Enabled: true
+Kernel:
+  # For the EFI bundle, turn off modesetting to avoid initializing GPUs
+  # Also set loglevel=4 to provide some helpful warning output
+  CommandLine: zfsbootmenu ro loglevel=4 nomodeset

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -1,0 +1,9 @@
+# This builds the ZFSBootMenu builder and then runs it to create images
+version: "2"
+services:
+    zfsbootmenu-compiler:
+        build: "."
+        # Mount the current repo (../..) where the builder expects it
+        # Outputs will be stored in ../../contrib/docker/build
+        volumes:
+            - "../..:/zbm"

--- a/contrib/docker/zbm-build.sh
+++ b/contrib/docker/zbm-build.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+error() {
+	echo ERROR: "$@"
+	exit 1
+}
+
+# shellcheck disable=SC2010 
+if ls -Aq /zbm | grep -q . >/dev/null 2>&1; then
+	# If /zbm is not empty, make sure it looks like it has what we need
+	[ -d /zbm/90zfsbootmenu ] || error "missing path /zbm/90zfsbootmenu"
+	[ -d /zbm/contrib/docker ] || error "missing path /zbm/contrib/docker"
+	[ -x /zbm/bin/generate-zbm ] || error "missing executable /zbm/bin/generate-zbm"
+else
+	# If /zbm is empty, clone the upstream repo into it
+	xbps-install -Sy git
+	git clone --depth=1 https://github.com/zbm-dev/zfsbootmenu /zbm
+fi
+
+# Make sure that dracut can find the ZFSBootMenu module
+ln -sf /zbm/90zfsbootmenu /usr/lib/dracut/modules.d/90zfsbootmenu
+
+# If there is no provided config, copy the default
+if [ ! -e /zbm/contrib/docker/config.yaml ]; then
+	cp /zbm/contrib/docker/config.yaml.default /zbm/contrib/docker/config.yaml
+fi
+
+exec /zbm/bin/generate-zbm --config /zbm/contrib/docker/config.yaml


### PR DESCRIPTION
This is my first attempt to add a Dockerfile and docker-compose.yml
The Dockerfile is not perfect yet and I am not sure if this is the right way with regards to when to build and which directorys to include at docker build time vs docker runtime.

However if you run:
```
git clone -b feature-docker git@github.com:t-oster/zfsbootmenu.git
cd zfsbootmenu
docker-compose up
```
you end up with a fresh vmlinuz.EFI in your ./out directory.

You can then change the sourcecode at your will and rerun
```
sudo rm -rf out #we need to delete the directory because it was created as root
docker-compose up
```
in order to regenerate the image.