### PR TITLE
Add "settled" and "finished" hooks to force dracut event loop to fire

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -151,6 +151,9 @@ install() {
   inst_simple "${moddir}/zkexec.sh" "/bin/zkexec" || _ret=$?
   inst_hook cmdline 95 "${moddir}/zfsbootmenu-parse-commandline.sh" || _ret=$?
   inst_hook pre-mount 90 "${moddir}/zfsbootmenu-preinit.sh" || _ret=$?
+  # Add hooks to force the dracut event loop to fire at least once
+  inst_hook initqueue/settled 99 "${moddir}/zfsbootmenu-ready-set.sh" || _ret=$?
+  inst_hook initqueue/finished 99 "${moddir}/zfsbootmenu-ready-chk.sh" || _ret=$?
 
   # Install "early setup" hooks
   # shellcheck disable=SC2154

--- a/90zfsbootmenu/zfsbootmenu-preinit.sh
+++ b/90zfsbootmenu/zfsbootmenu-preinit.sh
@@ -43,11 +43,5 @@ getcmdline | sed -e 's/^[ \t]*//' > "${BASE}/zbm.cmdline"
 # Set a non-empty hostname so we show up in zpool history correctly
 echo "ZFSBootMenu" > /proc/sys/kernel/hostname
 
-# try to set console options for display and interaction
-# this is sometimes run as an initqueue hook, but cannot be guaranteed
-#shellcheck disable=SC2154
-[ -x /lib/udev/console_init ] && [ -c "${control_term}" ] \
-  && /lib/udev/console_init "${control_term##*/}" >/dev/null 2>&1
-
 # https://busybox.net/FAQ.html#job_control
 exec setsid bash -c "exec /libexec/zfsbootmenu-init <${control_term} >${control_term} 2>&1"

--- a/90zfsbootmenu/zfsbootmenu-ready-chk.sh
+++ b/90zfsbootmenu/zfsbootmenu-ready-chk.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+test -f /zfsbootmenu/ready

--- a/90zfsbootmenu/zfsbootmenu-ready-set.sh
+++ b/90zfsbootmenu/zfsbootmenu-ready-set.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+mkdir -p /zfsbootmenu
+: > /zfsbootmenu/ready


### PR DESCRIPTION
The only hooks guaranteed to run in the dracut event loop are "finished" hooks. If none are installed (or they all indicate success up front), no other "initqueue" or "settled" hooks will ever run. This includes, e.g., console initialization.

Rather than force console initialization in zfsbootmenu-preinit.sh, let's add a initqueue/settled and initqueue/finished hooks that, respectively, touch and watch for a file. This will force at least one iteration of the entire event loop (except for "timeout" hooks, which may still be short-circuited). If we want, we can make the settled hook more sophisticated and use it to stand up the necessary pre-requisites.

On real hardware, I have confirmed that the initqueue/finished hook runs several times (after other hook categories are run, the finish hooks are re-checked to determine whether to short-circuit the initqueue), the initqueue/settled hook runs at least once, and then the initqueue/finished hook runs a few more times (in my case, because other hooks are holding up the loop) before everything succeeds and ZBM starts.