### PR TITLE
zbm-builder.sh: various changes

### DIFF
--- a/zbm-builder.sh
+++ b/zbm-builder.sh
@@ -80,7 +80,6 @@ fi
 while getopts "b:dhi:l:t:CH" opt; do
   case "${opt}" in
     b)
-      sanitise_path
       BUILD_DIRECTORY="${OPTARG}"
       ;;
     d)
@@ -94,7 +93,6 @@ while getopts "b:dhi:l:t:CH" opt; do
       BUILD_TAG="${OPTARG}"
       ;;
     l)
-      sanitise_path 
       VOLUME_ARGS+=( "-v" "${OPTARG}:/zbm" )
      ;;
     t)
@@ -150,4 +148,4 @@ if ! [ -r "${BUILD_DIRECTORY}"/config.yaml ]; then
 fi
 
 # Make `/build` the working directory so relative paths in a config file make sense
-echo "${PODMAN}" run --rm "${VOLUME_ARGS[@]}" -w "/build" "${BUILD_TAG}" "${BUILD_ARGS[@]}"
+"${PODMAN}" run --rm "${VOLUME_ARGS[@]}" -w "/build" "${BUILD_TAG}" "${BUILD_ARGS[@]}"

--- a/zbm-builder.sh
+++ b/zbm-builder.sh
@@ -66,7 +66,7 @@ Usage: $0 [options]
      (By default, a source archive is pulled by the container from GitHub.)
 
   -t <tag>
-     Build a specific ZFSBootMenu release tag (e.g. v1.12.0, v1.10.1, v1.9.0).
+     Build a specific ZFSBootMenu commit or tag (e.g. v1.12.0, v1.10.1, d5594589).
      (By default, the current upstream master is used.)
 
   -C Do not integrate /etc/zfs/zpool.cache into build image image from host.

--- a/zbm-builder.sh
+++ b/zbm-builder.sh
@@ -1,70 +1,145 @@
 #!/bin/bash
 # vim: softtabstop=2 shiftwidth=2 expandtab
 
