### PR TITLE
Allow diffs between two snapshots

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-preview.sh
+++ b/90zfsbootmenu/zfsbootmenu-preview.sh
@@ -43,3 +43,8 @@ fi
 
 colorize "${_COLOR}" "${selected_env_str}\n"
 echo "${selected_arguments}"
+
+if [ -n "${3}" ]; then
+  context="$( center_string "${3}" )"
+  colorize "orange" "${context}"
+fi

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -220,6 +220,9 @@ while true; do
 
       # shellcheck disable=SC2162
       IFS=, read subkey selected_snap <<< "${selection}"
+
+      # two snapshots were potentially returned - discard the second
+      selected_snap="${selected_snap%,*}"
       zdebug "selected snapshot: ${selected_snap}"
 
       # Parent of the selected dataset, must be nonempty
@@ -260,6 +263,9 @@ while true; do
       pre_populated="${selected_snap##*/}"
       # Strip snapshot name and append NEW
       pre_populated="${pre_populated%%@*}_NEW"
+
+      header="$( center_string "${selected_snap}" )"
+      colorize green "${header}"
 
       while true; do
         echo -e "\nNew boot environment name (leave blank to abort)"

--- a/pod/online/snapshot-management.pod
+++ b/pod/online/snapshot-management.pod
@@ -39,7 +39,7 @@ The operation will fail gracefully if the pool can not be set I<read/write>.
 
 =item I<[MOD+D]> B<diff>
 
-Compare the differences between the selected snapshot and the current state of the boot environment.
+Compare the differences between snapshots and filesystems. A single snapshot can be selected and a diff will be generated between that and the current state of the filesystem. Two snapshots can be selected (and deselected) with the tab key and a diff will be generated between them.
 
 The operation will fail gracefully if the pool can not be set I<read/write>.
 


### PR DESCRIPTION
You know what I'd do if I won a million dollars?

Two snapshots at the same time.

Add `--multi 2` to the snapshot browsing screen to pass in up to two arguments to `draw_diff` . If two arguments are passed in, the `creation` value for each snapshot is retrieved and the oldest (smallest) value dictates which snapshot is the first term passed to `zfs diff`. If only one snapshot is passed into `draw_diff`, the previous behavior of comparing that snapshot against the current state of the filesystem is used.

For non-diff browsing actions, the second snapshot (`mod-c,snapshot@1,snapshot@2`) is discarded and the first is exclusively acted upon.  The selected snapshot name is now shown at the top of the screen when creating a new duplicated/cloned boot environment.