### PR TITLE
Log function/execution errors

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -292,8 +292,8 @@ EOF
 
   # Setup a default environment for all login shells
   cat << EOF >> "${initdir}/etc/profile"
-[ -f /lib/zfsbootmenu-lib.sh ] && source /lib/zfsbootmenu-lib.sh
 [ -f /etc/zfsbootmenu.conf ] && source /etc/zfsbootmenu.conf
+[ -f /lib/zfsbootmenu-lib.sh ] && source /lib/zfsbootmenu-lib.sh
 
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -63,6 +63,16 @@ zerror() {
   zlog 3 "$@"
 }
 
+traperror() {
+  zdebug "trapped error from: '${BASH_COMMAND}'"
+}
+
+if [ ${loglevel:-4} -eq 7 ] ; then
+  set -o errtrace
+  set -o functrace
+  trap traperror ERR
+fi
+
 # arg1: color name
 # arg2...argN: text to color
 # prints: text with color escape codes

--- a/90zfsbootmenu/zfsbootmenu-preinit.sh
+++ b/90zfsbootmenu/zfsbootmenu-preinit.sh
@@ -22,7 +22,7 @@ export BASE="/zfsbootmenu"
 mkdir -p "${BASE}"
 
 # shellcheck disable=SC2154
-cat >> "/etc/profile" <<EOF
+cat >> "/etc/zfsbootmenu.conf" <<EOF
 # Added by zfsbootmenu-preinit.sh
 export BASE="/zfsbootmenu"
 export endian="${endian}"


### PR DESCRIPTION
Add a trap for ERR conditions inside anything that sources `zfsbootmenu-lib.sh`. Right now, the handler simply logs what was being executed to `zdebug`, and takes no further action. This can potentially help us find issues when developing new features / rewriting code.