### PR TITLE
Start pushing users to drop /etc/default/grub

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -1253,6 +1253,11 @@ preload_be_cmdline() {
 
   if [ -n "${zfsbe_mnt}" ] && [ -r "${zfsbe_mnt}/etc/default/grub" ]; then
     zdebug "using ${zfsbe_mnt}/etc/default/grub"
+
+    color=green delay=10 timed_prompt "Using KCL from /etc/default/grub on ${zfsbe_fs}" \
+      "This behavior is DEPRECATED and will be removed soon" \
+      "Migrate to an org.zfsbootmenu:commandline property on your BE"
+
     echo "$(
       # shellcheck disable=SC1090,SC1091
       . "${zfsbe_mnt}/etc/default/grub" ;

--- a/90zfsbootmenu/zfsbootmenu-preinit.sh
+++ b/90zfsbootmenu/zfsbootmenu-preinit.sh
@@ -23,7 +23,7 @@ mkdir -p "${BASE}"
 
 # shellcheck disable=SC2154
 cat >> "/etc/zfsbootmenu.conf" <<EOF
-# Added by zfsbootmenu-preinit.sh
+# BEGIN additions by zfsbootmenu-preinit.sh
 export BASE="/zfsbootmenu"
 export endian="${endian}"
 export spl_hostid="${spl_hostid}"
@@ -37,6 +37,7 @@ export zbm_sort="${zbm_sort}"
 export zbm_set_hostid="${zbm_set_hostid}"
 export zbm_import_delay="${zbm_import_delay}"
 export control_term="${control_term}"
+# END additions by zfsbootmenu-preinit.sh
 EOF
 
 getcmdline > "${BASE}/zbm.cmdline"


### PR DESCRIPTION
We're a real bootloader and we hate grub with a passion, so let's start the process of getting users away from its configuration file.

The color of the prompt is up for grabs, but let's stay away from red for now. We'll move red to the last release that supports the file.

Once we drop the deprecated behavior, I think we should hard fail if we detect an /etc/default/grub with non-empty KCL, then provide a simple helper people can run from the recovery shell to migrate the KCL to a property.