### PR TITLE
Improve KCL manipulations, drop dracut-lib dependency

### DIFF
--- a/90zfsbootmenu/bin/zfsbootmenu
+++ b/90zfsbootmenu/bin/zfsbootmenu
@@ -278,7 +278,7 @@ while true; do
       cmdline="$( /libexec/zfsbootmenu-input "${def_args}" )"
 
       if [ -n "${cmdline}" ] ; then
-        echo "${cmdline}" > "${BASE}/cmdline"
+        kcl_tokenize <<< "${cmdline}" > "${BASE}/cmdline"
       fi
       ;;
     "mod-j")

--- a/90zfsbootmenu/bin/zfsbootmenu
+++ b/90zfsbootmenu/bin/zfsbootmenu
@@ -23,7 +23,7 @@ unset src sources
 # Make sure /dev/zfs exists, otherwise drop to a recovery shell
 [ -e /dev/zfs ] || emergency_shell "/dev/zfs missing, check that kernel modules are loaded"
 
-mkdir -p "${BASE}"
+mkdir -p "${BASE:=/zfsbootmenu}"
 
 while [ ! -e "${BASE}/initialized" ]; do
   if ! timed_prompt -d 5 -e "to cancel" \

--- a/90zfsbootmenu/hook/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/hook/zfsbootmenu-parse-commandline.sh
@@ -2,7 +2,8 @@
 # vim: softtabstop=2 shiftwidth=2 expandtab
 
 # shellcheck disable=SC1091
-. /lib/dracut-lib.sh
+source /lib/dracut-lib.sh
+source /lib/kmsg-log-lib.sh >/dev/null 2>&1
 
 # Source options detected at build time
 # shellcheck disable=SC1091
@@ -15,7 +16,7 @@ if [ -n "${embedded_kcl}" ]; then
 fi
 
 if [ -z "${BYTE_ORDER}" ]; then
-  warn "unable to determine platform endianness; assuming little-endian"
+  zwarn "unable to determine platform endianness; assuming little-endian"
   BYTE_ORDER="le"
 fi
 
@@ -42,7 +43,7 @@ if [ -n "${cli_spl_hostid}" ] ; then
     spl_hostid=0
   # Not valid hex or dec, log
   else
-    warn "ZFSBootMenu: invalid hostid value ${cli_spl_hostid}, ignoring"
+    zwarn "invalid hostid value ${cli_spl_hostid}, ignoring"
   fi
 fi
 
@@ -50,10 +51,10 @@ fi
 control_term=$( getarg console )
 if [ -n "${control_term}" ]; then
   control_term="/dev/${control_term%,*}"
-  info "ZFSBootMenu: setting controlling terminal to: ${control_term}"
+  zinfo "setting controlling terminal to: ${control_term}"
 else
   control_term="/dev/tty1"
-  info "ZFSBootMenu: defaulting controlling terminal to: ${control_term}"
+  zinfo "defaulting controlling terminal to: ${control_term}"
 fi
 
 # Use loglevel to determine logging to /dev/kmsg
@@ -62,7 +63,7 @@ loglevel=$( getarg loglevel )
 if [ -n "${loglevel}" ]; then
   # minimum log level of 4, so we never lose error or warning messages
   [ "${loglevel}" -ge ${min_logging} ] || loglevel=${min_logging}
-  info "ZFSBootMenu: setting log level from command line: ${loglevel}"
+  zinfo "setting log level from command line: ${loglevel}"
 else
   loglevel=${min_logging}
 fi
@@ -76,42 +77,42 @@ if [ -n "${import_policy}" ]; then
   case "${import_policy}" in
     hostid)
       if [ "${BYTE_ORDER}" = "be" ]; then
-        info "ZFSBootMenu: invalid option for big endian systems"
-        info "ZFSBootMenu: setting import_policy to strict"
+        zwarn "invalid option for big endian systems"
+        zinfo "setting import_policy to strict"
         import_policy="strict"
       else
