### PR TITLE
Include cryptsetup in containerized builds

### DIFF
--- a/releng/docker/Dockerfile
+++ b/releng/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN echo "ignorepkg=linux" > /etc/xbps.d/10-nolinux.conf \
 # Install components necessary to build the image
 RUN xbps-query -Rp run_depends zfsbootmenu | xargs xbps-install -y
 RUN xbps-install -y linux5.10 linux5.10-headers \
-	zfs gummiboot-efistub curl yq-go bash kbd terminus-font dracut mkinitcpio
+	zfs gummiboot-efistub curl yq-go bash kbd terminus-font dracut mkinitcpio cryptsetup
 
 # Remove headers and massive dkms development toolchain; binutils
 # provides objcopy, which is necessary for UEFI bundle creation

--- a/releng/docker/image-build.sh
+++ b/releng/docker/image-build.sh
@@ -49,7 +49,7 @@ buildah run "${container}" \
 buildah run "${container}" xbps-install -y \
   linux5.10 linux5.10-headers gummiboot-efistub curl yq-go bash kbd terminus-font \
   dracut mkinitcpio dracut-network gptfdisk iproute2 iputils parted curl \
-  dosfstools e2fsprogs efibootmgr
+  dosfstools e2fsprogs efibootmgr cryptsetup
 
 # Remove headers and development toolchain, but keep binutils for objcopy
 buildah run "${container}" sh -c 'echo "ignorepkg=dkms" > /etc/xbps.d/10-nodkms.conf'


### PR DESCRIPTION
When building zfsbootmenu using the default build container it's not possible to include the crypt dracut module or the encrypt mkinitcpio hook.
The default build container should install cryptsetup for those modules/hooks to work. Including those modules/hooks is required for the [contrib/luks-unlock.sh](https://github.com/zbm-dev/zfsbootmenu/tree/master/contrib/luks-unlock.sh) script to work. 
