### PR TITLE
Extend actions to include building images on PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build check
+on: [ pull_request ]
+
+jobs:
+  build:
+    name: Build boot images
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/zbm-dev/zbm-builder
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Create files
+        run: |
+          ln -s "$(pwd)" /zbm
+          [ -x /zbm/releng/docker/zbm-build.sh ] && /zbm/releng/docker/zbm-build.sh
+
+      - name: Archive EFI
+        uses: actions/upload-artifact@v2
+        with:
+          name: EFI
+          path: /zbm/releng/docker/build/*.EFI
+
+      - name: Archive components
+        uses: actions/upload-artifact@v2
+        with:
+          name: Components
+          path: |
+            /zbm/releng/docker/build/*
+            !/zbm/releng/docker/build/*.EFI

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,4 +1,4 @@
-name: ZFS Boot Menu
+name: Analyze scripts
 on: [ push ] 
 
 jobs:
@@ -7,5 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master


### PR DESCRIPTION
Use our fancy-schmancy `zbm-builder` image to build both component and EFI files when a PR is opened. The files are archived according to our repository policy - currently 90 days.