-usage() {
-  cat <<EOF
-Usage: $0 [options]
-  OPTIONS:
-  -h Display help text
-
-  -L Use local './' source tree instead of remote.
-     (Default: upstream master.)
-
-  -H Do not copy /etc/hostid into image
-     (Has no effect if ./hostid exists)
-
-  -C Do not copy /etc/zfs/zpool.cache into image
-     (Has no effect if ./zpool.cache exists)
-
-  -d Force use of docker instead of podman
-
-  -t <tag>
-     Build the given ZFSBootMenu tag
-     (Default: upstream master)
-
-  -B <tag>
-     Use the given zbm-builder tag to build images
-     (Default: ghcr.io/zbm-dev/zbm-builder:latest)
-EOF
+sanitise_path() {
+  if [ -d "${OPTARG}" ]; then
+    OPTARG=$(readlink -f "${OPTARG}")
+  else
+    echo "Error: ${OPTARG} is not a valid path."
+    exit 1
+  fi
 }
 
-if command -v podman >/dev/null 2>&1; then
-  PODMAN=podman
-elif command -v docker >/dev/null 2>&1; then
-  PODMAN=docker
-fi
+sanitise_file() {
+  if [ -x "${OPTARG}" ] && ! [ -d "${OPTARG}" ]; then
+    OPTARG=$(readlink -f "${OPTARG}")
+  else
+    echo "Error: ${OPTARG} is not a valid, executable file."
+    exit 1
+  fi
+}
 
+usage() {
+  cat << EOF
+
+zbm-builder.sh
+
+This script generates bootable ZFSBootMenu components inside a pre-made
+build container, freeing the user from having to install ZFSBootMenu and
+dependencies on the host system or invoke the build scripts directly.
+
+For more information, please see BUILD.md and README.md, or find the latest
+documentation at https://github.com/zbm-dev/zfsbootmenu/
+
+Usage: $0 [options]
+
+  OPTIONS:
+ 
+  -1 <file>
+     Fetch inidcated file to build directory and mark for integration as
+     a 'zfsbootmenu_early_setup' hook. This command can be invoked multiple
+     times.
+
+  -2 <file>
+     Fetch inidcated file to build directory and mark for integration as
+     a 'zfsbootmenu_setup' hook. This comand can be invoked multiple times.
+  
+  -3 <file>
+     Fetch inidcated file to build directory and mark for integration as
+     a 'zfsbootmenu_teardown' hook. This command can be invoked multiple
+     times.
+
+  -b <path>
+     Use an alternate build directory for the container.
+     (By default, the directory containing 'zbm-builder.sh' is used.)
+
+  -d Force use of Docker instead of Podman as container management tool.
+
+  -h Display this help text.
+
+  -i <image>
+     Use a different container image or version as build environment.
+     (By default, the official ghcr.io/zbm-dev/zbm-builder:latest is used.)
+
+  -l <path>
+     Use local ZFSBootMenu source tree at <path> instead of remote repository.
+     (By default, a source archive is pulled by the container from GitHub.)
+
+  -t <tag>
+     Build a specific ZFSBootMenu release tag (e.g. v1.12.0, v1.10.1, v1.9.0).
+     (By default, the current upstream master is used.)
+
+  -C Do not integrate /etc/zfs/zpool.cache into build image image from host.
+     (If ./zpool.cache exists, this switch will be ignored.)
+
+  -H Do not integrate /etc/hostid into build image from host.
+     (If ./hostid exists, this switch will be ignored.)
+
+EOF
+}
+  
 SKIP_HOSTID=
 SKIP_CACHE=
 
 BUILD_TAG="ghcr.io/zbm-dev/zbm-builder:latest"
+BUILD_DIRECTORY=
 
 BUILD_ARGS=()
-VOLUME_ARGS=("-v" "${PWD}:/build")
+VOLUME_ARGS=()
 
-while getopts "hHLCdt:B:" opt; do
+HOOKS_EARLY_SETUP=()
+HOOKS_SETUP=()
+HOOKS_TEARDOWN=()
+
+if command -v podman >/dev/null 2>&1; then
+  PODMAN="podman"
+elif command -v docker >/dev/null 2>&1; then
+  PODMAN="docker"
+else
+  echo "Error: No suitable container management front-end found."
+  exit 1
+fi
+
+while getopts "1:2:3:b:dhi:l:t:CH" opt; do
   case "${opt}" in
-    L)
-      VOLUME_ARGS+=("-v" "${PWD}:/zbm")
-     ;;
-    H)
-      SKIP_HOSTID="yes"
-      ;;
-    C)
-      SKIP_CACHE="yes"
+    1)
+      sanitise_file "${OPTARG}"
+      HOOKS_EARLY_SETUP+=( "${OPTARG}" )
+    ;;
+    2)
+      sanitise_file "${OPTARG}"
+      HOOKS_SETUP+=( "${OPTARG}" )
+    ;;
+    3)
+      sanitise_file "${OPTARG}"
+      HOOKS_TEARDOWN+=( "${OPTARG}" )
+    ;;
+    b)
+      sanitise_path
+      BUILD_DIRECTORY="${OPTARG}"
       ;;
     d)
       PODMAN=docker
       ;;
-    t)
-      BUILD_ARGS+=( "-t" "${OPTARG}" )
-      ;;
-    B)
-      BUILD_TAG="${OPTARG}"
-      ;;
     h)
       usage
       exit 0
+      ;;
+    i)
+      BUILD_TAG="${OPTARG}"
+      ;;
+    l)
+      sanitise_path 
+      VOLUME_ARGS+=( "-v" "${OPTARG}:/zbm" )
+     ;;
+    t)
+      BUILD_ARGS+=( "-t" "${OPTARG}" )
+      ;;
+    C)
+      SKIP_CACHE="yes"
+      ;;
+    H)
+      SKIP_HOSTID="yes"
       ;;
     *)
       usage
