### PR TITLE
Make default efi path distro agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ vmlinuz-5.3.18_1
 vmlinuz-5.4.6_1
 ```
 
-Typically, EFI system partitions (ESP) are mounted at `/boot/efi`, as is shown above. An ESP may contain a number of sub-directories, including an `EFI` directory that often contains multiple independent EFI executables. In this example layout, `/boot/efi/EFI/void` may hold ZFSBootMenu kernels and initramfs images. After setting the `ImageDir` property of the `Components` section of `/etc/zfsbootmenu/config.yaml` to `/boot/efi/EFI/void`, running `generate-zbm` will cause ZFSBootMenu kernel and initramfs pairs to be installed in the desired location:
+Typically, EFI system partitions (ESP) are mounted at `/boot/efi`, as is shown above. An ESP may contain a number of sub-directories, including an `EFI` directory that often contains multiple independent EFI executables. In this example layout, `/boot/efi/EFI/zbm` may hold ZFSBootMenu kernels and initramfs images. After setting the `ImageDir` property of the `Components` section of `/etc/zfsbootmenu/config.yaml` to `/boot/efi/EFI/zbm`, running `generate-zbm` will cause ZFSBootMenu kernel and initramfs pairs to be installed in the desired location:
 
 ```
 # lsblk -f /dev/sda
@@ -150,7 +150,7 @@ sdg
 ├─sda1 vfat         AFC2-35EE                               7.9G     1% /boot/efi
 └─sda2 swap         412401b6-4aec-4452-a6bd-6fc20fbdc2a5                [SWAP]
 
-# ls /boot/efi/EFI/void/
+# ls /boot/efi/EFI/zbm/
 initramfs-1.12.0_1.img
 initramfs-1.12.0_2.img
 vmlinuz-1.12.0_1
@@ -166,8 +166,8 @@ efibootmgr --disk /dev/sda \
   --part 1 \
   --create \
   --label "ZFSBootMenu" \
-  --loader '\EFI\void\vmlinuz-1.12.0_2' \
-  --unicode 'zbm.prefer=zroot ro initrd=\EFI\void\initramfs-1.12.0_2.img quiet' \
+  --loader '\EFI\zbm\vmlinuz-1.12.0_2' \
+  --unicode 'zbm.prefer=zroot ro initrd=\EFI\zbm\initramfs-1.12.0_2.img quiet' \
   --verbose
 ```
 
@@ -177,7 +177,7 @@ Each time ZFSBootMenu is updated, a new EFI entry will need to be manually added
 
 ## rEFInd
 
-`rEFInd` is considerably easier to install and manage. Refer to your distribution's packages for installation. Once rEFInd has been installed, you can create `refind_linux.conf` in the directory holding the ZFSBootMenu files (`/boot/efi/EFI/void` in our example):
+`rEFInd` is considerably easier to install and manage. Refer to your distribution's packages for installation. Once rEFInd has been installed, you can create `refind_linux.conf` in the directory holding the ZFSBootMenu files (`/boot/efi/EFI/zbm` in our example):
 
 ```
 "Boot default"  "zbm.prefer=zroot ro quiet loglevel=0 zbm.skip"

--- a/docs/man/generate-zbm.5
+++ b/docs/man/generate-zbm.5
@@ -235,7 +235,7 @@ Behaves similarly to \fIComponents.Versions\fR, but acts on files matching the \
 The path to the \s-1EFI\s0 stub loader used to boot the unified bundle. If not set, a default of \fI/usr/lib/gummiboot/linuxx64.efi.stub\fR is assumed.
 .SH "EXAMPLE"
 .IX Header "EXAMPLE"
-The following example will write separate, unversioned ZFSBootMenu kernel and initramfs images to \fI/boot/efi/EFI/void\fR, keeping a backup for each file that would be overwritten when creating the new images. In addition, a versioned \s-1UEFI\s0 bundle will be stored in the same directory, where two prior revisions of the current version and the highest revision of each of the two most recent prior versions will be retained.
+The following example will write separate, unversioned ZFSBootMenu kernel and initramfs images to \fI/boot/efi/EFI/zbm\fR, keeping a backup for each file that would be overwritten when creating the new images. In addition, a versioned \s-1UEFI\s0 bundle will be stored in the same directory, where two prior revisions of the current version and the highest revision of each of the two most recent prior versions will be retained.
 .Sp
 .Vb 10
 \&  Global:
@@ -243,14 +243,14 @@ The following example will write separate, unversioned ZFSBootMenu kernel and in
 \&    BootMountPoint: /boot/efi
 \&    DracutConfDir: /etc/zfsbootmenu/dracut.conf.d
 \&  Components:
-\&    ImageDir: /boot/efi/EFI/void
+\&    ImageDir: /boot/efi/EFI/zbm
 \&    Versions: false
 \&    Enabled: true
 \&    syslinux:
 \&      Config: /boot/syslinux/syslinux.cfg
 \&      Enabled: false
 \&  EFI:
-\&    ImageDir: /boot/efi/EFI/void
+\&    ImageDir: /boot/efi/EFI/zbm
 \&    Versions: 2
 \&    Enabled: true
 \&  Kernel:

--- a/docs/pod/generate-zbm.5.pod
+++ b/docs/pod/generate-zbm.5.pod
@@ -144,7 +144,7 @@ The path to the EFI stub loader used to boot the unified bundle. If not set, a d
 
 =head1 EXAMPLE
 
-The following example will write separate, unversioned ZFSBootMenu kernel and initramfs images to I</boot/efi/EFI/void>, keeping a backup for each file that would be overwritten when creating the new images. In addition, a versioned UEFI bundle will be stored in the same directory, where two prior revisions of the current version and the highest revision of each of the two most recent prior versions will be retained.
+The following example will write separate, unversioned ZFSBootMenu kernel and initramfs images to I</boot/efi/EFI/zbm>, keeping a backup for each file that would be overwritten when creating the new images. In addition, a versioned UEFI bundle will be stored in the same directory, where two prior revisions of the current version and the highest revision of each of the two most recent prior versions will be retained.
 
 =over 4
 
@@ -153,14 +153,14 @@ The following example will write separate, unversioned ZFSBootMenu kernel and in
     BootMountPoint: /boot/efi
     DracutConfDir: /etc/zfsbootmenu/dracut.conf.d
   Components:
-    ImageDir: /boot/efi/EFI/void
+    ImageDir: /boot/efi/EFI/zbm
     Versions: false
     Enabled: true
     syslinux:
       Config: /boot/syslinux/syslinux.cfg
       Enabled: false
   EFI:
-    ImageDir: /boot/efi/EFI/void
+    ImageDir: /boot/efi/EFI/zbm
     Versions: 2
     Enabled: true
   Kernel:

--- a/etc/zfsbootmenu/config.yaml
+++ b/etc/zfsbootmenu/config.yaml
@@ -7,14 +7,14 @@ Global:
   InitCPIO: false
   InitCPIOConfig: /etc/zfsbootmenu/mkinitcpio.conf
 Components:
-  ImageDir: /boot/efi/EFI/void
+  ImageDir: /boot/efi/EFI/zbm
   Versions: 3
   Enabled: true
   syslinux:
     Config: /boot/syslinux/syslinux.cfg
     Enabled: false
 EFI:
-  ImageDir: /boot/efi/EFI/void
+  ImageDir: /boot/efi/EFI/zbm
   Versions: false
   Enabled: false
 Kernel:


### PR DESCRIPTION
Replaces `void` with `zbm` in the default esp path in configs and docs.