### PR TITLE
zkexec: recovery shell arbitrary kexec wrapper

### DIFF
--- a/90zfsbootmenu/help-files/134/recovery-shell.pod
+++ b/90zfsbootmenu/help-files/134/recovery-shell.pod
@@ -7,8 +7,12 @@
 [33mzfsbootmenu[0m
   Launch the interactive boot environment menu.
 
-[33mzfs-chroot[0m [1mzfs filesystem[0m
+[33mzfs-chroot[0m [1mfilesystem[0m
   Enter a chroot of the specified boot environment. The boot environment is mounted [33mread/write[0m if the zpool is imported [33mread/write[0m.
+
+[33mzkexec[0m [1mfilesystem[0m [1mkernel[0m [1minitramfs[0m
+  Directly [33mkexec[0m a kernel and initramfs from a boot environment, allowing any kernel and initramfs to be loaded into memory and
+  immediately booted.
 
 [33mset_rw_pool[0m [1mpool[0m
   Export, then re-import the pool [33mread/write[0m.

--- a/90zfsbootmenu/help-files/54/recovery-shell.pod
+++ b/90zfsbootmenu/help-files/54/recovery-shell.pod
@@ -7,10 +7,15 @@
 [33mzfsbootmenu[0m
   Launch the interactive boot environment menu.
 
-[33mzfs-chroot[0m [1mzfs filesystem[0m
+[33mzfs-chroot[0m [1mfilesystem[0m
   Enter a chroot of the specified boot environment.
   The boot environment is mounted [33mread/write[0m if the
   zpool is imported [33mread/write[0m.
+
+[33mzkexec[0m [1mfilesystem[0m [1mkernel[0m [1minitramfs[0m
+  Directly [33mkexec[0m a kernel and initramfs from a boot
+  environment, allowing any kernel and initramfs to be
+  loaded into memory and immediately booted.
 
 [33mset_rw_pool[0m [1mpool[0m
   Export, then re-import the pool [33mread/write[0m.

--- a/90zfsbootmenu/help-files/94/recovery-shell.pod
+++ b/90zfsbootmenu/help-files/94/recovery-shell.pod
@@ -7,9 +7,13 @@
 [33mzfsbootmenu[0m
   Launch the interactive boot environment menu.
 
-[33mzfs-chroot[0m [1mzfs filesystem[0m
+[33mzfs-chroot[0m [1mfilesystem[0m
   Enter a chroot of the specified boot environment. The boot environment is mounted [33mread/write[0m
   if the zpool is imported [33mread/write[0m.
+
+[33mzkexec[0m [1mfilesystem[0m [1mkernel[0m [1minitramfs[0m
+  Directly [33mkexec[0m a kernel and initramfs from a boot environment, allowing any kernel and
+  initramfs to be loaded into memory and immediately booted.
 
 [33mset_rw_pool[0m [1mpool[0m
   Export, then re-import the pool [33mread/write[0m.

--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -156,6 +156,7 @@ install() {
   inst_simple "${moddir}/zfsbootmenu.sh" "/bin/zfsbootmenu" || _ret=$?
   inst_simple "${moddir}/zlogtail.sh" "/bin/zlogtail" || _ret=$?
   inst_simple "${moddir}/ztrace.sh" "/bin/ztrace" || _ret=$?
+  inst_simple "${moddir}/zkexec.sh" "/bin/zkexec" || _ret=$?
   inst_hook cmdline 95 "${moddir}/zfsbootmenu-parse-commandline.sh" || _ret=$?
   inst_hook pre-mount 90 "${moddir}/zfsbootmenu-preinit.sh" || _ret=$?
 

--- a/90zfsbootmenu/zfsbootmenu-completions.sh
+++ b/90zfsbootmenu/zfsbootmenu-completions.sh
@@ -75,6 +75,7 @@ _zkexec() {
   local ARG
   COMPREPLY=()
 
+  shopt -s nullglob
   case "${#COMP_WORDS[@]}" in
     2)
       for FS in $( zfs list -H -o name ) ; do
@@ -87,7 +88,6 @@ _zkexec() {
       mp="$( mount_zfs "${COMP_WORDS[1]}" )"
       [ -d "${mp}/boot" ] || return
 
-      shopt -s nullglob
       for BIN in "${mp}"/boot/* ; do
         BIN="${BIN##*/}"
         ARG+=("${BIN}")

--- a/90zfsbootmenu/zfsbootmenu-completions.sh
+++ b/90zfsbootmenu/zfsbootmenu-completions.sh
@@ -72,11 +72,13 @@ _mount_zfs() {
 complete -F _mount_zfs mount_zfs
 
 _zkexec() {
-  local ARG
+  local ARG index
   COMPREPLY=()
 
   shopt -s nullglob
-  case "${#COMP_WORDS[@]}" in
+
+  index="${#COMP_WORDS[@]}"
+  case "${index}" in
     2)
       for FS in $( zfs list -H -o name ) ; do
         ARG+=("${FS}")
@@ -84,7 +86,7 @@ _zkexec() {
 
       COMPREPLY=( $( compgen -W "${ARG[*]}" -- "${COMP_WORDS[1]}" ) )
     ;;
-    3)
+    3|4)
       mp="$( mount_zfs "${COMP_WORDS[1]}" )"
       [ -d "${mp}/boot" ] || return
 
@@ -93,18 +95,7 @@ _zkexec() {
         ARG+=("${BIN}")
       done
       umount "${mp}"
-      COMPREPLY=( $( compgen -W "${ARG[*]}" -- "${COMP_WORDS[2]}" ) )
-    ;;
-    4)
-      mp="$( mount_zfs "${COMP_WORDS[1]}" )"
-      [ -d "${mp}/boot" ] || return
-
-      for BIN in "${mp}"/boot/* ; do
-        BIN="${BIN##*/}"
-        ARG+=("${BIN}")
-      done
-      umount "${mp}"
-      COMPREPLY=( $( compgen -W "${ARG[*]}" -- "${COMP_WORDS[3]}" ) )
+      COMPREPLY=( $( compgen -W "${ARG[*]}" -- "${COMP_WORDS[$(( index - 1))]}" ) )
     ;;
   esac
 

--- a/90zfsbootmenu/zfsbootmenu-completions.sh
+++ b/90zfsbootmenu/zfsbootmenu-completions.sh
@@ -70,3 +70,43 @@ _mount_zfs() {
   COMPREPLY=( $( compgen -W "${ZFS[*]}" -- "${COMP_WORDS[1]}" ) )
 }
 complete -F _mount_zfs mount_zfs
+
+_zkexec() {
+  local ARG
+  COMPREPLY=()
+
+  case "${#COMP_WORDS[@]}" in
+    2)
+      for FS in $( zfs list -H -o name ) ; do
+        ARG+=("${FS}")
+      done
+
+      COMPREPLY=( $( compgen -W "${ARG[*]}" -- "${COMP_WORDS[1]}" ) )
+    ;;
+    3)
+      mp="$( mount_zfs "${COMP_WORDS[1]}" )"
+      [ -d "${mp}/boot" ] || return
+
+      shopt -s nullglob
+      for BIN in "${mp}"/boot/* ; do
+        BIN="${BIN##*/}"
+        ARG+=("${BIN}")
+      done
+      umount "${mp}"
+      COMPREPLY=( $( compgen -W "${ARG[*]}" -- "${COMP_WORDS[2]}" ) )
+    ;;
+    4)
+      mp="$( mount_zfs "${COMP_WORDS[1]}" )"
+      [ -d "${mp}/boot" ] || return
+
+      for BIN in "${mp}"/boot/* ; do
+        BIN="${BIN##*/}"
+        ARG+=("${BIN}")
+      done
+      umount "${mp}"
+      COMPREPLY=( $( compgen -W "${ARG[*]}" -- "${COMP_WORDS[3]}" ) )
+    ;;
+  esac
+
+}
+complete -F _zkexec zkexec

--- a/90zfsbootmenu/zkexec.sh
+++ b/90zfsbootmenu/zkexec.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# shellcheck disable=SC1091
+[ -f /lib/zfsbootmenu-lib.sh ] && source /lib/zfsbootmenu-lib.sh
+
+if [ $# -ne 3 ] ; then
+ echo "Usage: $0 filesystem kernel initramfs"
+ exit
+fi
+
+fs="${1}"
+kernel="/boot/${2}"
+initramfs="/boot/${3}"
+
+kexec_kernel "${fs} ${kernel} ${initramfs}"

--- a/pod/online/recovery-shell.pod
+++ b/pod/online/recovery-shell.pod
@@ -12,9 +12,13 @@ B<zfsbootmenu> - Recovery Shell
 
 Launch the interactive boot environment menu.
 
-=item I<zfs-chroot> B<zfs filesystem>
+=item I<zfs-chroot> B<filesystem>
 
 Enter a chroot of the specified boot environment. The boot environment is mounted I<read/write> if the zpool is imported I<read/write>.
+
+=item I<zkexec> B<filesystem> B<kernel> B<initramfs>
+
+Directly I<kexec> a kernel and initramfs from a boot environment, allowing any kernel and initramfs to be loaded into memory and immediately booted.
 
 =item I<set_rw_pool> B<pool>
 


### PR DESCRIPTION
`zkexec` is designed to allow you to easily kexec any kernel/initramfs found in /boot contained in a filesystem. It tab completes each parameter but it will NOT validate that the files being loaded are correct for that argument position.