-        info "ZFSBootMenu: setting import_policy to hostid matching"
+        zinfo "setting import_policy to hostid matching"
       fi
       ;;
     force)
-      info "ZFSBootMenu: setting import_policy to force"
+      zinfo "setting import_policy to force"
       ;;
     strict)
-      info "ZFSBootMenu: setting import_policy to strict"
+      zinfo "setting import_policy to strict"
       ;;
     *)
-      info "ZFSBootMenu: unknown import policy ${import_policy}, defaulting to hostid"
+      zinfo "unknown import policy ${import_policy}, defaulting to hostid"
       import_policy="hostid"
       ;;
   esac
 elif getargbool 0 zbm.force_import -d force_import ; then
   import_policy="force"
-  info "ZFSBootMenu: setting import_policy to force"
+  zinfo "setting import_policy to force"
 else
-  info "ZFSBootMenu: defaulting import_policy to hostid"
+  zinfo "defaulting import_policy to hostid"
   import_policy="hostid"
 fi
 
 # zbm.timeout= overrides timeout=
 menu_timeout=$( getarg zbm.timeout -d timeout )
 if [ -n "${menu_timeout}" ]; then
-  info "ZFSBootMenu: setting menu timeout from command line: ${menu_timeout}"
+  zinfo "setting menu timeout from command line: ${menu_timeout}"
 elif getargbool 0 zbm.show ; then
   menu_timeout=-1;
-  info "ZFSBootMenu: forcing display of menu"
+  zinfo "forcing display of menu"
 elif getargbool 0 zbm.skip ; then
   menu_timeout=0;
-  info "ZFSBootMenu: skipping display of menu"
+  zinfo "skipping display of menu"
 else
   menu_timeout=10
 fi
@@ -119,7 +120,7 @@ fi
 zbm_import_delay=$( getarg zbm.import_delay )
 if [ "${zbm_import_delay:-0}" -gt 0 ] 2>/dev/null ; then
   # Again, this validates that zbm_import_delay is numeric in addition to logging
-  info "ZFSBootMenu: import retry delay is ${zbm_import_delay} seconds"
+  zinfo "import retry delay is ${zbm_import_delay} seconds"
 else
   zbm_import_delay=5
 fi
@@ -155,22 +156,22 @@ if [ -n "${sort_key}" ] ; then
     fi
   done
 
-  info "ZFSBootMenu: setting sort key order to ${zbm_sort}"
+  zinfo "setting sort key order to ${zbm_sort}"
 else
   zbm_sort="name;creation;used"
-  info "ZFSBootMenu: defaulting sort key order to ${zbm_sort}"
+  zinfo "defaulting sort key order to ${zbm_sort}"
 fi
 
 # shellcheck disable=SC2034
 if [ "${BYTE_ORDER}" = "be" ]; then
   zbm_set_hostid=0
-  info "ZFSBootMenu: big endian detected, disabling automatic replacement of spl_hostid"
+  zinfo "big endian detected, disabling automatic replacement of spl_hostid"
 elif getargbool 1 zbm.set_hostid ; then
   zbm_set_hostid=1
-  info "ZFSBootMenu: enabling automatic replacement of spl_hostid"
+  zinfo "enabling automatic replacement of spl_hostid"
 else
   zbm_set_hostid=0
-  info "ZFSBootMenu: disabling automatic replacement of spl_hostid"
+  zinfo "disabling automatic replacement of spl_hostid"
 fi
 
 # rewrite root=
@@ -188,7 +189,7 @@ case "${root}" in
     rootok=1
     wait_for_zfs=1
 
-    info "ZFSBootMenu: enabling menu after udev settles"
+    zinfo "enabling menu after udev settles"
     ;;
   zfsbootmenu:POOL=*)
     # Prefer a specific pool for bootfs value, root=zfsbootmenu:POOL=zroot
