### PR TITLE
Zbm-builder.sh (+ config.yaml, BUILD.md) tweaks.

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -54,7 +54,7 @@ To build a default image, invoke `zbm-builder.sh` with no arguments. For example
 ./zbm-builder.sh
 ```
 
-to produce a default kernel/initramfs pair in the `./build/components` subdirectory.
+to produce a bootable EFI image in the `./build` directory and kernel/initramfs pair in the `./build/components` subdirectory.
 
 The default behavior of `zbm-builder.sh` will:
 

--- a/etc/zfsbootmenu/config.yaml
+++ b/etc/zfsbootmenu/config.yaml
@@ -16,6 +16,6 @@ Components:
 EFI:
   ImageDir: /boot/efi/EFI/void
   Versions: false
-  Enabled: false
+  Enabled: true
 Kernel:
   CommandLine: ro quiet loglevel=0


### PR DESCRIPTION
As discussed in #273 :smile:

`./zbm-builder.sh`

  Local repository switch now expects directory
  Added option to use alternative .yaml config file
  Added option to use alternative ./build directory

`./etc/zfsbootmenu/config.yaml`

  By default, generate EFI plus kernel/initramfs pair

`./BUILD.md`

  Tweaked to describe above behavior.