### PR TITLE
Pare down release builds

### DIFF
--- a/etc/zfsbootmenu/release.conf.d/release.conf
+++ b/etc/zfsbootmenu/release.conf.d/release.conf
@@ -1,7 +1,16 @@
 zfsbootmenu_teardown+=" /zbm/contrib/xhci-teardown.sh "
 install_optional_items+=" /etc/zbm-commit-hash "
 omit_drivers+=" amdgpu radeon nvidia nouveau i915 "
+
+# Network related modules
 omit_dracutmodules+=" network network-legacy kernel-network-modules "
-omit_dracutmodules+=" qemu qemu-net crypt-ssh nfs lunmask "
+omit_dracutmodules+=" crypt-ssh nfs lunmask "
+
+# qemu drivers
+omit_dracutmodules+=" qemu qemu-net "
+
+# filesystem and other related bits 
+omit_dracutmodules+=" nvdimm fs-lib rootfs-block dm dmraid crypt "
+
 embedded_kcl="rd.hostonly=0"
 release_build=1


### PR DESCRIPTION
We ship a lot of extras in the release builds that we can probably do without.

Before: https://somebits.link/u/p/f9be9ee376/flamechart.svg
After: https://somebits.link/u/p/fa6452fa12/flamechart.svg

* nvdimm is unrelated firmware bits, seemingly for powerpc
* fs-lib provides fsck binaries - these can be safely omitted
* rootfs-block adds cmdline hooks, we don't ever need Dracut to dig around to find a root filesystem
* dm installs udev persistent rules, dmesetup, etc
* dmraid adds a [hook](https://somebits.link/u/p/f9be9ee376/flamechart.svg?x=763.3&y=229) for dmraid storage
* crypt adds two hooks - one for a [key device](https://somebits.link/u/p/f9be9ee376/flamechart.svg?x=138.8&y=229), one to parse [luks](https://somebits.link/u/p/f9be9ee376/flamechart.svg?x=292.7&y=229)

[01-parse-kernel.sh](https://somebits.link/u/p/f9be9ee376/flamechart.svg?x=11.4&y=229) is part of 90kernel-modules which installs quite a few modules we need.
[01-parse-root-opts.sh](https://somebits.link/u/p/f9be9ee376/flamechart.svg?x=194.2&y=229) is part of 99base which installs Dracut itself in the initramfs. 