@@ -197,7 +198,7 @@ case "${root}" in
     rootok=1
     wait_for_zfs=1
 
-    info "ZFSBootMenu: preferring ${root} for bootfs"
+    zinfo "preferring ${root} for bootfs"
     ;;
 esac
 

--- a/90zfsbootmenu/hook/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/hook/zfsbootmenu-parse-commandline.sh
@@ -28,8 +28,7 @@ if [ -n "${embedded_kcl}" ]; then
 fi
 
 # Make sure a base directory exists
-export BASE="/zfsbootmenu"
-mkdir -p "${BASE}"
+mkdir -p "${BASE:=/zfsbootmenu}"
 
 if [ -z "${BYTE_ORDER}" ]; then
   zwarn "unable to determine platform endianness; assuming little-endian"

--- a/90zfsbootmenu/hook/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/hook/zfsbootmenu-parse-commandline.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
 # vim: softtabstop=2 shiftwidth=2 expandtab
 
-# shellcheck disable=SC1091
-source /lib/dracut-lib.sh
-source /lib/kmsg-log-lib.sh >/dev/null 2>&1
+# Critical functions
+sources=(
+  /lib/kmsg-log-lib.sh
+  /lib/zfsbootmenu-kcl.sh
+)
+
+for src in "${sources[@]}"; do
+  # shellcheck disable=SC1090
+  if ! source "${src}" >/dev/null 2>&1; then
+    echo -e "\033[0;31mWARNING: ${src} was not sourced, unable to proceed\033[0m"
+    exec /bin/bash
+  fi
+done
+
+unset src sources
 
 # Source options detected at build time
 # shellcheck disable=SC1091
@@ -15,6 +27,10 @@ if [ -n "${embedded_kcl}" ]; then
   echo "${embedded_kcl}" > /etc/cmdline.d/zfsbootmenu.conf
 fi
 
+# Make sure a base directory exists
+export BASE="/zfsbootmenu"
+mkdir -p "${BASE}"
+
 if [ -z "${BYTE_ORDER}" ]; then
   zwarn "unable to determine platform endianness; assuming little-endian"
   BYTE_ORDER="le"
@@ -22,8 +38,7 @@ fi
 
 # Let the command line override our host id.
 # shellcheck disable=SC2034
-cli_spl_hostid=$( getarg spl.spl_hostid ) || cli_spl_hostid=$( getarg spl_hostid )
-if [ -n "${cli_spl_hostid}" ] ; then
+if cli_spl_hostid=$( get_zbm_arg spl.spl_hostid spl_hostid ) && [ -n "${cli_spl_hostid}" ]; then
   # Start empty so only valid hostids are set for future use
   spl_hostid=
 
@@ -48,7 +63,7 @@ if [ -n "${cli_spl_hostid}" ] ; then
 fi
 
 # Use the last defined console= to control menu output
-control_term=$( getarg console )
+control_term=$( get_zbm_arg console )
 if [ -n "${control_term}" ]; then
   control_term="/dev/${control_term%,*}"
   zinfo "setting controlling terminal to: ${control_term}"
@@ -59,7 +74,7 @@ fi
 
 # Use loglevel to determine logging to /dev/kmsg
 min_logging=4
-loglevel=$( getarg loglevel )
+loglevel=$( get_zbm_arg loglevel )
 if [ -n "${loglevel}" ]; then
   # minimum log level of 4, so we never lose error or warning messages
   [ "${loglevel}" -ge ${min_logging} ] || loglevel=${min_logging}
@@ -72,7 +87,7 @@ fi
 # force  - append -f to zpool import
 # strict - legacy behavior, drop to an emergency shell on failure
 
-import_policy=$( getarg zbm.import_policy )
+import_policy=$( get_zbm_arg zbm.import_policy )
 if [ -n "${import_policy}" ]; then
   case "${import_policy}" in
     hostid)
@@ -95,7 +110,7 @@ if [ -n "${import_policy}" ]; then
       import_policy="hostid"
       ;;
   esac
