### PR TITLE
[WIP] Recovery shell improvements

### DIFF
--- a/90zfsbootmenu/help-files/134/recovery-shell.pod
+++ b/90zfsbootmenu/help-files/134/recovery-shell.pod
@@ -1,0 +1,31 @@
+[1mNAME[0m
+
+[1mzfsbootmenu[0m - Recovery Shell
+
+[1mCommon Commands[0m
+
+[33mzfsbootmenu[0m
+  Launch the interactive boot environment menu.
+
+[33mzfs-chroot[0m [1mzfs filesystem[0m
+  Enter a chroot of the specified boot environment. The boot environment is mounted [33mread/write[0m if the zpool is imported [33mread/write[0m.
+
+[33mset_rw_pool[0m [1mpool[0m
+  Export, then re-import the pool [33mread/write[0m.
+
+[33mset_ro_pool[0m [1mpool[0m
+  Export, then re-import the pool [33mread-only[0m.
+
+[33mmount_zfs[0m [1mzfs filesystem[0m
+  Mount the filesystem at a unique location and print the mount point.
+
+[33mhelp[0m
+  View the online help system.
+
+[33mlogs[0m
+  View warning/error/debug logs.
+
+[1mAUTHOR[0m
+
+ZFSBootMenu Team <https://github.com/zbm-dev/zfsbootmenu>
+

--- a/90zfsbootmenu/help-files/54/recovery-shell.pod
+++ b/90zfsbootmenu/help-files/54/recovery-shell.pod
@@ -1,0 +1,35 @@
+[1mNAME[0m
+
+[1mzfsbootmenu[0m - Recovery Shell
+
+[1mCommon Commands[0m
+
+[33mzfsbootmenu[0m
+  Launch the interactive boot environment menu.
+
+[33mzfs-chroot[0m [1mzfs filesystem[0m
+  Enter a chroot of the specified boot environment.
+  The boot environment is mounted [33mread/write[0m if the
+  zpool is imported [33mread/write[0m.
+
+[33mset_rw_pool[0m [1mpool[0m
+  Export, then re-import the pool [33mread/write[0m.
+
+[33mset_ro_pool[0m [1mpool[0m
+  Export, then re-import the pool [33mread-only[0m.
+
+[33mmount_zfs[0m [1mzfs filesystem[0m
+  Mount the filesystem at a unique location and print
+  the mount point.
+
+[33mhelp[0m
+  View the online help system.
+
+[33mlogs[0m
+  View warning/error/debug logs.
+
+[1mAUTHOR[0m
+
+ZFSBootMenu Team
+<https://github.com/zbm-dev/zfsbootmenu>
+

--- a/90zfsbootmenu/help-files/94/recovery-shell.pod
+++ b/90zfsbootmenu/help-files/94/recovery-shell.pod
@@ -1,0 +1,32 @@
+[1mNAME[0m
+
+[1mzfsbootmenu[0m - Recovery Shell
+
+[1mCommon Commands[0m
+
+[33mzfsbootmenu[0m
+  Launch the interactive boot environment menu.
+
+[33mzfs-chroot[0m [1mzfs filesystem[0m
+  Enter a chroot of the specified boot environment. The boot environment is mounted [33mread/write[0m
+  if the zpool is imported [33mread/write[0m.
+
+[33mset_rw_pool[0m [1mpool[0m
+  Export, then re-import the pool [33mread/write[0m.
+
+[33mset_ro_pool[0m [1mpool[0m
+  Export, then re-import the pool [33mread-only[0m.
+
+[33mmount_zfs[0m [1mzfs filesystem[0m
+  Mount the filesystem at a unique location and print the mount point.
+
+[33mhelp[0m
+  View the online help system.
+
+[33mlogs[0m
+  View warning/error/debug logs.
+
+[1mAUTHOR[0m
+
+ZFSBootMenu Team <https://github.com/zbm-dev/zfsbootmenu>
+

--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -146,6 +146,7 @@ install() {
   _ret=0
   # shellcheck disable=SC2154
   inst_simple "${moddir}/zfsbootmenu-lib.sh" "/lib/zfsbootmenu-lib.sh" || _ret=$?
+  inst_simple "${moddir}/zfsbootmenu-completions.sh" "/lib/zfsbootmenu-completions.sh" || _ret=$?
   inst_simple "${moddir}/zfsbootmenu-init.sh" "/libexec/zfsbootmenu-init" || _ret=$?
   inst_simple "${moddir}/zfsbootmenu-preview.sh" "/libexec/zfsbootmenu-preview" || _ret=$?
   inst_simple "${moddir}/zfsbootmenu-input.sh" "/libexec/zfsbootmenu-input" || _ret=$?
@@ -317,12 +318,27 @@ EOF
   cat << EOF >> "${initdir}/etc/profile"
 [ -f /lib/zfsbootmenu-lib.sh ] && source /lib/zfsbootmenu-lib.sh
 [ -f /etc/zfsbootmenu.conf ] && source /etc/zfsbootmenu.conf
+
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 export TERM=vt220
+
+zdebug "sourced /etc/profile"
+
+EOF
+
+  # Setup a default environment for all login shells
+  cat << EOF >> "${initdir}/.bashrc"
+[ -f /etc/profile ] && source /etc/profile
+[ -f /lib/zfsbootmenu-completions.sh ] && source /lib/zfsbootmenu-completions.sh
 export PS1="\033[0;33mzfsbootmenu\033[0m \w > "
+
 alias clear="tput clear"
 alias reset="tput reset"
 alias zbm="zfsbootmenu"
 alias logs="zlogtail -f"
+alias help="/libexec/zfsbootmenu-help -L recovery-shell"
+
+zdebug "sourced /.bashrc"
+
 EOF
 }

--- a/90zfsbootmenu/zfsbootmenu-completions.sh
+++ b/90zfsbootmenu/zfsbootmenu-completions.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# shellcheck disable=SC2207
+
+# disabling this allows completions with the @ character
+shopt -u hostcomplete
+
+_zfs-chroot() {
+  local ZFS
+  COMPREPLY=()
+
+  [ "${#COMP_WORDS[@]}" != "2" ] && return
+
+  for SNAP in $( zfs list -H -o name -t snapshot ) ; do
+    ZFS+=("${SNAP}")
+  done
+
+  for FS in $( zfs list -H -o name ) ; do
+    ZFS+=("${FS}")
+  done
+
+  COMPREPLY=( $( compgen -W "${ZFS[*]}" -- "${COMP_WORDS[1]}" ) )
+}
+complete -F _zfs-chroot zfs-chroot
+complete -F _zfs-chroot zfs_chroot
+
+_set_rw_pool() {
+  local ZPOOL
+  COMPREPLY=()
+
+  [ "${#COMP_WORDS[@]}" != "2" ] && return
+
+  for POOL in $( zpool list -H -o name ) ; do
+    if ! is_writable "${POOL}" ; then
+      ZPOOL+=("${POOL}")
+    fi
+  done
+  COMPREPLY=( $( compgen -W "${ZPOOL[*]}" -- "${COMP_WORDS[1]}" ) )
+}
+complete -F _set_rw_pool set_rw_pool
+
+_set_ro_pool() {
+  local ZPOOL
+  COMPREPLY=()
+
+  [ "${#COMP_WORDS[@]}" != "2" ] && return
+
+  for POOL in $( zpool list -H -o name ) ; do
+    if is_writable "${POOL}" ; then
+      ZPOOL+=("${POOL}")
+    fi
+  done
+  COMPREPLY=( $( compgen -W "${ZPOOL[*]}" -- "${COMP_WORDS[1]}" ) )
+}
+complete -F _set_ro_pool set_ro_pool
+
+_mount_zfs() {
+  local ZFS
+  COMPREPLY=()
+
+  [ "${#COMP_WORDS[@]}" != "2" ] && return
+
+  for SNAP in $( zfs list -H -o name -t snapshot ) ; do
+    ZFS+=("${SNAP}")
+  done
+
+  for FS in $( zfs list -H -o name ) ; do
+    ZFS+=("${FS}")
+  done
+
+  COMPREPLY=( $( compgen -W "${ZFS[*]}" -- "${COMP_WORDS[1]}" ) )
+}
+complete -F _mount_zfs mount_zfs

--- a/90zfsbootmenu/zfsbootmenu-help.sh
+++ b/90zfsbootmenu/zfsbootmenu-help.sh
@@ -28,13 +28,14 @@ help_pager() {
   SORTED+=("${FINAL}")
 
   printf '%s\n' "${SORTED[@]}" | ${FUZZYSEL} \
-    --prompt 'Topic >' \
+    --prompt 'Topic > ' \
     --with-nth=2.. \
     --bind pgup:preview-up,pgdn:preview-down \
     --preview="$0 -s {1}" \
     --preview-window="right:${PREVIEW_SIZE}:wrap" \
     --header="$( colorize green "[ESC]" ) $( colorize lightblue "back" )" \
     --tac \
+    --inline-info \
     --ansi
 }
 

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -299,7 +299,7 @@ while true; do
       # This will make all keys in the pool unavailable, but populate_be_list
       # should reload the missing keys in the next iteration, so why unlock here?
       if is_writable "${pool}"; then
-        export_pool "${pool}" && read_write='' import_pool "${pool}"
+        set_ro_pool "${pool}"
       else
         set_rw_pool "${pool}"
       fi

--- a/pod/online/recovery-shell.pod
+++ b/pod/online/recovery-shell.pod
@@ -1,0 +1,45 @@
+=pod
+
+=head1 NAME
+
+B<zfsbootmenu> - Recovery Shell
+
+=head1 Common Commands
+
+=over 2
+
+=item I<zfsbootmenu>
+
+Launch the interactive boot environment menu.
+
+=item I<zfs-chroot> B<zfs filesystem>
+
+Enter a chroot of the specified boot environment. The boot environment is mounted I<read/write> if the zpool is imported I<read/write>.
+
+=item I<set_rw_pool> B<pool>
+
+Export, then re-import the pool I<read/write>.
+
+=item I<set_ro_pool> B<pool>
+
+Export, then re-import the pool I<read-only>.
+
+=item I<mount_zfs> B<zfs filesystem>
+
+Mount the filesystem at a unique location and print the mount point.
+
+=item I<help>
+
+View the online help system.
+
+=item I<logs>
+
+View warning/error/debug logs.
+
+=back
+
+=head2 AUTHOR
+
+ZFSBootMenu Team L<https://github.com/zbm-dev/zfsbootmenu>
+
+=cut


### PR DESCRIPTION
Add a few more niceties to the recovery shell:

- `help` now shows the help pager with recovery shell documentation
- A few useful `-lib` functions now have tab completion so that you can handily interact with ZFS filesystems
- Added a `set_ro_pool` function so that it's available in the recovery shell alongside `set_rw_pool`
- On recovery shell exit, `/etc/mtab` is parsed and all ZFS filesystems are unmounted. This protects against a BE being mounted manually, which will break the discovery process.
- The recovery shell is now invoked as an interactive shell, which causes it to source `/.bashrc`. This allows /etc/profile to stay strictly focused on values that should be used for all bash processes, with prompts, aliases and completions moved to the interactive shells only.