### PR TITLE
Allow rollbacks from the snapshot menu

### DIFF
--- a/pod/online/snapshot-management.pod
+++ b/pod/online/snapshot-management.pod
@@ -75,6 +75,10 @@ View logs, as indicated by I<[!]>. The indicator will be yellow for warning cond
 
 =back
 
+=item I<[MOD+R]> B<roll back snapshot>
+
+Roll back a boot environment to the selected snapshot. This is a destructive operation that will not proceed without affirmative confirmation.
+
 =head2 AUTHOR
 
 ZFSBootMenu Team L<https://github.com/zbm-dev/zfsbootmenu>


### PR DESCRIPTION
Because BE rollbacks must be done before a system is booted, the justification for allowing rollback within ZBM is much the same as allowing checkpoint rewind. Let's offer this feature.

Missing from this implementation is a preliminary check to determine whether the snapshot being rolled back actually contains kernels. We're giving users a footgun, so I'm not sure we should try to stop them from blowing off the entire leg. (Really, I don't have a fantastic way to check and fail if kernels are missing. We can split `find_be_kernels` to avoid writing output---because we don't want to clobber the kernel list files if we abandon a rollback---and just return 0/1 depending on whether at least one kernel and initramfs appears to exist. I'm open to suggestions here.)