### PR TITLE
WIP: Omit video drivers by default

### DIFF
--- a/etc/zfsbootmenu/dracut.conf.d/omit-drivers.conf
+++ b/etc/zfsbootmenu/dracut.conf.d/omit-drivers.conf
@@ -1,0 +1,3 @@
+# If you NEED drivers in ZFSBootMenu, modify the list below
+
+omit_drivers+=" amdgpu radeon nvidia nouveau i915 "


### PR DESCRIPTION
It's time to by-default blacklist video drivers in ZFSBootMenu.  Anybody using the Makefile to install ZBM components (random `make install` users, or Void package users) will now get this dracut configuration file.

Existing release/recovery builds already blacklist these drivers and whole swaths of other items.