### PR TITLE
Add is_snapshot function

### DIFF
--- a/90zfsbootmenu/zfs-chroot.sh
+++ b/90zfsbootmenu/zfs-chroot.sh
@@ -21,7 +21,7 @@ if mountpoint="$( allow_rw=yes mount_zfs "${selected}" )"; then
   pool="${selected%%/*}"
 
   # Snapshots and read-only pools always produce read-only mounts
-  if [[ "${selected}" =~ @ ]] || ! is_writable "${pool}"; then
+  if is_snapshot "${selected}" || ! is_writable "${pool}"; then
     writemode="$( colorize green "read-only")"
   else
     writemode="$( colorize red "read/write")"

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -229,10 +229,7 @@ while true; do
       selected_snap="${selected_snap%,*}"
       zdebug "selected snapshot: ${selected_snap}"
 
-      # Detect @ to skip acting on 'No snaphots available'
-      # for anything but mod-n
-
-      if [[ "${selected_snap}" =~ @ ]] ; then 
+      if is_snapshot "${selected_snap}" ; then
         case "${subkey}" in
           "mod-j")
             zfs_chroot "${selected_snap}"


### PR DESCRIPTION
What the PR title says - add `is_snapshot` to `-lib.sh` and use it in place of `=~ @` checks. I rewrote the read/write mount logic in `mount_zfs` to be a little more compact/clear.