### PR TITLE
Snapshot creation, reorganization

### DIFF
--- a/pod/online/snapshot-management.pod
+++ b/pod/online/snapshot-management.pod
@@ -37,6 +37,12 @@ This creates a boot environment from a snapshot with out modifying snapshot inhe
 
 The operation will fail gracefully if the pool can not be set I<read/write>.
 
+=item I<[MOD+N]> B<snapshot creation>
+
+This creates a new snapshot of the currently selected boot environment. A new snapshot is useful if you need to repair a boot environment from a chroot, to allow for easy roll-back of the changes.
+
+The operation will fail gracefully if the pool can not be set I<read/write>.
+
 =item I<[MOD+D]> B<diff>
 
 Compare the differences between snapshots and filesystems. A single snapshot can be selected and a diff will be generated between that and the current state of the filesystem. Two snapshots can be selected (and deselected) with the tab key and a diff will be generated between them.


### PR DESCRIPTION
Some times it's helpful to be able to create a snapshot from the bootloader, outside of the OS. On the snapshot screen, there's now a MOD+N option to create a (N)ew snapshot. It rides along the coat-tails of most of the snapshot cloning/duplication logic, as that has checks for everything we also care about.

The `MOD+S` handler in `zfsbootmenu.sh` was growing quite large. It created a substantial number of global variables. A large part of the logic in this handler has been moved to a dedicated subroutine that does all of the appropriate space checks, user input prompts/checking, and then dispatches to the right snapshot manipulation function.