@@ -73,15 +148,17 @@ while getopts "hHLCdt:B:" opt; do
   esac
 done
 
-if ! command -v "${PODMAN}" >/dev/null 2>&1; then
-  echo "ERROR: container front-end ${PODMAN} not found"
-  exit 1
+if [ -n "${BUILD_DIRECTORY}" ]; then
+  VOLUME_ARGS+=( "-v" "${BUILD_DIRECTORY}:/build" )
+else  
+  BUILD_DIRECTORY="${PWD}"
+  VOLUME_ARGS+=( "-v" "${PWD}:/build" )
 fi
 
 # If no local hostid is available, copy the system hostid if desired
-if ! [ -r ./hostid ]; then
+if ! [ -r "${BUILD_DIRECTORY}"/hostid ]; then
   if [ "${SKIP_HOSTID}" != "yes" ] && [ -r /etc/hostid ]; then
-    if ! cp /etc/hostid ./hostid; then
+    if ! cp /etc/hostid "${BUILD_DIRECTORY}"/hostid; then
       echo "ERROR: unable to copy /etc/hostid"
       echo "Copy a hostid file to ./hostid or use -H to disable"
       exit 1
@@ -90,9 +167,9 @@ if ! [ -r ./hostid ]; then
 fi
 
 # If no local zpool.cache is available, copy the system cache if desired
-if ! [ -r ./zpool.cache ]; then
+if ! [ -r "${BUILD_DIRECTORY}"/zpool.cache ]; then
   if [ "${SKIP_CACHE}" != "yes" ] && [ -r /etc/zfs/zpool.cache ]; then
-    if ! cp /etc/zfs/zpool.cache ./zpool.cache; then
+    if ! cp /etc/zfs/zpool.cache "${BUILD_DIRECTORY}"/zpool.cache; then
       echo "ERROR: unable to copy /etc/zfs/zpool.cache"
       echo "Copy a zpool cache to ./zpool.cache or use -C to disable"
       exit 1
@@ -100,11 +177,50 @@ if ! [ -r ./zpool.cache ]; then
   fi
 fi
 
-# If no config is specified, use in-tree default
-if ! [ -r ./config.yaml ]; then
+# If no config is specified, use in-tree default, do efi and kernel/initramfs
+if ! [ -r "${BUILD_DIRECTORY}"/config.yaml ]; then
   BUILD_ARGS+=( "-c" "/zbm/etc/zfsbootmenu/config.yaml" )
