### PR TITLE
zfsbootmenu-core.sh: drop preload_be_cmdline, improve KCL caching

### DIFF
--- a/zfsbootmenu/bin/zfsbootmenu
+++ b/zfsbootmenu/bin/zfsbootmenu
@@ -275,11 +275,11 @@ while true; do
         def_args="${line}"
       done <<< "${BE_ARGS}"
 
-      echo -e "\nNew kernel command line"
+      echo -e "\nNew kernel command line (root= arguments will be ignored)"
       cmdline="$( /libexec/zfsbootmenu-input "${def_args}" )"
 
       if [ -n "${cmdline}" ] ; then
-        kcl_tokenize <<< "${cmdline}" > "${BASE}/cmdline"
+        kcl_tokenize <<< "${cmdline}" | kcl_suppress root > "${BASE}/cmdline"
       fi
       ;;
     "mod-j")

--- a/zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -922,16 +922,10 @@ load_be_cmdline() {
 
   cache="${BASE}/${fs}/cmdline"
 
-  # root= is ALWAYS controlled by ZFSBootMenu
-  rems=( "root" )
-
-  # Nothing is added by default
-  adds=()
-
   if [ -r "${BASE}/cmdline" ]; then
     # Always prefer a user-entered KCL
     zdebug "using ${BASE}/cmdline as command line for ${fs}"
-    kcl_suppress "${rems[@]}" < "${BASE}/cmdline" | kcl_assemble
+    kcl_assemble < "${BASE}/cmdline"
     return
   elif validate_cmdline_cache "${cache}"; then
     # Otherwise, if the BE has a valid KCL cache, just assemble that
@@ -939,6 +933,12 @@ load_be_cmdline() {
     kcl_assemble < "${cache}"
     return
   fi
+
+  # root= is ALWAYS controlled by ZFSBootMenu
+  rems=( "root" )
+
+  # Nothing is added by default
+  adds=()
 
   # In all other cases, build and attempt to cache the KCL
   args="$(read_kcl_prop "${fs}" | kcl_tokenize && exit "${PIPESTATUS[0]}" )" || args=""

--- a/zfsbootmenu/lib/zfsbootmenu-kcl.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-kcl.sh
@@ -112,7 +112,7 @@ kcl_suppress() {
     sup=0
     for rem in "$@"; do
       # Arguments match entirely or up to first equal
-      if [ "${arg}" = "${rem}" ] || [ "${arg%%=*}" = "${rem}" ]; then
+      if [[ "${arg}" == "${rem}" || "${arg%%=*}" == "${rem}" ]]; then
         sup=1
         break
       fi
@@ -132,9 +132,9 @@ kcl_append() {
   # Carry forward input KCL
   cat
 
-  # Append one line per argument
+  # Append one line per non-trivial argument
   for arg in "$@"; do
-    echo "$arg"
+    [ -n "${arg}" ] && echo "$arg"
   done
 }
 

--- a/zfsbootmenu/lib/zfsbootmenu-lib.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-lib.sh
@@ -568,6 +568,9 @@ populate_be_list() {
 
   ret=1
   for fs in "${candidates[@]}"; do
+    # Remove any existing cmdline cache
+    rm -f "${BASE}/${fs}/cmdline"
+
     # Unlock if necessary
     load_key "${fs}" || continue
 


### PR DESCRIPTION
I haven't actually tested this, but here's my proposal for improved KCL cache handling.