### PR TITLE
Add option to revert to default KCL via ctrl-t in draw_be

### DIFF
--- a/docs/pod/online/main-screen.pod
+++ b/docs/pod/online/main-screen.pod
@@ -30,6 +30,10 @@ The operation will fail gracefully if the pool can not be set I<read/write>.
 
 Temporarily edit the kernel command line that will be used to boot the chosen kernel in the selected boot environment. This change does not persist across reboots.
 
+=item I<[MOD+T]> B<revert kcl>
+
+Revert the temporary kernel command line set via I<[MOD+E]>.
+
 =item I<[MOD+P]> B<pool status>
 
 View the health and status of each imported pool.

--- a/zfsbootmenu/bin/zfsbootmenu
+++ b/zfsbootmenu/bin/zfsbootmenu
@@ -282,6 +282,9 @@ while true; do
         kcl_tokenize <<< "${cmdline}" | kcl_suppress root > "${BASE}/cmdline"
       fi
       ;;
+    "mod-t")
+      [ -f "${BASE}/cmdline" ] && rm "${BASE}/cmdline"
+      ;;
     "mod-j")
       zfs_chroot "${selected_be}"
       ;;

--- a/zfsbootmenu/help-files/132/main-screen.pod
+++ b/zfsbootmenu/help-files/132/main-screen.pod
@@ -22,6 +22,9 @@
   Temporarily edit the kernel command line that will be used to boot the chosen kernel in the selected boot environment. This change
   does not persist across reboots.
 
+[33m[MOD+T][0m [1mrevert kcl[0m
+  Revert the temporary kernel command line set via [33m[MOD+E][0m.
+
 [33m[MOD+P][0m [1mpool status[0m
   View the health and status of each imported pool.
 

--- a/zfsbootmenu/help-files/52/main-screen.pod
+++ b/zfsbootmenu/help-files/52/main-screen.pod
@@ -31,6 +31,10 @@
   boot environment. This change does not persist
   across reboots.
 
+[33m[MOD+T][0m [1mrevert kcl[0m
+  Revert the temporary kernel command line set via
+  [33m[MOD+E][0m.
+
 [33m[MOD+P][0m [1mpool status[0m
   View the health and status of each imported pool.
 

--- a/zfsbootmenu/help-files/92/main-screen.pod
+++ b/zfsbootmenu/help-files/92/main-screen.pod
@@ -24,6 +24,9 @@
   Temporarily edit the kernel command line that will be used to boot the chosen kernel in
   the selected boot environment. This change does not persist across reboots.
 
+[33m[MOD+T][0m [1mrevert kcl[0m
+  Revert the temporary kernel command line set via [33m[MOD+E][0m.
+
 [33m[MOD+P][0m [1mpool status[0m
   View the health and status of each imported pool.
 

--- a/zfsbootmenu/lib/zfsbootmenu-lib.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-lib.sh
@@ -63,7 +63,7 @@ column_wrap() {
 # returns: 0 on successful selection, 1 if Esc was pressed, 130 if BE list is missing
 
 draw_be() {
-  local env selected header expects
+  local env selected header expects kcl_text kcl_bind blank
 
   env="${1}"
   if [ -z "${env}" ]; then
@@ -78,17 +78,25 @@ draw_be() {
 
   zdebug "using environment file: ${env}"
 
+  if [ -f "${BASE}/cmdline" ]; then
+    kcl_text="[CTRL+T] revert kcl"
+    kcl_bind="alt-t"
+    blank=
+  else
+    blank=':'
+  fi
+
   header="$( column_wrap "\
 [RETURN] boot:[ESCAPE] refresh view:[CTRL+P] pool status
 [CTRL+D] set bootfs:[CTRL+S] snapshots:[CTRL+K] kernels
 [CTRL+E] edit kcl:[CTRL+J] jump into chroot:[CTRL+R] recovery shell
-[CTRL+L] view logs::[CTRL+H] help" \
+${kcl_text:+${kcl_text}:}[CTRL+L] view logs:${blank}[CTRL+H] help" \
 "\
 [RETURN] boot
 [CTRL+R] recovery shell
 [CTRL+H] help" )"
 
-  expects="--expect=alt-e,alt-k,alt-d,alt-s,alt-c,alt-r,alt-p,alt-w,alt-j,alt-o"
+  expects="--expect=alt-e,alt-k,alt-d,alt-s,alt-c,alt-r,alt-p,alt-w,alt-j,alt-o${kcl_bind:+,${kcl_bind}}"
 
   if ! selected="$( ${FUZZYSEL} -0 --prompt "BE > " \
       ${expects} ${expects//alt-/ctrl-} ${expects//alt-/ctrl-alt-} \


### PR DESCRIPTION
If `${BASE}/cmdline` exists, draw help text for reverting the KCL and attach the `alt-t` keybind to the main menu.