### PR TITLE
Support arbitrary colors in timed_prompt(), use getopts for arg parsing

### DIFF
--- a/90zfsbootmenu/bin/zfsbootmenu
+++ b/90zfsbootmenu/bin/zfsbootmenu
@@ -26,7 +26,9 @@ unset src sources
 mkdir -p "${BASE}"
 
 while [ ! -e "${BASE}/initialized" ]; do
-  if ! delay=5 prompt="Press [ESC] to cancel" timed_prompt "Waiting for ZFSBootMenu initialization"; then
+  if ! timed_prompt -d 5 -e "to cancel" \
+    -p "Waiting for ZFSBootMenu initialization"; then
+
     zdebug "exited while waiting for initialization"
     tput cnorm
     tput clear
@@ -38,7 +40,9 @@ done
 
 # If the takeover fails for some reason, spin until it ends
 while [ -e "${BASE}/active" ]; do
-  if ! delay=1 prompt="Press [ESC] to cancel" timed_prompt "Waiting for other ZFSBootMenu instance to terminate"; then
+  if ! timed_prompt -d 1 -e "to cancel" \
+    -p "Waiting for other ZFSBootMenu instance to terminate"; then
+
     zdebug "exited while waiting to own ${BASE}/active"
     tput cnorm
     tput clear
@@ -101,19 +105,9 @@ if [ ${loglevel:-4} -eq 7 ] ; then
   )
 fi
 
-if command -v fzf >/dev/null 2>&1; then
-  export FUZZYSEL=fzf
-  export PREVIEW_HEIGHT=2
-  export FZF_DEFAULT_OPTS="${fuzzy_default_options[*]}"
-else
-  # The menu needs a fuzzy menu
-  color=red delay=10 timed_prompt \
-    "fzf is not available"
-    "Dropping to an emergency shell"
-  tput clear
-  tput cnorm
-  exit 1
-fi
+export FUZZYSEL=fzf
+export PREVIEW_HEIGHT=2
+export FZF_DEFAULT_OPTS="${fuzzy_default_options[*]}"
 
 # Clear screen before a possible password prompt
 tput clear
@@ -133,9 +127,9 @@ while true; do
 
     if [ "${ret}" -eq 130 ]; then
       # No BEs were found, so print a warning and drop to the emergency shell
-      color=red delay=10 timed_prompt \
-        "No boot environments with kernels found" \
-        "Dropping to an emergency shell to allow recovery attempts"
+      timed_prompt -d 10 \
+        -m "$( colorize red "No boot environments with kernels found" )" \
+        -m "$( colorize red "Dropping to an emergency shell to allow recovery attempts" )"
       tput clear
       tput cnorm
       exit 1

--- a/90zfsbootmenu/lib/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/lib/zfsbootmenu-lib.sh
@@ -419,8 +419,8 @@ snapshot_dispatcher() {
         avail_space="$( zfs list -H -o available "${parent_ds}" )"
         be_size="$( zfs list -H -o refer "${selected}" )"
         zerror "Insufficient space for duplication, ${parent_ds}' has ${avail_space} free but needs ${be_size}"
-        color=red delay=10 timed_prompt "Insufficient space for duplication" \
-          "'${parent_ds}' has ${avail_space} free but needs ${be_size}"
+        timed_prompt -m "$( colorize red "Insufficient space for duplication" )" \
+          -m "'$( colorize magenta "${parent_ds}" )' has ${avail_space} free but needs ${be_size}"
         return 1
       fi
   fi

--- a/90zfsbootmenu/libexec/zfsbootmenu-help
+++ b/90zfsbootmenu/libexec/zfsbootmenu-help
@@ -34,7 +34,7 @@ help_pager() {
     --bind pgup:preview-up,pgdn:preview-down \
     --preview="$0 -s {1}" \
     --preview-window="right:${PREVIEW_SIZE}:wrap" \
-    --header="$( colorize green "[ESC]" ) $( colorize lightblue "back" )" \
+    --header="$( colorize green "[ESCAPE]" ) $( colorize lightblue "back" )" \
     --tac --inline-info --ansi --layout="reverse-list"
 }
 

--- a/90zfsbootmenu/libexec/zfsbootmenu-init
+++ b/90zfsbootmenu/libexec/zfsbootmenu-init
@@ -136,8 +136,10 @@ while true; do
   zinfo "unable to import a pool on attempt ${zbm_import_attempt}"
 
   # Just keep retrying after a delay until the user presses ESC
-  if delay="${zbm_import_delay:-5}" prompt="Unable to import ${try_pool:-pool}, retrying in %0.2d seconds" \
-    timed_prompt "[RETURN] to retry immediately" "[ESCAPE] for a recovery shell"; then
+  if timed_prompt -d "${zbm_import_delay:-5}" \
+    -p "Unable to import $( colorize magenta "${try_pool:-pool}" ), retrying in $( colorize yellow "%0.2d" ) seconds" \
+    -r "to retry immediately" \
+    -e "for a recovery shell"; then
       continue
   fi
 
@@ -168,7 +170,8 @@ done <<<"$( zpool get all -H -o name,property )"
 
 if [ "${unsupported}" -ne 0 ]; then
   zerror "Unsupported features detected, Upgrade ZFS modules in ZFSBootMenu with generate-zbm"
-  color=red timed_prompt "Unsupported features detected" "Upgrade ZFS modules in ZFSBootMenu with generate-zbm"
+  timed_prompt -m "$( colorize red 'Unsupported features detected')" \
+    -m "$( colorize red 'Upgrade ZFS modules in ZFSBootMenu with generate-zbm')"
 fi
 
 # Attempt to find the bootfs property
@@ -194,7 +197,10 @@ fi
 if [ "${menu_timeout}" -ge 0 ] && [ -n "${BOOTFS}" ]; then
   # Draw a countdown menu
   # shellcheck disable=SC2154
-  if delay="${menu_timeout}" prompt="Booting ${BOOTFS} in %0.${#menu_timeout}d seconds" timed_prompt "[ENTER] to boot" "[ESC] boot menu" ; then
+  if timed_prompt -d "${menu_timeout}" \
+    -p "Booting $( colorize cyan "${BOOTFS}" ) in $( colorize yellow "%0.${#menu_timeout}d" ) seconds" \
+    -r "boot now " \
+    -e "boot menu" ; then
     # This lock file is present if someone has SSH'd to take control
     # Do not attempt to automatically boot if present
     if [ ! -e "${BASE}/active" ] ; then


### PR DESCRIPTION
The function `decolorize()` has been added to strip color sequences from an arbitrary string and then echo the string for capture. With this function, we can now embed any number of color escape sequences in a string and then later strip them out to determine the 'on screen' size of the string for left pad purposes.

`timed_prompt()` now has arguments passed to it via `getopts`, so that we can more easily see exactly what is being passed to the function. I've semi-settled on a default color scheme for prompts and messages:

`[ESCAPE]` should be `red` in prompts/messages
`[RETURN]` should be `green` in prompts/messages

A ZFS pool or dataset should be `magenta`
A ZFS property should be `orange`
The countdown timer digits should be `yellow`

I've normalized all timed_prompt invocations to the new format, and tested the following prompts:

GRUB migration
Refusing to import r/w due to degraded status
Unable to find any kernels in a boot environment