### PR TITLE
Code removal / cleanup pass

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -96,13 +96,8 @@ install() {
     fi
   done
 
-  # sk can be used as a substitute for fzf
-  if dracut_install fzf; then
-    FUZZY_FIND="fzf"
-  elif dracut_install sk; then
-    FUZZY_FIND="sk"
-  else
-    dfatal "failed to install fzf or sk"
+  if ! dracut_install fzf; then
+    dfatal "failed to install fzf"
     exit 1
   fi
 
@@ -260,22 +255,12 @@ install() {
 
   # Check if fuzzy finder supports the refresh-preview flag
   # Added in fzf 0.22.0
-  if command -v "${FUZZY_FIND}" >/dev/null 2>&1 && \
-    echo "abc" | "${FUZZY_FIND}" -f "abc" --bind "alt-l:refresh-preview" --exit-0 >/dev/null 2>&1
+  if command -v fzf >/dev/null 2>&1 && \
+    echo "abc" | fzf -f "abc" --bind "alt-l:refresh-preview" --exit-0 >/dev/null 2>&1
   then
     has_refresh=1
   else
     has_refresh=
-  fi
-
-  # Check if fuzzy finder supports the --info= flag
-  # Added in fzf 0.19.0
-  if command -v "${FUZZY_FIND}" >/dev/null 2>&1 && \
-    echo "abc" | "${FUZZY_FIND}" -f "abc" --info=hidden --exit-0 >/dev/null 2>&1
-  then
-    has_info=1
-  else
-    has_info=
   fi
 
   # Collect all of our build-time feature flags
@@ -283,7 +268,6 @@ install() {
   cat << EOF > "${initdir}/etc/zfsbootmenu.conf"
 export BYTE_ORDER=${endian:-le}
 export HAS_REFRESH=${has_refresh}
-export HAS_INFO=${has_info}
 EOF
 
   # Embed a kernel command line in the initramfs

--- a/90zfsbootmenu/zfsbootmenu-help.sh
+++ b/90zfsbootmenu/zfsbootmenu-help.sh
@@ -5,8 +5,8 @@
 source /lib/zfsbootmenu-lib.sh
 
 # zfsbootmenu-help invokes itself, so the value of $WIDTH depends
-# on if $0 is launching fzf/sk (-L) or is being launched inside
-# fzf/sk (-s).
+# on if $0 is launching fzf (-L) or is being launched inside
+# fzf (-s).
 
 WIDTH="$( tput cols )"
 PREVIEW_SIZE="$(( WIDTH - 26 ))"

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -562,7 +562,7 @@ draw_kernel() {
 # returns: 130 on error, 0 otherwise
 
 draw_snapshots() {
-  local benv selected header expects sort_key snapshots multi
+  local benv selected header expects sort_key snapshots
 
   benv="${1}"
   if [ -z "${benv}" ]; then
@@ -586,15 +586,8 @@ draw_snapshots() {
 
   zdebug "snapshots: ${snapshots[*]}"
 
-  multi=( "--multi" )
-
-  # skim's --multi doesn't support any arguments
-  if [ "${FUZZYSEL}" == "fzf" ]; then
-    multi+=( "2" )
-  fi
-
   if ! selected="$( HELP_SECTION=snapshot-management ${FUZZYSEL} \
-        --prompt "Snapshot > " --header="${header}" --tac "${multi[@]}" \
+        --prompt "Snapshot > " --header="${header}" --tac --multi 2 \
         ${expects} ${expects//alt-/ctrl-} ${expects//alt-/ctrl-alt-} \
         --bind='alt-d:execute[ /libexec/zfunc draw_diff {+} ]' \
         --bind='ctrl-d:execute[ /libexec/zfunc draw_diff {+} ]' \

--- a/90zfsbootmenu/zlogtail.sh
+++ b/90zfsbootmenu/zlogtail.sh
@@ -1,66 +1,14 @@
 #!/bin/bash
 
-PID_FILE="$( mktemp --tmpdir="${BASE}" )"
-export PID_FILE
-trap 'rm -f ${PID_FILE}' EXIT
-
-#shellcheck disable=SC2154
-LOG_LEVEL="0,1,2,3,4,5,6,7"
-FACILITY="kern,user,daemon"
-ALLOW_EXIT=1
-while getopts "cfnl:F:" opt; do
-  case "${opt}" in
-    l)
-      LOG_LEVEL="${OPTARG}"
-      ;;
-    n)
-      ALLOW_EXIT=0
-      ;;
-    f)
-      FOLLOW="-w"
-      ;;
-    c)
-      [ -f "${BASE}/have_errors" ] && rm "${BASE}/have_errors"
-      [ -f "${BASE}/have_warnings" ] && rm "${BASE}/have_warnings"
-      ;;
-    F)
-      FACILITY="${OPTARG}"
-      ;;
-    *)
-      ;;
-  esac
-done
+[ -f "${BASE}/have_errors" ] && rm "${BASE}/have_errors"
+[ -f "${BASE}/have_warnings" ] && rm "${BASE}/have_warnings"
 
 fuzzy_default_options+=(
- "--no-sort"
- "--ansi"
- "--tac"
+ "--no-sort" "--ansi" "--tac" "--no-mouse"
  "--bind" '"ctrl-q:ignore,ctrl-c:ignore,ctrl-g:ignore,enter:ignore"'
 )
 
