### PR TITLE
Create a global debug/trace log viewer

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -154,6 +154,7 @@ install() {
   inst_simple "${moddir}/zfs-chroot.sh" "/bin/zfs-chroot" || _ret=$?
   inst_simple "${moddir}/zfsbootmenu.sh" "/bin/zfsbootmenu" || _ret=$?
   inst_simple "${moddir}/zlogtail.sh" "/bin/zlogtail" || _ret=$?
+  inst_simple "${moddir}/ztrace.sh" "/bin/ztrace" || _ret=$?
   inst_hook cmdline 95 "${moddir}/zfsbootmenu-parse-commandline.sh" || _ret=$?
   inst_hook pre-mount 90 "${moddir}/zfsbootmenu-preinit.sh" || _ret=$?
 
@@ -272,13 +273,6 @@ install() {
     mark_hostonly /etc/hostid
   fi
 
-  # Check if dmesg supports --noescape
-  if dmesg --noescape -V >/dev/null 2>&1 ; then
-    has_escape=1
-  else
-    has_escape=
-  fi
-
   # Check if fuzzy finder supports the refresh-preview flag
   # Added in fzf 0.22.0
   if command -v "${FUZZY_FIND}" >/dev/null 2>&1 && \
@@ -303,7 +297,6 @@ install() {
   # shellcheck disable=SC2154
   cat << EOF > "${initdir}/etc/zfsbootmenu.conf"
 export BYTE_ORDER=${endian:-le}
-export HAS_NOESCAPE=${has_escape}
 export HAS_REFRESH=${has_refresh}
 export HAS_INFO=${has_info}
 EOF

--- a/90zfsbootmenu/zfsbootmenu-preinit.sh
+++ b/90zfsbootmenu/zfsbootmenu-preinit.sh
@@ -36,6 +36,7 @@ export default_hostid=00bab10c
 export zbm_sort="${zbm_sort}"
 export zbm_set_hostid="${zbm_set_hostid}"
 export zbm_import_delay="${zbm_import_delay}"
+export control_term="${control_term}"
 EOF
 
 getcmdline > "${BASE}/zbm.cmdline"

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -72,7 +72,10 @@ fuzzy_default_options=( "--ansi" "--no-clear"
   "--layout=reverse-list" "--inline-info" "--tac" "--color=16"
   "--bind" '"alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} ]"'
   "--bind" '"ctrl-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} ]"'
-  "--bind" '"ctrl-alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} ]"' )
+  "--bind" '"ctrl-alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} ]"'
+  "--bind" '"alt-t:execute[ /sbin/ztrace > ${control_term} ]"'
+  "--bind" '"ctrl-t:execute[ /sbin/ztrace > ${control_term} ]"'
+  "--bind" '"ctrl-alt-t:execute[ /sbin/ztrace > ${control_term} ]"' )
 
 if [ -n "${HAS_REFRESH}" ] ; then
   fuzzy_default_options+=(

--- a/90zfsbootmenu/zlogtail.sh
+++ b/90zfsbootmenu/zlogtail.sh
@@ -31,8 +31,6 @@ while getopts "cfnl:F:" opt; do
   esac
 done
 
-[ -n "${HAS_NOESCAPE}" ] && NOESCAPE="--noescape"
-
 fuzzy_default_options+=(
  "--no-sort"
  "--ansi"
@@ -63,6 +61,6 @@ elif command -v sk >/dev/null 2>&1; then
 fi
 
 # shellcheck disable=SC2086
-( dmesg -T --time-format reltime ${NOESCAPE} -f ${FACILITY} -l ${LOG_LEVEL} ${FOLLOW} & echo $! >&3 ) \
+( dmesg -T --time-format reltime -f ${FACILITY} -l ${LOG_LEVEL} ${FOLLOW} & echo $! >&3 ) \
   3>"${PID_FILE}" \
   | ${FUZZYSEL}

--- a/90zfsbootmenu/ztrace.sh
+++ b/90zfsbootmenu/ztrace.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#shellcheck disable=SC2086
+
+r="\033[0;31m"
+g="\033[0;32m"
+o="\033[0;33m"
+n="\033[0m"
+
+while read -r line ; do
+  time="${line:0:13}"
+  suffix="${line:14:${#line}}"
+
+  if [ "${suffix:0:3}" != "ZBM" ]; then
+    continue
+  fi
+
+  IFS='|' read -r prefix trace log <<<"${suffix}"
+  IFS=';' read -ra tokens <<<"${trace}"
+
+  ppref="$( printf "%*s" 11 "${prefix}:" )"
+  tpref="$( printf "%*s" 11 "trace:" )"
+
+  pad=' '
+  c="${g}"
+
+  echo -e "${time} ${ppref} ${log}"
+  for token in "${tokens[@]}" ; do
+    IFS=',' read -r func file line <<<"${token}"
+    echo -e "${time} ${tpref}${pad}${r}${func}@${c}${file}${n}#${line}"
+    pad="${pad} "
+    c="${o}"
+  done
+
+done < <( dmesg -T --time-format reltime -f user -l 7 ) | less -R -S +G


### PR DESCRIPTION
The previous debug logging had a few limitations. It encoded color escape sequences in the log line, didn't show the full picture of what was calling what, it tried to wrap log lines to the terminal width, and it generally relied on fzf. This work attempts to address those issues.

Debug log lines are now semi-structured, and take the following form:
` ZBM:[pid]|<function,file,line;..>|<log message>`
`[    3.316907] ZBM:[556]|main,/bin/zfsbootmenu,124;draw_be,/lib/zfsbootmenu-lib.sh,493|selected: mod-r,ztest/ROOT/void`

Because the log lines are now semi-structured, the can be broken down to the component parts by a new tool, `ztrace`, and reconstructed in a more meaningful fashion. Log lines starting with `ZBM` are parsed out according to the above structure.

`ztrace` outputs look like this:

![image](https://user-images.githubusercontent.com/13874853/130308779-441127c0-5603-49e5-b5d6-0fbf267a3c6e.png)

The output is piped into `less -R -S` automatically.