### PR TITLE
Make the emergency shell slightly fancy

### DIFF
--- a/contrib/luks-unlock.sh
+++ b/contrib/luks-unlock.sh
@@ -98,7 +98,7 @@ while true; do
       -p "Continuing in %0.2d seconds" ; then
         continue
     else
-      emergency_shell "Unable to unlock LUKS partition"
+      emergency_shell "unable to unlock LUKS partition"
     fi
   fi
 done

--- a/zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -302,7 +302,7 @@ kexec_kernel() {
   tput clear
 
   if ! mnt=$( mount_zfs "${fs}" ); then
-    emergency_shell "unable to mount ${fs}"
+    emergency_shell "unable to mount $( colorize cyan "${fs}" )"
     return 1
   fi
 
@@ -1770,16 +1770,19 @@ zfs_chroot() {
 # returns: nothing
 
 emergency_shell() {
-  local message skip mp fs
-  message=${1:-unknown reason}
+  local skip mp fs
 
   tput clear
   tput cnorm
   stty echo
 
-  echo -n "Launching emergency shell: "
-  echo -e "${message}\n"
+  cat <<-EOF
+	$( colorize green "emergency shell")${1:+: $1}
 
+	type '$(colorize red "help")' for online documentation
+	type '$( colorize red "exit")' to return to ZFSBootMenu
+
+	EOF
   # -i (interactive) mode will source $HOME/.bashrc
   /bin/bash -i
 

--- a/zfsbootmenu/libexec/zfsbootmenu-init
+++ b/zfsbootmenu/libexec/zfsbootmenu-init
@@ -209,7 +209,7 @@ if [ "${menu_timeout}" -ge 0 ] && [ -n "${BOOTFS}" ]; then
       # Clear screen before a possible password prompt
       tput clear
       if ! NO_CACHE=1 load_key "${BOOTFS}"; then
-        emergency_shell "unable to load key for ${BOOTFS}; type 'exit' to continue"
+        emergency_shell "unable to load key for $( colorize cyan "${BOOTFS}" )"
       elif find_be_kernels "${BOOTFS}" && [ ! -e "${BASE}/active" ]; then
         # Automatically select a kernel and boot it
         kexec_kernel "$( select_kernel "${BOOTFS}" )"
@@ -221,7 +221,7 @@ fi
 # If the lock file is present, drop to a recovery shell to avoid
 # stealing control back from an SSH session
 if [ -e "${BASE}/active" ] ; then
-  emergency_shell "type 'exit' to return to ZFSBootMenu"
+  emergency_shell "an active instance is already running"
 fi
 
 while true; do
@@ -229,5 +229,5 @@ while true; do
     /bin/zfsbootmenu
   fi
 
-  emergency_shell "type 'exit' to return to ZFSBootMenu"
+  emergency_shell
 done


### PR DESCRIPTION
The emergency shell now always shows:

```
emergency shell

type 'help' for online documentation
type 'exit' to return to ZFSBootMenu
```
If a specific message is passed in to the function, it is shown as follows:

```
emergency shell: contextual message

type 'help' for online documentation
type 'exit' to return to ZFSBootMenu
```