-elif getargbool 0 zbm.force_import -d force_import ; then
+elif get_zbm_bool 0 zbm.force_import force_import ; then
   import_policy="force"
   zinfo "setting import_policy to force"
 else
@@ -104,20 +119,20 @@ else
 fi
 
 # zbm.timeout= overrides timeout=
-menu_timeout=$( getarg zbm.timeout -d timeout )
+menu_timeout=$( get_zbm_arg zbm.timeout timeout )
 if [ -n "${menu_timeout}" ]; then
   zinfo "setting menu timeout from command line: ${menu_timeout}"
-elif getargbool 0 zbm.show ; then
+elif get_zbm_bool 0 zbm.show ; then
   menu_timeout=-1;
   zinfo "forcing display of menu"
-elif getargbool 0 zbm.skip ; then
+elif get_zbm_bool 0 zbm.skip ; then
   menu_timeout=0;
   zinfo "skipping display of menu"
 else
   menu_timeout=10
 fi
 
-zbm_import_delay=$( getarg zbm.import_delay )
+zbm_import_delay=$( get_zbm_arg zbm.import_delay )
 if [ "${zbm_import_delay:-0}" -gt 0 ] 2>/dev/null ; then
   # Again, this validates that zbm_import_delay is numeric in addition to logging
   zinfo "import retry delay is ${zbm_import_delay} seconds"
@@ -127,13 +142,13 @@ fi
 
 # Allow setting of console size; there are no defaults here
 # shellcheck disable=SC2034
-zbm_lines=$( getarg zbm.lines )
+zbm_lines=$( get_zbm_arg zbm.lines )
 # shellcheck disable=SC2034
-zbm_columns=$( getarg zbm.columns )
+zbm_columns=$( get_zbm_arg zbm.columns )
 
 # Allow sorting based on a key
 zbm_sort=
-sort_key=$( getarg zbm.sort_key )
+sort_key=$( get_zbm_arg zbm.sort_key )
 if [ -n "${sort_key}" ] ; then
   valid_keys=( "name" "creation" "used" )
   for key in "${valid_keys[@]}"; do
@@ -166,7 +181,7 @@ fi
 if [ "${BYTE_ORDER}" = "be" ]; then
   zbm_set_hostid=0
   zinfo "big endian detected, disabling automatic replacement of spl_hostid"
-elif getargbool 1 zbm.set_hostid ; then
+elif get_zbm_bool 1 zbm.set_hostid ; then
   zbm_set_hostid=1
   zinfo "enabling automatic replacement of spl_hostid"
 else
@@ -175,7 +190,7 @@ else
 fi
 
 # rewrite root=
-prefer=$( getarg zbm.prefer )
+prefer=$( get_zbm_arg zbm.prefer )
 if [ -n "${prefer}" ]; then
   root="zfsbootmenu:POOL=${prefer}"
 fi

--- a/90zfsbootmenu/hook/zfsbootmenu-preinit.sh
+++ b/90zfsbootmenu/hook/zfsbootmenu-preinit.sh
@@ -21,7 +21,7 @@ export BASE="/zfsbootmenu"
 # shellcheck disable=SC2154
 cat >> "/etc/zfsbootmenu.conf" <<EOF
 # BEGIN additions by zfsbootmenu-preinit.sh
-export BASE="/zfsbootmenu"
+export BASE="${BASE}"
 export endian="${endian}"
 export spl_hostid="${spl_hostid}"
 export import_policy="${import_policy}"

--- a/90zfsbootmenu/hook/zfsbootmenu-preinit.sh
+++ b/90zfsbootmenu/hook/zfsbootmenu-preinit.sh
@@ -17,7 +17,6 @@ if ! [[ ${control_term} =~ ${tty_re} ]]; then
 fi
 
 export BASE="/zfsbootmenu"
-mkdir -p "${BASE}"
 
 # shellcheck disable=SC2154
 cat >> "/etc/zfsbootmenu.conf" <<EOF
