### PR TITLE
Use an early-setup hook to force console init in release images

### DIFF
--- a/contrib/console-init.sh
+++ b/contrib/console-init.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+## This early-setup hook forces the dracut console initialization hook to run.
+##
+## ZFSBootMenu release builds embed rd.hostonly=0 in the kernel command line,
+## which causes the normal dracut initqueue to be thrown out; the ZFSBootMenu
+## initqueue hooks that force the dracut event loop to run at least once are
+## purged, so dracut terminates the event loop before console initialization.
+
+# There is nothing to do if the console initializer is not executable
+[ -x /lib/udev/console_init ] || exit 0
+
+if [ -z "${control_term}" ] && [ -f /etc/zfsbootmenu.conf ]; then
+  # If control_term isn't defined, check the runtime config for it
+  # shellcheck disable=SC1091
+  source /etc/zfsbootmenu.conf
+fi
+
+# There is nothing to do without a valid control_term device
+[ -c "${control_term}" ] || exit 0
+
+# Try to initialize the console
+/lib/udev/console_init "${control_term##*/}" >/dev/null 2>&1

--- a/etc/zfsbootmenu/recovery.conf.d/recovery.conf
+++ b/etc/zfsbootmenu/recovery.conf.d/recovery.conf
@@ -1,4 +1,5 @@
 zfsbootmenu_teardown+=" /zbm/contrib/xhci-teardown.sh "
+zfsbootmenu_early_setup+=" /zbm/contrib/console-init.sh "
 install_optional_items+=" /etc/zbm-commit-hash /bin/gdisk /bin/parted /bin/mkfs.vfat /bin/mkfs.ext4 /bin/curl /bin/efibootmgr /bin/ip /bin/dhclient /sbin/dhclient-script "
 omit_drivers+=" amdgpu radeon nvidia nouveau i915 "
 

--- a/etc/zfsbootmenu/release.conf.d/release.conf
+++ b/etc/zfsbootmenu/release.conf.d/release.conf
@@ -1,4 +1,5 @@
 zfsbootmenu_teardown+=" /zbm/contrib/xhci-teardown.sh "
+zfsbootmenu_early_setup+=" /zbm/contrib/console-init.sh "
 install_optional_items+=" /etc/zbm-commit-hash "
 omit_drivers+=" amdgpu radeon nvidia nouveau i915 "
 


### PR DESCRIPTION
Setting rd.hostonly=0 in the release and recovery images causes dracut to throw out the initqueue hooks that ZBM installs to force the event loop to fire at least once. As a result, the console is often not initialized before ZBM takes control. ZFSBootMenu early-setup hooks provide a convenient place to force the console initialization, allowing things like fonts and keymaps to be set before password prompts might appear.