### PR TITLE
Handle empty snapshots list with no-op item

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -565,7 +565,7 @@ draw_kernel() {
 # returns: 130 on error, 0 otherwise
 
 draw_snapshots() {
-  local benv selected header expects sort_key
+  local benv selected header expects sort_key snapshots
 
   benv="${1}"
   if [ -z "${benv}" ]; then
@@ -583,15 +583,18 @@ draw_snapshots() {
 
   expects="--expect=alt-x,alt-c,alt-j,alt-o,alt-n"
 
-  if ! selected="$( zfs list -t snapshot -H -o name "${benv}" -S "${sort_key}" |
-      HELP_SECTION=snapshot-management ${FUZZYSEL} \
+  # ${snapshots} must always be defined so that the mod-n handler can be executed
+  snapshots="$( zfs list -t snapshot -H -o name "${benv}" -S "${sort_key}" )"
+  snapshots="${snapshots:-No snaphots available}"
+
+  if ! selected="$( HELP_SECTION=snapshot-management ${FUZZYSEL} \
         --prompt "Snapshot > " --header="${header}" --tac --multi 2 \
         ${expects} ${expects//alt-/ctrl-} ${expects//alt-/ctrl-alt-} \
         --bind='alt-d:execute[ /libexec/zfunc draw_diff {+} ]' \
         --bind='ctrl-d:execute[ /libexec/zfunc draw_diff {+} ]' \
         --bind='ctrl-alt-d:execute[ /libexec/zfunc draw_diff {+} ]' \
         --preview="/libexec/zfsbootmenu-preview ${benv} ${BOOTFS} '${context}'" \
-        --preview-window="up:$(( PREVIEW_HEIGHT + 1 ))" )"; then
+        --preview-window="up:$(( PREVIEW_HEIGHT + 1 ))" <<<"${snapshots}" )"; then
     return 1
   fi
 

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -229,22 +229,38 @@ while true; do
       selected_snap="${selected_snap%,*}"
       zdebug "selected snapshot: ${selected_snap}"
 
-      case "${subkey}" in
-        "mod-j")
-          zfs_chroot "${selected_snap}"
-          BE_SELECTED=1
-          continue
-        ;;
-        "mod-o")
-          change_sort
-          BE_SELECTED=1
-          continue
-        ;;
-        *)
-          snapshot_dispatcher "${selected_snap}" "${subkey}"
-          continue
-        ;;
-      esac
+      # Detect @ to skip acting on 'No snaphots available'
+      # for anything but mod-n
+
+      if [[ "${selected_snap}" =~ @ ]] ; then 
+        case "${subkey}" in
+          "mod-j")
+            zfs_chroot "${selected_snap}"
+            BE_SELECTED=1
+            continue
+          ;;
+          "mod-o")
+            change_sort
+            BE_SELECTED=1
+            continue
+          ;;
+          *)
+            snapshot_dispatcher "${selected_snap}" "${subkey}"
+            continue
+          ;;
+        esac
+      else
+        case "${subkey}" in
+          "mod-n")
+            snapshot_dispatcher "${selected_be}" "${subkey}"
+            continue
+          ;;
+          *)
+            BE_SELECTED=1
+            continue
+          ;;
+        esac
+      fi
       ;;
     "mod-r")
       tput cnorm


### PR DESCRIPTION
fzf requires something to be selected for --expect keybinds to work. If there are no snapshots, the fzf list is empty and MOD+N can't be triggered.

Detect if there are no snapshots and feed 'No snapshots available' to the snapshot pager. When handling the key + selection after
draw_snapshots() returns, ensure that the selected text has '@' in it, otherwise ignore any action other than creating a new snapshot.