@@ -37,8 +36,6 @@ export zbm_import_delay="${zbm_import_delay}"
 export control_term="${control_term}"
 # END additions by zfsbootmenu-preinit.sh
 EOF
-
-getcmdline | sed -e 's/^[ \t]*//' > "${BASE}/zbm.cmdline"
 
 # Set a non-empty hostname so we show up in zpool history correctly
 echo "ZFSBootMenu" > /proc/sys/kernel/hostname

--- a/90zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/90zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -6,7 +6,10 @@
 readonly _ZFSBOOTMENU_CORE=1
 
 # shellcheck disable=1091
-source /lib/zfsbootmenu-kcl.sh >/dev/null 2>&1 || exit 1
+if ! source /lib/zfsbootmenu-kcl.sh >/dev/null 2>&1; then
+  zerror "failed to load KCL manipulation functions"
+  exit 1
+fi
 
 # arg1: text with color sequences
 # prints: text with color sequences removed
@@ -1014,7 +1017,7 @@ load_be_cmdline() {
   # Default KCL is very basic
   zfsbe_args="$( kcl_tokenize <<< "quiet loglevel=4" )"
 
-  # Use 
+  # Use a BE-specific KCL if one is preovided
   if [ -r "${BASE}/${zfsbe_fs}/cmdline" ]; then
     zdebug "using ${BASE}/${zfsbe_fs}/cmdline as commandline for ${zfsbe_fs}"
     zfsbe_args="$( kcl_suppress root < "${BASE}/${zfsbe_fs}/cmdline" )"
@@ -1022,8 +1025,8 @@ load_be_cmdline() {
 
   if [ -e "${BASE}/noresume" ]; then
     zdebug "${BASE}/noresume set, processing: '${zfsbe_args}'"
-    # Must replace resume= arguments and append a noresume
-    zfsbe_args="$( kcl_suppress resume <<< "${zfsbe_args}" | kcl_append noresume )" 
+    # Must drop resume= arguments and append a noresume
+    zfsbe_args="$( kcl_suppress resume <<< "${zfsbe_args}" | kcl_append noresume )"
   fi
 
   # shellcheck disable=SC2154

--- a/90zfsbootmenu/lib/zfsbootmenu-kcl.sh
+++ b/90zfsbootmenu/lib/zfsbootmenu-kcl.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# vim: softtabstop=2 shiftwidth=2 expandtab
+
+# Include guard
+[ -n "${_ZFSBOOTMENU_KCL}" ] && return
+readonly _ZFSBOOTMENU_KCL=1
+
+# args: none
+# prints: tokenization of KCL [read from stdin]: one argument per line
+
+kcl_tokenize() {
+  awk '
+    BEGIN {
+      strt = 1;
+      quot = 0;
+    }
+
+    {
+      for (i=1; i <= NF; i++) {
+        # If an odd number of quotes are in this field, toggle quoting
+        if ( gsub(/"/, "\"", $(i)) % 2 == 1 ) {
+          quot = (quot + 1) % 2;
+        }
+
+        # Print a space if this is not the start of a line
+        if (strt == 0) {
+          printf " ";
+        }
+
+        printf "%s", $(i);
+
+        if (quot == 0) {
+          strt = 1;
+          printf "\n";
+        } else {
+          strt = 0;
+        }
+      }
+    }
+  '
+}
+
+# arg1: ZFS filesystem
+# prints: value of org.zfsbootmenu:commandline, with %{parent} recursively expanded
+# returns: 0 on success
+
+read_kcl_prop() {
+  local zfsbe args parfs par_args inherited
+
+  zfsbe="${1}"
+  if [ -z "${zfsbe}" ]; then
+    zerror "zfsbe is undefined"
+    return 1
+  fi
+
+  if ! args="$( zfs get -H -o value org.zfsbootmenu:commandline "${zfsbe}" )"; then
+    zerror "unable to read org.zfsbootmenu:commandline on ${zfsbe}"
+    return 1
+  fi
+
+  # KCL is empty, nothing to see
+  if [ "${args}" = "-" ]; then
+    zdebug "org.zfsbootmenu:commandline on ${zfsbe} has no value"
+    echo ""
+    return 0
+  fi
+
+  # KCL does not specify parent inheritance, just return the args
+  if ! [[ "${args}" =~ "%{parent}" ]]; then
+    zdebug "no parent reference in org.zfsbootmenu:commandline on ${zfsbe}"
+    echo "${args}"
+    return 0
+  fi
+
+  # Need to recursively expand "%{parent}"
+
+  parfs="${zfsbe%/*}"
+  if [ -z "${parfs}" ] || [ "${parfs}" = "${zfsbe}" ]; then
+    # There is no parent, par_args is empty
+    par_args=""
+  else
+    # Query the parent for KCL properties
+    if ! par_args="$( read_kcl_prop "${parfs}" )"; then
+      zwarn "failed to invoke read_kcl_prop on parent ${parfs}"
+      par_args=""
+    fi
+
+    # When the KCL property is inherited, recursive expansion fully populates
+    # the KCL at the level of the ancestor that actually defines the property.
+    if inherited="$( zfs get -H -o source -s inherited org.zfsbootmenu:commandline "${zfsbe}" 2>/dev/null )"; then
+      # Inherited property have a source of "inherited from <ancestor>";
+      # non-inherited properties will not be printed with `-s inherited`
+      if [ -n "${inherited}" ]; then
+        zdebug "org.zfsbootmenu:commandline on ${zfsbe} is inherited, using parent expansion verbatim"
+        echo "${par_args}"
+        return 0
+      fi
+    fi
+  fi
+
+  echo "${args//%\{parent\}/${par_args}}"
+  return 0
+}
+
+# arg1..argN: keys (and, optionally, associated value) to suppress from KCL
+# prints: tokenized KCL [read from stdin] with suppressed arguments removed
+
+kcl_suppress() {
+  local arg rem sup
+  while read -r arg; do
+    # Check match against all exclusions
+    sup=0
+    for rem in "$@"; do
+      # Arguments match entirely or up to first equal
+      if [ "${arg}" = "${rem}" ] || [ "${arg%%=*}" = "${rem}" ]; then
+        sup=1
+        break
+      fi
+    done
+
+    # Echo argument if it was not suppressed
+    [ "${sup}" -ne 1 ] && echo "${arg}"
+  done
+}
+
+# args1..argN: keys (and values, as appropriate) to append to a tokenized KCL
+# prints: tokenized KCL [read from stdin] with appended arguments
+
+kcl_append() {
+  local arg
+
+  # Carry forward input KCL
+  cat
+
+  # Append one line per argument
+  for arg in "$@"; do
+    echo "$arg"
+  done
+}
+
+
+# args: none
+# prints: space-separated concatenation of tokenized KCL [read from stdin]
+
+kcl_assemble() {
+  awk '
+    BEGIN{ strt = 1; }
+
+    {
+      if (strt == 0) {
+        printf " ";
+      }
+
+      printf "%s", $0;
+      strt = 0;
+    }
+  '
+}
+
+# prints: contents of $BASE/zbm.cmdline, assembled as KCL
+
+zbmcmdline() {
+  [ -r "${BASE}/zbm.cmdline" ] && kcl_assemble < "${BASE}/zbm.cmdline"
+  echo 
+}

--- a/90zfsbootmenu/libexec/zfsbootmenu-init
+++ b/90zfsbootmenu/libexec/zfsbootmenu-init
@@ -23,8 +23,8 @@ done
 
 unset src sources
 
+[ -n "${BASE}" ] || export BASE="/zfsbootmenu"
 mkdir -p "${BASE}"
-getcmdline | kcl_tokenize > "${BASE}/zbm.cmdline"
 
 # Attempt to load spl normally
 if ! _modload="$( modprobe spl 2>&1 )" ; then

--- a/90zfsbootmenu/libexec/zfsbootmenu-init
+++ b/90zfsbootmenu/libexec/zfsbootmenu-init
@@ -23,8 +23,7 @@ done
 
 unset src sources
 
-[ -n "${BASE}" ] || export BASE="/zfsbootmenu"
-mkdir -p "${BASE}"
+mkdir -p "${BASE:=/zfsbootmenu}"
 
 # Attempt to load spl normally
 if ! _modload="$( modprobe spl 2>&1 )" ; then

--- a/90zfsbootmenu/libexec/zfsbootmenu-init
+++ b/90zfsbootmenu/libexec/zfsbootmenu-init
@@ -7,6 +7,7 @@ trap '' SIGINT
 # Source functional libraries, logging and configuration
 sources=(
   /etc/zfsbootmenu.conf
+  /lib/zfsbootmenu-kcl.sh
   /lib/zfsbootmenu-core.sh
   /lib/kmsg-log-lib.sh
   /etc/profile
@@ -23,6 +24,7 @@ done
 unset src sources
 
 mkdir -p "${BASE}"
+getcmdline | kcl_tokenize > "${BASE}/zbm.cmdline"
 
 # Attempt to load spl normally
 if ! _modload="$( modprobe spl 2>&1 )" ; then

--- a/bin/zbm-kcl
+++ b/bin/zbm-kcl
@@ -206,7 +206,7 @@ done
 
 shift $((OPTIND-1))
 
-zbm_load_lib "zfsbootmenu-core.sh"
+zbm_load_lib "zfsbootmenu-kcl.sh"
 zbm_load_lib "echo-log-lib.sh"
 
 bootenv="${1}"
@@ -247,23 +247,13 @@ if [ "${havemods}" != "yes" ]; then
 fi
 
 # Act on raw KCL argument for append/remove operations
-if ! kcl="$(raw_kcl "${bootenv}")"; then
+if ! kcl="$(raw_kcl "${bootenv}" | kcl_tokenize )"; then
   zerror "failed to read KCL for ${bootenv}"
   exit 1
 fi
 
-# Strip all unwanted arguments from the KCL
-for rem in "${removes[@]}"; do
-  kcl="$(suppress_kcl_arg "${rem}" "${kcl}")" || exit 1
-done
-
-for add in "${appends[@]}"; do
-  if [ -z "${kcl}" ]; then
-    kcl="${add}"
-  else
-    kcl+=" ${add}"
-  fi
-done
+# Strip and append arguments
+kcl="$( kcl_suppress "${removes[@]}" <<< "${kcl}" | kcl_append "${appends[@]}" | kcl_assemble )"
 
 if ! zfs set org.zfsbootmenu:commandline="${kcl}" "${bootenv}"; then
   zerror "failed to set ZBM KCL"


### PR DESCRIPTION
I think this branch is ready for review and **thorough** testing.

Two things to consider:
1. We `mkdir -p ${BASE}` in a few places. We agree this redundancy is useful, but shoud we also *define* a default value `BASE=/zfsbootmenu` in all of these places? Right now `bin/zfsbootmenu` will make the directory but doesn't care if the value is set and this should probably change.
2. The new `zfsbootmenu-parse-commandline.sh` relies on the new `get_zbm_arg` and `get_zbm_bool` to write a cache file at `${BASE}/zbm.cmdline` that is also read by the `zbmcmdline` interactive helper. Should we manage the caching of the ZBM KCL in a different fashion?

These changes put us within striking distance of also supporting `mkinitcpio` or other initramfs generators. All we need are installation and "hook" scripts for each to populate the needed components and invoke -preinint as necessary. (At that point, we probably want to separate out the ZBM configuration part of `zfsbootmenu-parse-commandline.sh` to be independent of dracut assumptions.)