### PR TITLE
zbm-builder.sh: add script to build custom images using GHCR container

### DIFF
--- a/zbm-builder.sh
+++ b/zbm-builder.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# vim: softtabstop=2 shiftwidth=2 expandtab
+
+usage() {
+  cat <<EOF
+Usage: $0 [options]
+  OPTIONS:
+  -h Display help text
+
+  -H Do not copy /etc/hostid into image
+     (Has no effect if ./hostid exists)
+
+  -C Do not copy /etc/zfs/zpool.cache into image
+     (Has no effect if ./zpool.cache exists)
+
+  -d Force use of docker instead of podman
+
+  -t <tag>
+     Build the given ZFSBootMenu tag
+     (Default: upstream master)
+
+  -B <tag>
+     Use the given zbm-builder tag to build images
+     (Default: ghcr.io/zbm-dev/zbm-builder:latest)
+EOF
+}
+
+if command -v podman >/dev/null 2>&1; then
+  PODMAN=podman
+elif command -v docker >/dev/null 2>&1; then
+  PODMAN=docker
+fi
+
+SKIP_HOSTID=
+SKIP_CACHE=
+
+BUILD_TAG="ghcr.io/zbm-dev/zbm-builder:latest"
+
+BUILD_ARGS=()
+
+while getopts "hHCdt:B:" opt; do
+  case "${opt}" in
+    H)
+      SKIP_HOSTID="yes"
+      ;;
+    C)
+      SKIP_CACHE="yes"
+      ;;
+    d)
+      PODMAN=docker
+      ;;
+    t)
+      BUILD_ARGS+=( "-t" "${OPTARG}" )
+      ;;
+    B)
+      BUILD_TAG="${OPTARG}"
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if ! command -v "${PODMAN}" >/dev/null 2>&1; then
+  echo "ERROR: container front-end ${PODMAN} not found"
+  exit 1
+fi
+
+# If no local hostid is available, copy the system hostid if desired
+if ! [ -r ./hostid ]; then
+  if [ "${SKIP_HOSTID}" != "yes" ] && [ -r /etc/hostid ]; then
+    if ! cp /etc/hostid ./hostid; then
+      echo "ERROR: unable to copy /etc/hostid"
+      echo "Copy a hostid file to ./hostid or use -H to disable"
+      exit 1
+    fi
+  fi
+fi
+
+# If no local zpool.cache is available, copy the system cache if desired
+if ! [ -r ./zpool.cache ]; then
+  if [ "${SKIP_CACHE}" != "yes" ] && [ -r /etc/zfs/zpool.cache ]; then
+    if ! cp /etc/zfs/zpool.cache ./zpool.cache; then
+      echo "ERROR: unable to copy /etc/zfs/zpool.cache"
+      echo "Copy a zpool cache to ./zpool.cache or use -C to disable"
+      exit 1
+    fi
+  fi
+fi
+
+# If no config is specified, use in-tree default
+if ! [ -r ./config.yaml ]; then
+  BUILD_ARGS+=( "-c" "/zbm/etc/zfsbootomenu/config.yaml" )
+fi
+
+# Make `/build` the working directory so relative paths in a config file make sense
+"${PODMAN}" run --rm -v ".:/build" -w "/build" "${BUILD_TAG}" "${BUILD_ARGS[@]}"


### PR DESCRIPTION
This is a simple script that wraps a container build to spit out custom images without requiring users install ZFSBootMenu and its dependencies locally. It bind-mounts the current directory as `/build` in the build container and uses defaults to create a `build` subdirectory that will contain output images.

If `hostid` or `zpool.cache` are found in the current directory, the script will use those. Otherwise, the system files will be copied (unless corresponding "disable" flags are specified) to the current directory for inclusion in the images.

Docker can be forced over podman if desired. A specific tag or general commit-like can be specified, so you can build arbitrary ZBM versions on command. The default build container is whatever is tagged "latest" on GHCR, but this can be overridden.

If `config.yaml` exists in the current directory, it will be used; otherwise, whatever is the in-tree default configuration will be used.

Using the current `latest` image, built from the `bob-and-bob` branch, allows for conveniences like dropping extra dracut configs into `./dracut.conf.d` that will be put (via symlinks) in the default system location during the build.

There are two caveats:
1. Paths in `config.yaml` need to be aware of in-container filesystem structure. The default config and our default copy-or-symlink behavior for, *e.g.*, hostid and `dracut.conf.d` should make this mostly a non-issue. The build script already overwrites `ImageDir` values in the config to ensure that we have total control of where build artifacts appear. However, if you want to build a custom mkinitcpio image from `bob-and-bob`, you'll have to put a `mkinitcpio.conf` in `.` and set `InitCPIOConfig: /build/mkinitcpio.conf` to tell `generate-zbm` how to find the config. I don't really have a good solution here. For now, a simple solution seems to be running `podman` with `-w /build` to set the working directory to `/build`, allowing paths in the config file to be relative to the current directory.
2. Because the build script dumps artifacts into a temporary directory and then copies them into place, none of the `generate-zbm` backup logic works; each build just clobbers any prior artifacts unless the version differs. I'm not sure this is a real issue; the user can just copy the aritfacts where needed before running again.