### PR TITLE
Exploit common configurations for recovery/release images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,18 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - name: Prepare repository for build
+        run: |
+          rm -rf /zbm
+          ln -s "$(pwd)" /zbm
+          echo "zfsbootmenu_module_root='/zbm/zfsbootmenu'" > /zbm/etc/zfsbootmenu/dracut.conf.d/zbm_modroot.conf
+          yq-go e '.Global.DracutFlags += ["--no-early-microcode"]' /zbm/releng/docker/config.yaml.default > /zbm/releng/docker/config.yaml
+
       - name: Build release artifacts
         run: |
-          ln -s "$(pwd)" /zbm
-          cp /zbm/etc/zfsbootmenu/release.conf.d/release.conf /zbm/etc/zfsbootmenu/dracut.conf.d/
-          echo "zfsbootmenu_module_root='/zbm/zfsbootmenu'" >> /zbm/etc/zfsbootmenu/dracut.conf.d/release.conf
-          /zbm/releng/docker/zbm-build.sh -b /zbm/releng/docker -e '.Global.DracutFlags += ["--no-early-microcode"]' -- --debug
+          cp /zbm/etc/zfsbootmenu/dracut.conf.d/*.conf /zbm/etc/zfsbootmenu/release.conf.d/
+          yq-go e '.Global.DracutConfDir = "/zbm/etc/zfsbootmenu/release.conf.d"' -i /zbm/releng/docker/config.yaml
+          /zbm/releng/docker/zbm-build.sh -b /zbm/releng/docker -- --debug
 
       - name: Archive release EFI
         uses: actions/upload-artifact@v2
@@ -31,13 +37,15 @@ jobs:
             /zbm/releng/docker/build/*
             !/zbm/releng/docker/build/*.EFI
 
+      - name: Prune release artifacts
+        run: |
+          rm -rf /zbm/releng/docker/build/*
+
       - name: Build recovery artifacts
         run: |
-          rm /zbm/etc/zfsbootmenu/dracut.conf.d/release.conf
-          rm -rf /zbm/releng/docker/build/*
-          cp /zbm/etc/zfsbootmenu/recovery.conf.d/recovery.conf /zbm/etc/zfsbootmenu/dracut.conf.d/
-          echo "zfsbootmenu_module_root='/zbm/zfsbootmenu'" >> /zbm/etc/zfsbootmenu/dracut.conf.d/recovery.conf
-          /zbm/releng/docker/zbm-build.sh -b /zbm/releng/docker -e '.Global.DracutFlags += ["--no-early-microcode"]' -- --debug
+          cp /zbm/etc/zfsbootmenu/dracut.conf.d/*.conf /zbm/etc/zfsbootmenu/recovery.conf.d/
+          yq-go e '.Global.DracutConfDir = "/zbm/etc/zfsbootmenu/recovery.conf.d"' -i /zbm/releng/docker/config.yaml
+          /zbm/releng/docker/zbm-build.sh -b /zbm/releng/docker -- --debug
 
       - name: Archive recovery EFI
         uses: actions/upload-artifact@v2

--- a/etc/zfsbootmenu/dracut.conf.d/omit-drivers.conf
+++ b/etc/zfsbootmenu/dracut.conf.d/omit-drivers.conf
@@ -1,3 +1,3 @@
 # If you NEED drivers in ZFSBootMenu, modify the list below
 
-omit_drivers+=" amdgpu radeon nvidia nouveau i915 "
+omit_drivers+=" amdgpu radeon nvidia nouveau i915 drm "

--- a/etc/zfsbootmenu/recovery.conf.d/common.conf
+++ b/etc/zfsbootmenu/recovery.conf.d/common.conf
@@ -1,0 +1,1 @@
+../release.conf.d/common.conf

--- a/etc/zfsbootmenu/recovery.conf.d/recovery.conf
+++ b/etc/zfsbootmenu/recovery.conf.d/recovery.conf
@@ -1,29 +1,12 @@
-zfsbootmenu_teardown+=" /zbm/contrib/xhci-teardown.sh "
-zfsbootmenu_early_setup+=" /zbm/contrib/console-init.sh "
-install_optional_items+="\
- /etc/zbm-commit-hash\
- /bin/gdisk\
- /bin/parted\
- /bin/mkfs.vfat\
- /bin/mkfs.ext4\
- /bin/cryptsetup\
- /bin/efibootmgr\
- /bin/ip\
- /bin/curl\
- /bin/dhclient\
- /sbin/dhclient-script\
-"
-omit_drivers+=" amdgpu radeon nvidia nouveau i915 "
+# Filesystem manipulation
+install_optional_items+=" /bin/gdisk /bin/parted /bin/mkfs.vfat /bin/mkfs.ext4 "
 
-# Network related modules
+# Boot manipulation
+install_optional_items+=" /bin/efibootmgr "
+
+# LUKS control
+install_optional_items+=" /bin/cryptsetup "
+
+# Networking
+install_optional_items+=" /bin/ip /bin/curl /bin/dhclient /sbin/dhclient-script "
 add_dracutmodules+=" kernel-network-modules qemu-net "
-omit_dracutmodules+=" crypt-ssh nfs lunmask "
-
-# qemu drivers
-omit_dracutmodules+=" qemu "
-
-# filesystem and other related bits
-omit_dracutmodules+=" nvdimm fs-lib rootfs-block dm dmraid crypt "
-
-embedded_kcl="rd.hostonly=0"
-release_build=1

--- a/etc/zfsbootmenu/release.conf.d/common.conf
+++ b/etc/zfsbootmenu/release.conf.d/common.conf
@@ -1,0 +1,15 @@
+zfsbootmenu_teardown+=" /zbm/contrib/xhci-teardown.sh "
+zfsbootmenu_early_setup+=" /zbm/contrib/console-init.sh "
+
+install_optional_items+=" /etc/zbm-commit-hash "
+
+omit_dracutmodules+=" crypt-ssh nfs lunmask "
+
+# qemu drivers
+omit_dracutmodules+=" qemu "
+
+# filesystem and other related bits
+omit_dracutmodules+=" nvdimm fs-lib rootfs-block dm dmraid crypt "
+
+embedded_kcl="rd.hostonly=0"
+release_build=1

--- a/etc/zfsbootmenu/release.conf.d/release.conf
+++ b/etc/zfsbootmenu/release.conf.d/release.conf
@@ -1,17 +1,5 @@
-zfsbootmenu_teardown+=" /zbm/contrib/xhci-teardown.sh "
-zfsbootmenu_early_setup+=" /zbm/contrib/console-init.sh "
-install_optional_items+=" /etc/zbm-commit-hash "
-omit_drivers+=" amdgpu radeon nvidia nouveau i915 "
-
-# Network related modules
+# Network related modules are not in the regular release
 omit_dracutmodules+=" network network-legacy kernel-network-modules "
-omit_dracutmodules+=" crypt-ssh nfs lunmask "
 
-# qemu drivers
-omit_dracutmodules+=" qemu qemu-net "
-
-# filesystem and other related bits 
-omit_dracutmodules+=" nvdimm fs-lib rootfs-block dm dmraid crypt "
-
-embedded_kcl="rd.hostonly=0"
-release_build=1
+# qemu network driver
+omit_dracutmodules+=" qemu-net "


### PR DESCRIPTION
This is tested only to the point that I prepared some release assets with `make-binary.sh` and did an `lsinitrd` on the release and recovery EFI bundles to confirm that some contents are expected.