### PR TITLE
Dev/remote ssh access

### DIFF
--- a/docs/REMOTE-SSH.md
+++ b/docs/REMOTE-SSH.md
@@ -1,0 +1,56 @@
+# Remote SSH Support
+
+There are several ways to do this, below is only one possible option (which has
+worked at least once in the past). The script changes are heavily based on the
+instructions in the [Remote-Access-to-ZBM](https://github.com/zbm-dev/zfsbootmenu/wiki/Remote-Access-to-ZBM)
+
+
+## Preparation
+
+The ZBM initrd will contain its own SSH host keys, which will be created by
+`zbm-builder.sh` if they are not already present in `etc/dropbear` as
+`ssh_host_ecdsa_key` and `ssh_host_rsa_key`.
+Authentication of clients happens via `etc/dropbear/authorized_keys`. All
+files will end up unencrypted in the final initrd, so it is good to use
+host keys distinct from the true OS.
+
+
+## ZBM
+
+The scripts on this branch have been updated to install dropbear ssh server in
+the ZBM initrd. Make sure you have the required prerequisites mentioned in
+[BUILD.md](BUILD.md). Then a custom image can easily be built by running the
+following (possibly as root, depending on permissions required by your setup)
+
+```
+./releng/docker/image-build.sh zbm-build
+buildah push localhost/zbm-build docker-daemon:localhost/zbm-build:latest
+./zbm-builder.sh -H -C -i localhost/zbm-build -l . -s
+```
+
+
+## Filesystem
+
+The root filesystem needs to be unlockable by the primary initrd (the one that
+is started by ZBM). This can be done by using a key file stored in that initrd.
+(Instructions below for ubuntu, but can be adapted to various platforms.)
+
+```
+mkdir -p -m 700 /etc/zfs/keys
+cp passwordfile /etc/zfs/keys/rpool.key
+zfs change-key \
+    -o keylocation=file:///etc/zfs/keys/rpool.key \
+    -o keyformat=passphrase rpool
+update-initramfs -u
+```
+
+
+## Usage
+
+To unlock the pool remotely, log in via ssh, then start zfsbootmenu, enter the key
+and continue as usual.
+
+```
+ssh root@host -p 222
+zfsbootmenu
+```

--- a/etc/dropbear/.gitignore
+++ b/etc/dropbear/.gitignore
@@ -1,0 +1,2 @@
+# This directory is for user keys copied into the image
+*

--- a/etc/zfsbootmenu/dracut.conf.d/dropbear.conf
+++ b/etc/zfsbootmenu/dracut.conf.d/dropbear.conf
@@ -1,0 +1,6 @@
+# Enable dropbear ssh server and pull in network configuration args
+add_dracutmodules+=" crypt-ssh "
+install_optional_items+=" /etc/cmdline.d/dracut-network.conf "
+dropbear_rsa_key=/etc/dropbear/ssh_host_rsa_key
+dropbear_ecdsa_key=/etc/dropbear/ssh_host_ecdsa_key
+dropbear_acl=/etc/dropbear/authorized_keys

--- a/etc/zfsbootmenu/dracut.conf.d/dropbear.conf
+++ b/etc/zfsbootmenu/dracut.conf.d/dropbear.conf
@@ -1,6 +1,0 @@
-# Enable dropbear ssh server and pull in network configuration args
-add_dracutmodules+=" crypt-ssh "
-install_optional_items+=" /etc/cmdline.d/dracut-network.conf "
-dropbear_rsa_key=/etc/dropbear/ssh_host_rsa_key
-dropbear_ecdsa_key=/etc/dropbear/ssh_host_ecdsa_key
-dropbear_acl=/etc/dropbear/authorized_keys

--- a/releng/docker/image-build.sh
+++ b/releng/docker/image-build.sh
@@ -29,7 +29,7 @@ if [ ! -r "${ZBM_BUILDER}" ]; then
 fi
 
 maintainer="ZFSBootMenu Team, https://zfsbootmenu.org"
-container="$(buildah from voidlinux/voidlinux:latest)"
+container="$(buildah from ghcr.io/void-linux/void-linux:latest-full-x86_64)"
 
 buildah config --label author="${maintainer}" "${container}"
 
@@ -50,6 +50,14 @@ buildah run "${container}" xbps-install -y \
   linux5.10 linux5.10-headers gummiboot-efistub curl yq-go bash kbd terminus-font \
   dracut mkinitcpio dracut-network gptfdisk iproute2 iputils parted curl \
   dosfstools e2fsprogs efibootmgr cryptsetup
+
+# SSH related dependencies
+buildah run "${container}" xbps-install -y \
+  dracut-crypt-ssh dropbear
+
+# Enable networking
+buildah run "${container}" mkdir -p /etc/cmdline.d
+buildah run "${container}" sh -c 'echo "ip=dhcp rd.neednet=1" > /etc/cmdline.d/dracut-network.conf'
 
 # Remove headers and development toolchain, but keep binutils for objcopy
 buildah run "${container}" sh -c 'echo "ignorepkg=dkms" > /etc/xbps.d/10-nodkms.conf'

--- a/releng/docker/zbm-build.sh
+++ b/releng/docker/zbm-build.sh
@@ -246,6 +246,9 @@ if [ -d "${BUILDROOT}/dracut.conf.d" ]; then
   done
 fi
 
+# Copy dropbear related files
+cp -rv ${BUILDROOT}/etc/dropbear /etc/ || error "unable to copy dropbear directory"
+
 /zbm/bin/generate-zbm "${GENARGS[@]}" || error "failed to build images"
 
 for f in "${ZBMWORKDIR}"/build/*; do

--- a/zbm-builder.sh
+++ b/zbm-builder.sh
@@ -157,6 +157,27 @@ if ! [ -r "${BUILD_DIRECTORY}"/zpool.cache ]; then
   fi
 fi
 
+# SSH Key Files
+
+# If no local ssh host keys are available, create them
+# WARNING: These private keys will be part of the final image!
+DROPBEAR_DIR="${BUILD_DIRECTORY}"/etc/dropbear
+mkdir -p "${DROPBEAR_DIR}"
+
+if [ ! -f "${DROPBEAR_DIR}"/ssh_host_rsa_key ]; then
+  ssh-keygen -t rsa -m PEM -N '' -f "${DROPBEAR_DIR}"/ssh_host_rsa_key
+fi
+if [ ! -f "${DROPBEAR_DIR}"/ssh_host_ecdsa_key ]; then
+  ssh-keygen -t ecdsa -m PEM -N '' -f "${DROPBEAR_DIR}"/ssh_host_ecdsa_key
+fi
+
+# SSH authorized Keys
+if [ ! -f "${DROPBEAR_DIR}"/authorized_keys ]; then
+  echo "ERROR: cannot find file \"${DROPBEAR_DIR}/authorized_keys\""
+  echo "Copy an authorized_keys file to ${DROPBEAR_DIR}"
+  exit 1
+fi
+
 # If no config is specified, use in-tree default but force EFI and components
 if ! [ -r "${BUILD_DIRECTORY}"/config.yaml ]; then
   BUILD_ARGS+=( "-c" "/zbm/etc/zfsbootmenu/config.yaml" )


### PR DESCRIPTION
Extend the image-build.ssh script to install dependencies, and zbm-build.sh / zbm-builder.sh to bundle keys and configuration as described in [0]. The created image will contain ssh host private keys, and user public keys.

[0] https://github.com/zbm-dev/zfsbootmenu/wiki/Remote-Access-to-ZBM