### PR TITLE
testing: allow installation of multiple distros in one setup run

### DIFF
--- a/testing/helpers/image.sh
+++ b/testing/helpers/image.sh
@@ -241,9 +241,14 @@ if [ -d "${CHROOT_MNT}/zfsbootmenu" ]; then
     for f in vmlinuz-bootmenu initramfs-bootmenu.img; do
       file="${CHROOT_MNT}/zfsbootmenu/build/${f}"
       [ -f "${file}" ] || continue
-      cp "${file}" "${TESTDIR}"
-      chmod 644 "${TESTDIR}/${f}"
-      chown "${USERGROUP}" "${TESTDIR}/${f}"
+
+      cp "${file}" "${TESTDIR}/${f}.${DISTRO}"
+      chmod 644 "${TESTDIR}/${f}.${DISTRO}"
+      chown "${USERGROUP}" "${TESTDIR}/${f}.${DISTRO}"
+
+      if [ ! -e "${TESTDIR}/${f}" ] || [ -L "${TESTDIR}/${f}" ]; then
+        ln -sf "${f}.${DISTRO}" "${TESTDIR}/${f}"
+      fi
     done
   fi
 fi


### PR DESCRIPTION
SUCKS TO YOUR FEATURE FREEZE!

That's right, Iceman. Let's allow installation of multiple distributions into the same pool in a single pass for easier setup of testing environments.

```sh
./setup.sh -a -e -l -o debian -o ubuntu
./setup.sh -a -e -p my-pool-does-not-suck -o arch -o void -o void-musl
```

Still running through some tests.