### PR TITLE
Add a documentation linting stage

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,16 @@
+name: Lint documentation
+on: [ push ] 
+
+jobs:
+  documentation:
+    name: Lint documentation 
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+
+    - name: Run pod2man 
+      run: releng/pod2man.sh "${GITHUB_SHA}"
+
+    - name: Run pod2help
+      run: releng/pod2help.sh
+

--- a/releng/pod2help.sh
+++ b/releng/pod2help.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 td="90zfsbootmenu/help-files"
 for size in 54 94 134 ; do

--- a/releng/pod2man.sh
+++ b/releng/pod2man.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e 
 
 release="${1?ERROR: no release version specified}"
 

--- a/releng/tag-release.sh
+++ b/releng/tag-release.sh
@@ -60,8 +60,13 @@ if [ ! -x releng/pod2man.sh ]; then
   error "ERROR: unable to convert documentation"
 fi
 
-releng/pod2man.sh "${release}"
-releng/pod2help.sh
+if ! out="$( releng/pod2man.sh "${release}" )" ; then
+  error "ERROR: ${out}"
+fi
+
+if ! out="$( releng/pod2help.sh )" ; then
+  error "ERROR: ${out}"
+fi
 
 # Generate a short history for CHANGELOG.md
 # git log --format="* %h - %s (%an)" v1.4.1..HEAD


### PR DESCRIPTION
Both pod2man and pod2text default to 'die' on any POD formatting errors. We can leverage that by enabling `set -e` in `pod2man.sh` and `pod2help.sh`. `tag-release.sh` will now also trap any errors from either script and exit accordingly.

See https://github.com/zbm-dev/zfsbootmenu/runs/4584433141?check_suite_focus=true for an example of a forced failure.