### PR TITLE
Tweaks to `zbm-builder.sh`

### DIFF
--- a/zbm-builder.sh
+++ b/zbm-builder.sh
@@ -95,7 +95,7 @@ fi
 
 # If no config is specified, use in-tree default
 if ! [ -r ./config.yaml ]; then
-  BUILD_ARGS+=( "-c" "/zbm/etc/zfsbootomenu/config.yaml" )
+  BUILD_ARGS+=( "-c" "/zbm/etc/zfsbootmenu/config.yaml" )
 fi
 
 # Make `/build` the working directory so relative paths in a config file make sense

--- a/zbm-builder.sh
+++ b/zbm-builder.sh
@@ -45,7 +45,7 @@ VOLUME_ARGS=()
 while getopts "hHLCdt:B:" opt; do
   case "${opt}" in
     L)
-      VOLUME_ARGS+=("-v" "$(pwd):/zbm")
+      VOLUME_ARGS+=("-v" "${PWD}:/zbm")
      ;;
     H)
       SKIP_HOSTID="yes"
@@ -106,4 +106,4 @@ if ! [ -r ./config.yaml ]; then
 fi
 
 # Make `/build` the working directory so relative paths in a config file make sense
-"${PODMAN}" run --rm "${VOLUME_ARGS[@]}" -v "$(pwd):/build" -w "/build" "${BUILD_TAG}" "${BUILD_ARGS[@]}"
+"${PODMAN}" run --rm "${VOLUME_ARGS[@]}" -v "${PWD}:/build" -w "/build" "${BUILD_TAG}" "${BUILD_ARGS[@]}"

--- a/zbm-builder.sh
+++ b/zbm-builder.sh
@@ -7,6 +7,9 @@ Usage: $0 [options]
   OPTIONS:
   -h Display help text
 
+  -L Use local './' source tree instead of remote.
+     (Default: upstream master.)
+
   -H Do not copy /etc/hostid into image
      (Has no effect if ./hostid exists)
 
@@ -37,9 +40,13 @@ SKIP_CACHE=
 BUILD_TAG="ghcr.io/zbm-dev/zbm-builder:latest"
 
 BUILD_ARGS=()
+VOLUME_ARGS=()
 
-while getopts "hHCdt:B:" opt; do
+while getopts "hHLCdt:B:" opt; do
   case "${opt}" in
+    L)
+      VOLUME_ARGS+=("-v" "$(pwd):/zbm")
+     ;;
     H)
       SKIP_HOSTID="yes"
       ;;
@@ -99,4 +106,4 @@ if ! [ -r ./config.yaml ]; then
 fi
 
 # Make `/build` the working directory so relative paths in a config file make sense
-"${PODMAN}" run --rm -v "$(pwd):/build" -w "/build" "${BUILD_TAG}" "${BUILD_ARGS[@]}"
+"${PODMAN}" run --rm "${VOLUME_ARGS[@]}" -v "$(pwd):/build" -w "/build" "${BUILD_TAG}" "${BUILD_ARGS[@]}"

--- a/zbm-builder.sh
+++ b/zbm-builder.sh
@@ -99,4 +99,4 @@ if ! [ -r ./config.yaml ]; then
 fi
 
 # Make `/build` the working directory so relative paths in a config file make sense
-"${PODMAN}" run --rm -v ".:/build" -w "/build" "${BUILD_TAG}" "${BUILD_ARGS[@]}"
+"${PODMAN}" run --rm -v "$(pwd):/build" -w "/build" "${BUILD_TAG}" "${BUILD_ARGS[@]}"


### PR DESCRIPTION
## Minor fixes to the `zbm-builder.sh` script.

ZBM-builder.sh script does not begin work on a fresh repository clone using Docker; however, it works fine using Podman. This is because Docker will not accept `.` or `./` as part of a `-v` command line argument, whereas Podman will.

`zbm-builder.sh -d` executes

`docker run --rm -v .:/build -w /build ghcr.io/zbm-dev/zbm-builder:latest -c /zbm/etc/zfsbootomenu/config.yaml`

Resulting in the following error...

`docker: Error response from daemon: create .: volume name is too short, names should be at least two alphanumeric characters.`

Expanding `.` to `./` is also not enough, as Docker reports.

`docker: Error response from daemon: create ./: "./" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.`

Thus, modifying `zbm-builder.sh` to use `$(pwd)` instead of `.` works for both Docker and Podman.

`$ docker/podman run --rm -v "$(pwd)":/build -w /build ghcr.io/zbm-dev/zbm-builder:latest -c /zbm/etc/zfsbootomenu/config.yaml`

Also, there was a little typo in the `BUILD_ARGS` line that passed an incorrect default `config.yaml` location to `zbm-build.sh` inside the container, causing build failure.

```
  BUILD_ARGS+=( "-c" "/zbm/etc/zfs**bootomenu**/config.yaml" )
```
Replacing boot**o**menu with bootmenu sorts this.

## Added option to use a local repository as opposed to a remote one.

As `zbm-builder.sh` is hard coded to pull the given tag from the zbm-dev/zfsbootmenu repository, this enables people to work from another repository using a local `git clone`. Combined with pulling images, this allows an offline edit-build-test workflow (i.e. it allows newbies such as myself to clone/pull and tinker locally. :baby:)