### PR TITLE
Force creation of the finished hook at runtime

### DIFF
--- a/90zfsbootmenu/hook/zfsbootmenu-make-finished.sh
+++ b/90zfsbootmenu/hook/zfsbootmenu-make-finished.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This exists because rd.hostonly=0 from release builds causes
+# all of the finished initqueue directory to be destroyed.
+# This short-circuits the execution of console_init, which
+# breaks setting a keymap (amongst other things).
+
+exec 2>/dev/null
+INIT_FIN="/lib/dracut/hooks/initqueue/finished/"
+mkdir "${INIT_FIN}" || exit 0
+cat << EOF >> "${INIT_FIN}/99-zfsbootmenu-ready-chk.sh"
+#!/bin/bash
+test -f /zfsbootmenu/ready
+EOF
+chmod +x "${INIT_FIN}/99-zfsbootmenu-ready-chk.sh"

--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -154,13 +154,14 @@ install() {
   done
 
   # Hooks necessary to initialize ZBM
+  inst_hook cmdline 15 "${moddir}/hook/zfsbootmenu-make-finished.sh" || _ret=$?
   inst_hook cmdline 95 "${moddir}/hook/zfsbootmenu-parse-commandline.sh" || _ret=$?
   inst_hook pre-mount 90 "${moddir}/hook/zfsbootmenu-preinit.sh" || _ret=$?
 
   # Hooks to force the dracut event loop to fire at least once
   # Things like console configuration are done in optional event-loop hooks
   inst_hook initqueue/settled 99 "${moddir}/hook/zfsbootmenu-ready-set.sh" || _ret=$?
-  inst_hook initqueue/finished 99 "${moddir}/hook/zfsbootmenu-ready-chk.sh" || _ret=$?
+  # The initqueue/finished hook is now created at run-time via zfsbootmenu-make-finished.sh
 
   # If tracing is enabled, build in the full-weight profiling library
   if [ -n "${zfsbootmenu_trace_enable}" ]; then


### PR DESCRIPTION
Setting rd.hostonly=0 in the release and recovery images causes dracut
to throw out the initqueue hooks that ZBM installs to force the event
loop to fire at least once. As a result, the console is often not
initialized before ZBM takes control.

Use a fake cmdline hook to create this for us after initqueue/finished/
has been destroyed.