### PR TITLE
Replace 'tr' with bash string manipulation

### DIFF
--- a/zfsbootmenu/install-helpers.sh
+++ b/zfsbootmenu/install-helpers.sh
@@ -20,7 +20,6 @@ zfsbootmenu_essential_binaries=(
   "sed"
   "grep"
   "tail"
-  "tr"
   "tac"
   "blkid"
   "awk"
@@ -73,7 +72,8 @@ create_zbm_conf() {
   # Create core ZBM configuration file
 
   local endian ival
-  ival="$( echo -n 3 | od -tx2 -N2 -An | tr -d '[:space:]' )"
+  ival="$( echo -n 3 | od -tx2 -N2 -An )"
+  ival="${ival//[[:space:]]/}"
   if [ "${ival}" = "3300" ]; then
     endian="be"
   else

--- a/zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -118,7 +118,8 @@ get_spl_hostid() {
 
   # Otherwise look to /etc/hostid, if possible
   if [ -r /etc/hostid ] && command -v od >/dev/null 2>&1; then
-    spl_hostid="$( od -tx4 -N4 -An /etc/hostid 2>/dev/null | tr -d '[:space:]' )"
+    spl_hostid="$( od -tx4 -N4 -An /etc/hostid 2>/dev/null )"
+    spl_hostid="${spl_hostid//[[:space:]]/}"
     if [ -n "${spl_hostid}" ]; then
       zdebug "hostid from /etc/hostid: ${spl_hostid}"
       echo -n "0x${spl_hostid}"

--- a/zfsbootmenu/lib/zfsbootmenu-lib.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-lib.sh
@@ -404,7 +404,10 @@ snapshot_dispatcher() {
 
     [ -n "${user_input}" ] || return
 
-    valid_name=$( echo "${user_input}" | tr -c -d 'a-zA-Z0-9-_.:' )
+    shopt -s extglob
+    valid_name="${user_input//+([!a-zA-Z0-9-_.:])/}"
+    shopt -u extglob
+
     if [[ "${user_input}" != "${valid_name}" ]]; then
       echo "${user_input} is invalid, ${valid_name} can be used"
       pre_populated="${valid_name}"


### PR DESCRIPTION
`tr` is only used in a few places, so this drops it from images without busybox. Might or might not be worth it. 

What might be more important is the additional use of `shopt -s extglob`. I'm debating turning that on globally and just fixing the fallout from it - if there is any. Thoughts?