### PR TITLE
Code-golf header_wrap

### DIFF
--- a/zfsbootmenu/bin/ztrace
+++ b/zfsbootmenu/bin/ztrace
@@ -21,8 +21,8 @@ while read -r line ; do
   IFS='|' read -r prefix trace log <<<"${suffix}"
   IFS=';' read -ra tokens <<<"${trace}"
 
-  ppref="$( printf "%*s" 11 "${prefix}:" )"
-  tpref="$( printf "%*s" 11 "trace:" )"
+  printf -v ppref "%*s" 11 "${prefix}:"
+  printf -v tpref "%*s" 11 "trace:"
 
   pad=' '
   c="${g}"

--- a/zfsbootmenu/hook/zfsbootmenu-parse-commandline.sh
+++ b/zfsbootmenu/hook/zfsbootmenu-parse-commandline.sh
@@ -56,7 +56,7 @@ if cli_spl_hostid=$( get_zbm_arg spl.spl_hostid spl_hostid ) ; then
 
   # Test for decimal
   if (( 10#${cli_spl_hostid} )) >/dev/null 2>&1 ; then
-    spl_hostid="$( printf "%08x" "${cli_spl_hostid}" )"
+    printf -v spl_hostid "%08x" "${cli_spl_hostid}"
   # Test for hex. Requires 0x, if present, to be stripped
   # The change to cli_spl_hostid isn't saved outside of the test
   elif (( 16#${cli_spl_hostid#0x} )) >/dev/null 2>&1 ; then
@@ -64,7 +64,7 @@ if cli_spl_hostid=$( get_zbm_arg spl.spl_hostid spl_hostid ) ; then
     # printf will strip leading 0s if there are more than 8 hex digits
     # normalize to a maximum of 8, then run through printf to fill in
     # if there are fewer than 8 digits.
-    spl_hostid="$( printf "%08x" "0x${spl_hostid:0:8}" )"
+    printf -v spl_hostid "%08x" "0x${spl_hostid:0:8}"
   # base 10 / base 16 tests fail on 0
   elif [ "${cli_spl_hostid#0x}" -eq "0" ] >/dev/null 2>&1 ; then
     spl_hostid=0

--- a/zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -74,7 +74,7 @@ write_hostid() {
   splmod="/sys/module/spl/parameters/spl_hostid"
 
   # Normalize the hostid
-  if ! hostid="$( printf "%08x" "0x${1:-0}" 2>/dev/null )"; then
+  if ! printf -v hostid "%08x" "0x${1:-0}" 2>/dev/null ; then
     zerror "invalid hostid $1"
     return 1
   fi
@@ -177,7 +177,7 @@ match_hostid() {
     zdebug "trying to import: ${pool}"
 
     if [[ $( zpool import -o readonly=on -N "${pool}" 2>&1 ) =~ $hostid_re ]] ; then
-      hostid="$( printf "%08x" "0x${BASH_REMATCH[1]}" )"
+      printf -v hostid "%08x" "0x${BASH_REMATCH[1]}"
       zdebug "discovered pool owner hostid: ${hostid}"
     else
       zdebug "unable to scrape hostid for ${pool}, skipping"
@@ -1181,16 +1181,14 @@ timed_prompt() {
   [ "${lines}" -gt 0 ] || return 1
 
   tput civis
-  HEIGHT=$( tput lines )
-  WIDTH=$( tput cols )
   tput clear
 
-  x=$(( ( (HEIGHT - 0 ) / 2 ) - lines ))
+  x=$(( ( ( LINES - 0 ) / 2 ) - lines ))
   [ "${x}" -lt 0 ] && x=0
 
   for line in "${message[@]}"; do
     short="$( decolorize "${line}" )"
-    y=$(( (WIDTH - ${#short}) / 2 ))
+    y=$(( ( COLUMNS - ${#short}) / 2 ))
     [ "${y}" -lt 0 ] && y=0
     tput cup $x $y
     echo -n -e "${line}"
@@ -1200,9 +1198,9 @@ timed_prompt() {
 
   for (( i=delay; i>0; i-- )); do
     # shellcheck disable=SC2059
-    mes="$( printf "${prompt}" "${i}" )"
+    printf -v mes "${prompt}" "${i}"
     short="$( decolorize "${mes}" )"
-    y=$(( (WIDTH - ${#short}) / 2 ))
+    y=$(( ( COLUMNS - ${#short}) / 2 ))
     [ "${y}" -lt 0 ] && y=0
     tput cup $x $y
     echo -ne "${mes}"


### PR DESCRIPTION
* Avoid looping over the list of tokens twice when calculating the
  largest field width and maximum number of columns. Calculate both in
  one go, and then only set field_width if it's not passed in.

* Use the built-in LINES, instead of shelling out to tput

* Use printf's ability to store a string in a variable, avoiding a
  subshell

* Use the built-in COLUMNS, instead of shelling out to tput