+  BUILD_ARGS+=( "-e" ".EFI.Enabled=true" )
+  BUILD_ARGS+=( "-e" ".Components.Enabled=true" )
+fi
+
+# custom dracut.conf.d/*.configs need to go into ./build/dracut.conf.d :)
+if [ -n "${HOOKS_EARLY_SETUP}" ] || [ -n "${HOOKS_SETUP}" ] || [ -n "${HOOKS_TEARDOWN}" ]; then
+  mkdir -p "${BUILD_DIRECTORY}"/dracut.conf.d
+fi
+
+if [ -n "${HOOKS_EARLY_SETUP}" ]; then
+  # copy requested hook scripts in, then convert canonical path to /build
+  for i in "${!HOOKS_EARLY_SETUP[@]}"; do
+    cp "${HOOKS_EARLY_SETUP[$i]}" "${BUILD_DIRECTORY}"
+    HOOKS_EARLY_SETUP[$i]="/build/`basename ${HOOKS_EARLY_SETUP[$i]}`"
+  done
+  # echo collated hook scripts to config file
+  echo "zfsbootmenu_early_setup+=\" "${HOOKS_EARLY_SETUP[@]}" \"" \
+  > "${BUILD_DIRECTORY}"/dracut.conf.d/zfsbootmenu.earlyhooks.conf;
+fi
+
+if [ -n "${HOOKS_SETUP}" ]; then
+  # copy requested hook scripts in, then convert canonical path to /build
+  for i in "${!HOOKS_SETUP[@]}"; do
+    cp "${HOOKS_SETUP[$i]}" "${BUILD_DIRECTORY}"
+    HOOKS_SETUP[$i]="/build/`basename ${HOOKS_SETUP[$i]}`"
+  done
+  # echo collated hook scripts to config file
+  echo "zfsbootmenu_setup+=\" "${HOOKS_SETUP[@]}" \"" \
+  > "${BUILD_DIRECTORY}"/dracut.conf.d/zfsbootmenu.setuphooks.conf;
+fi
+
+if [ -n "${HOOKS_TEARDOWN}" ]; then
+  # copy requested hook scripts in, then convert canonical path to /build
+  for i in "${!HOOKS_TEARDOWN[@]}"; do
+    cp "${HOOKS_TEARDOWN[$i]}" "${BUILD_DIRECTORY}"
+    HOOKS_TEARDOWN[$i]="/build/`basename ${HOOKS_TEARDOWN[$i]}`"
+  done
+  # echo collated hook scripts to config file
+  echo "zfsbootmenu_teardown+=\" "${HOOKS_TEARDOWN[@]}" \"" \
+  > "${BUILD_DIRECTORY}"/dracut.conf.d/zfsbootmenu.teardown.conf;
 fi
 
 # Make `/build` the working directory so relative paths in a config file make sense
 "${PODMAN}" run --rm "${VOLUME_ARGS[@]}" -w "/build" "${BUILD_TAG}" "${BUILD_ARGS[@]}"
-


### PR DESCRIPTION
**As discussed, following features are now present:**

- Specify local source directory (rather than assuming `$PWD`)
- Specify hook scripts for various stages
- `EFI` and `kernel/initramfs` pair will be generated if default `config.yaml` is used.

---

`zbm-builder.sh`: **Added `-l`ocal source option.**

Added `-l`ocal source path option (as lowercase, -C and -H being inhibitory.)
Added simple sanitise_path() function to help with docker path issues.

`zbm-builder.sh` - **Clarified help text**

Added short paragraph describing function of script and directing users to further information.

Clarified options `-B` and `-t`, which both used `tag` terminology.

The term `<tag>` now only refers to a release build tag, `<image>` replacing `<tag>` with regard to specifying an alternate container image.

`zbm-builder.sh`: **Kernel and EFI generation**

While not using a custom `config.yaml`, `zbm-builder.sh` will produce both kernel/initramfs pair and EFI bundle unless inhibited with the `-K` and `-E` options respectively.

`zbm-builder.sh`: **Collated all podman/docker checks**

Collated all docker/podman checks into one location in script.

`zbm-builder.sh`: **Rearranged/tweaked command line.**

Further re-wording of help text.

Switched `B` to `b` to conform to custom that capital letters prohibit actions.

Minor typo tweaks to error messages.

Re-arranged command line options in help text and script to alphabetical order, displaying augment/modify switches before prohibitive switches.

`zbm-builder.sh`: **Added `-i` switch to set build directory**

The `-i` switch allows user to choose an alternate build directory.

`zbm-builder.sh`: **Removed `-E` and `-K` switches**

As suggested, -E and -K switches are no longer exposed, but the script will still override default `config.yaml` (when used) to produce both EFI bundle and kernel/initramfs pair.

`zbm-builder.sh`: **swapped `-i` and `-b` options, typos.**

Swapped -i and -b switches; `-i` dictating image and `-b` dictating build directory makes more sense.

Typo fixes to help text, restored -h option text.

`zbm-builder.sh`: **switches to add hooks scripts**

New command line switches `-1`, `-2` and `-3` automate integration of hook scripts for the `zbm_early_setup`, `zbm_setup` and `zbm_teardown` stages respectively.

Added `sanitise_file()` function to check input is suitable hook script.