### PR TITLE
Generate release and recovery image builds

### DIFF
--- a/etc/zfsbootmenu/recovery.conf.d/recovery.conf
+++ b/etc/zfsbootmenu/recovery.conf.d/recovery.conf
@@ -1,0 +1,16 @@
+zfsbootmenu_teardown+=" /zbm/contrib/xhci-teardown.sh "
+install_optional_items+=" /etc/zbm-commit-hash /bin/gdisk /bin/parted /bin/mkfs.vfat /bin/mkfs.ext4 /bin/curl /bin/efibootmgr"
+omit_drivers+=" amdgpu radeon nvidia nouveau i915 "
+
+# Network related modules
+add_dracutmodules+=" network network-legacy kernel-network-modules "
+omit_dracutmodules+=" crypt-ssh nfs lunmask "
+
+# qemu drivers
+omit_dracutmodules+=" qemu qemu-net "
+
+# filesystem and other related bits
+omit_dracutmodules+=" nvdimm fs-lib rootfs-block dm dmraid crypt "
+
+embedded_kcl="rd.hostonly=0"
+release_build=1

--- a/etc/zfsbootmenu/recovery.yaml
+++ b/etc/zfsbootmenu/recovery.yaml
@@ -1,0 +1,1 @@
+release.yaml

--- a/releng/docker/image-build.sh
+++ b/releng/docker/image-build.sh
@@ -47,7 +47,9 @@ EOF
 buildah run "${container}" \
   sh -c 'xbps-query -Rp run_depends zfsbootmenu | xargs xbps-install -y'
 buildah run "${container}" xbps-install -y \
-  linux5.10 linux5.10-headers gummiboot-efistub curl yq-go bash kbd terminus-font
+  linux5.10 linux5.10-headers gummiboot-efistub curl yq-go bash kbd terminus-font \
+  gptfdisk dracut-network iproute2 iputils parted curl dosfstools e2fsprogs \
+  efibootmgr
 
 # Remove headers and development toolchain, but keep binutils for objcopy
 buildah run "${container}" sh -c 'echo "ignorepkg=dkms" > /etc/xbps.d/10-nodkms.conf'

--- a/releng/tag-release.sh
+++ b/releng/tag-release.sh
@@ -118,18 +118,23 @@ if ! releng/sign-assets.sh "${release}"; then
   error "ERROR: unable to sign release assets, exiting!"
 fi
 
-assets="$( realpath -e "releng/assets/${release}" )"
+asset_dir="$( realpath -e "releng/assets/${release}" )"
 asset_files=()
 
-for asset in zfsbootmenu-vmlinuz-${arch}-v${release}.EFI zfsbootmenu-${arch}-v${release}tar.gz; do
-  f="${assets}/${asset}"
+for style in release recovery; do
+  assets+=( "zfsbootmenu-${style}-vmlinuz-${arch}-v${release}.EFI" )
+  assets+=( "zfsbootmenu-${style}-${arch}-v${release}.tar.gz" )
+done
+
+for asset in "${assets[@]}" ; do
+  f="${asset_dir}/${asset}"
   [ -f "${f}" ] || error "ERROR: missing boot image ${f}"
   asset_files+=( "${f}" )
 done
 
 for f in sha256.{txt,sig}; do
-  [ -f "${assets}/${f}" ] || error "ERROR: missng sum file ${assets}/${f}"
-  asset_files+=( "${assets}/${f}" )
+  [ -f "${asset_dir}/${f}" ] || error "ERROR: missng sum file ${asset_dir}/${f}"
+  asset_files+=( "${asset_dir}/${f}" )
 done
 
 # github-cli does not automatically strip header that hub uses for a title


### PR DESCRIPTION
Add in support for a `recovery` style image which contains additional tools and networking support. Right now the additions are pretty minimal:

* gdisk
* parted
* mkfs.vfat / mkfs.ext4
* curl
* efibootmgr

The zfsbootmenu dracut module already installs mbuffer, lsblk and blkid into release images.  The changes behind the scenes allow for an arbitrary number of image styles to be made, with release and now recovery being made. EFI images are all made from a common container that must have all of the tooling available for every image style, so attention must be given to additional files/modules automatically being pulled in to the wrong image. I'm not convinced it's worth the effort though to make a new container per release style though.

Once this is merged and a new ZFSBootMenu release is cut, [redirect.pl](https://github.com/zbm-dev/get.zfsbootmenu.org/blob/master/redirect.pl) needs to be validated / updated to work with multiple EFI and .tar.gz files available per release.

This closes #227 