-# Any info visibly repaints when following dmesg under tmux
-if [ -n "${HAS_INFO}" ] ; then
-  fuzzy_default_options+=("--info=hidden")
-else
-  fuzzy_default_options+=("--inline-info")
-fi
-
-if ((ALLOW_EXIT)) ; then
-  # shellcheck disable=SC2016
-  fuzzy_default_options+=("--bind" '"esc:execute-silent[ kill $( cat ${PID_FILE} ) ]+abort"')
-else
-  fuzzy_default_options+=("--bind" '"esc:ignore"')
-fi
-
-if command -v fzf >/dev/null 2>&1; then
-  FUZZYSEL=fzf
-  export FZF_DEFAULT_OPTS="--no-mouse ${fuzzy_default_options[*]}"
-elif command -v sk >/dev/null 2>&1; then
-  FUZZYSEL=sk
-  export SKIM_DEFAULT_OPTIONS="${fuzzy_default_options[*]}"
-fi
+export FZF_DEFAULT_OPTS="${fuzzy_default_options[*]}"
 
 # shellcheck disable=SC2086
-( dmesg -T --time-format reltime -f ${FACILITY} -l ${LOG_LEVEL} ${FOLLOW} & echo $! >&3 ) \
-  3>"${PID_FILE}" \
-  | ${FUZZYSEL}
+dmesg -T --time-format reltime -f user,daemon -l err,warn | ${FUZZYSEL}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In broad strokes, it works as follows:
 At this point, you'll be booting into your usual OS-managed kernel and initramfs, along with any arguments needed to correctly boot your system.
 
 This tool makes uses of the following additional software:
- * [fzf](https://github.com/junegunn/fzf) or [skim](https://github.com/lotabout/skim)
+ * [fzf](https://github.com/junegunn/fzf)
  * [kexec-tools](https://github.com/horms/kexec-tools)
  * [mbuffer](http://www.maier-komor.de/mbuffer.html)
  * [Linux Kernel](https://www.kernel.org)
@@ -172,7 +172,7 @@ The [zfsbootmenu(7)](pod/zfsbootmenu.7.pod#zfs-properties) manual page describes
 `bin/generate-zbm` can be used to create an initramfs on your system. It ships with Void-specific defaults in [etc/zfsbootmenu/config.yaml](etc/zfsbootmenu/config.yaml). To create an initramfs, the following additional tools/libraries will need to be available on your system:
 
  * For inclusion in the initramfs:
-   * [fzf](https://github.com/junegunn/fzf) or [skim](https://github.com/lotabout/skim)
+   * [fzf](https://github.com/junegunn/fzf)
    * [kexec-tools](https://github.com/horms/kexec-tools)
    * [mbuffer](http://www.maier-komor.de/mbuffer.html)
  * For running `bin/generate-zbm`:


### PR DESCRIPTION
Skim hasn't seen a release since February 2021. It's starting to miss a
few features that we come to expect in fzf. Additionally, it has a few
rendering bugs / keybind issues that aren't easily resolved.

Removing skim support ends support for any platform not supported by Go,
but ZFS usage on those platforms isn't really common.

With all debug logging now running through the ztrace script, zlogtail
has been heavily simplified. It's now exclusively geared towards showing
warnning and error logs generated by the zwarn() and zerror() functions.

There is a `command -v fzf` test inside zfsbootmenu.sh - this can
possibly be removed. We test for fzf in module-setup.sh and critically
fail if it's missing.