### PR TITLE
Add a top-row header showing the currently selected page

### DIFF
--- a/zfsbootmenu/bin/zfsbootmenu
+++ b/zfsbootmenu/bin/zfsbootmenu
@@ -125,7 +125,6 @@ while true; do
 
     bootenv="$( draw_be "${BASE}/bootenvs" )"
     ret=$?
-    tput clear
 
     if [ "${ret}" -eq 130 ]; then
       # No BEs were found, so print a warning and drop to the emergency shell
@@ -160,10 +159,7 @@ while true; do
       ;;
     "mod-k")
       if ! selection="$( draw_kernel "${selected_be}" )"; then
-        tput clear
         continue
-      else
-        tput clear
       fi
 
       # shellcheck disable=SC2162
@@ -191,10 +187,7 @@ while true; do
       ;;
     "mod-p")
       if ! selection="$( draw_pool_status )"; then
-        tput clear
         continue
-      else
-        tput clear
       fi
 
       # shellcheck disable=SC2162
@@ -216,10 +209,7 @@ while true; do
       ;;
     "mod-s")
       if ! selection="$( draw_snapshots "${selected_be}" )" ; then
-        tput clear
         continue
-      else
-        tput clear
       fi
 
       # shellcheck disable=SC2162

--- a/zfsbootmenu/bin/zfsbootmenu
+++ b/zfsbootmenu/bin/zfsbootmenu
@@ -125,6 +125,7 @@ while true; do
 
     bootenv="$( draw_be "${BASE}/bootenvs" )"
     ret=$?
+    tput clear
 
     if [ "${ret}" -eq 130 ]; then
       # No BEs were found, so print a warning and drop to the emergency shell
@@ -158,7 +159,12 @@ while true; do
       exit
       ;;
     "mod-k")
-      selection="$( draw_kernel "${selected_be}" )" || continue
+      if ! selection="$( draw_kernel "${selected_be}" )"; then
+        tput clear
+        continue
+      else
+        tput clear
+      fi
 
       # shellcheck disable=SC2162
       IFS=, read subkey selected_kernel <<< "${selection}"
@@ -184,7 +190,12 @@ while true; do
       esac
       ;;
     "mod-p")
-      selection="$( draw_pool_status )" || continue
+      if ! selection="$( draw_pool_status )"; then
+        tput clear
+        continue
+      else
+        tput clear
+      fi
 
       # shellcheck disable=SC2162
       IFS=, read subkey selected_pool <<< "${selection}"
@@ -204,7 +215,12 @@ while true; do
       echo "${BOOTFS}" > "${BASE}/bootfs"
       ;;
     "mod-s")
-      selection="$( draw_snapshots "${selected_be}" )" || continue
+      if ! selection="$( draw_snapshots "${selected_be}" )" ; then
+        tput clear
+        continue
+      else
+        tput clear
+      fi
 
       # shellcheck disable=SC2162
       IFS=, read subkey selected_snap <<< "${selection}"

--- a/zfsbootmenu/bin/zfsbootmenu
+++ b/zfsbootmenu/bin/zfsbootmenu
@@ -85,8 +85,10 @@ fi
 # Double quote the zlogtail lines so that they expand immediately
 
 # shellcheck disable=SC2016
+  #"--ansi" "--no-clear" "--cycle" "--color=16"
+  #"--layout=default" "--inline-info" "--tac"
 fuzzy_default_options=(
-  "--ansi" "--no-clear" "--cycle" "--color=16"
+  "--ansi" "--cycle" "--color=16"
   "--layout=reverse-list" "--inline-info" "--tac"
   "--bind" '"alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} ]"'
   "--bind" '"ctrl-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} ]"'

--- a/zfsbootmenu/bin/zfsbootmenu
+++ b/zfsbootmenu/bin/zfsbootmenu
@@ -85,8 +85,6 @@ fi
 # Double quote the zlogtail lines so that they expand immediately
 
 # shellcheck disable=SC2016
-  #"--ansi" "--no-clear" "--cycle" "--color=16"
-  #"--layout=default" "--inline-info" "--tac"
 fuzzy_default_options=(
   "--ansi" "--cycle" "--color=16"
   "--layout=reverse-list" "--inline-info" "--tac"

--- a/zfsbootmenu/bin/zlogtail
+++ b/zfsbootmenu/bin/zlogtail
@@ -40,3 +40,4 @@ log_tail() {
 }
 
 log_tail
+tput clear

--- a/zfsbootmenu/bin/zlogtail
+++ b/zfsbootmenu/bin/zlogtail
@@ -1,27 +1,42 @@
 #!/bin/bash
+# vim: softtabstop=2 shiftwidth=2 expandtab
 
-[ -f "${BASE}/have_errors" ] && rm "${BASE}/have_errors"
-[ -f "${BASE}/have_warnings" ] && rm "${BASE}/have_warnings"
+# shellcheck disable=SC1091
+source /lib/zfsbootmenu-core.sh >/dev/null 2>&1 || exit 1
+source /lib/zfsbootmenu-lib.sh >/dev/null 2>&1 || exit 1
 
-[ -z "${FUZZYSEL}" ] && FUZZYSEL=fzf
+log_tail() {
+  [ -f "${BASE}/have_errors" ] && rm "${BASE}/have_errors"
+  [ -f "${BASE}/have_warnings" ] && rm "${BASE}/have_warnings"
 
-fuzzy_default_options+=(
-  "--no-sort" "--ansi" "--tac" "--no-mouse"
-  "--info=hidden"
-)
+  [ -z "${FUZZYSEL}" ] && FUZZYSEL=fzf
 
-if [ -n "${HAS_DISABLED}" ]; then
+  HEIGHT="$( tput lines )"
+
   fuzzy_default_options+=(
-    "--disabled"
+    "--no-sort" "--ansi" "--tac" "--no-mouse"
+    "--inline-info" "--height $(( HEIGHT - 1 ))"
   )
-fi
 
-export FZF_DEFAULT_OPTS="${fuzzy_default_options[*]}"
+  if [ -n "${HAS_DISABLED}" ]; then
+    fuzzy_default_options+=(
+      "--disabled"
+    )
+  fi
 
-# Try to use feature flags found on dmesg from util-linux
-if output="$( dmesg --notime -f user -l err,warn 2>/dev/null )" ; then
-  echo "${output}" | ${FUZZYSEL}
-else
-  # fall back to manually parsing dmesg output; will show all ZBM generated logs up to zinfo level
-  dmesg | awk '/ZFSBootMenu:/{ for (i=3; i<=NF; i++){ printf("%s ", $i)}; printf "\n" }' | ${FUZZYSEL}
-fi
+  export FZF_DEFAULT_OPTS="${fuzzy_default_options[*]}"
+
+  source /lib/zfsbootmenu-core.sh >/dev/null 2>&1 || exit 1
+  source /lib/zfsbootmenu-lib.sh >/dev/null 2>&1 || exit 1
+  draw_page
+
+  # Try to use feature flags found on dmesg from util-linux
+  if output="$( dmesg --notime -f user -l err,warn 2>/dev/null )" ; then
+    echo "${output}" | ${FUZZYSEL}
+  else
+    # fall back to manually parsing dmesg output; will show all ZBM generated logs up to zinfo level
+    dmesg | awk '/ZFSBootMenu:/{ for (i=3; i<=NF; i++){ printf("%s ", $i)}; printf "\n" }' | ${FUZZYSEL}
+  fi
+}
+
+log_tail

--- a/zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -55,7 +55,6 @@ colorize() {
 
 draw_page() {
   local header tab
-
   zdebug "Called from function: ${BASH_SOURCE[1]} ${FUNCNAME[1]}"
   header="$( center_string "Boot Environments | Snapshots | Kernels | Pool Status | Logs | Help" )"
 

--- a/zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -53,6 +53,37 @@ colorize() {
   echo -e -n '\033[0m'
 }
 
+draw_page() {
+  local header tab
+
+  zdebug "Called from function: ${FUNCNAME[1]}"
+  header="$( center_string "Boot Environments | Snapshots | Kernels | Pool Status | Logs | Help" )"
+
+  case "${FUNCNAME[1]}" in
+    draw_be)
+      tab="$( colorize red "Boot Environments" )"
+      header="${header/Boot Environments/${tab}}"
+      ;;
+    draw_kernel)
+      tab="$( colorize red "Kernels" )"
+      header="${header/Kernels/${tab}}"
+      ;;
+    draw_snapshots)
+      tab="$( colorize red "Snapshots" )"
+      header="${header/Snapshots/${tab}}"
+      ;;
+    draw_pool_status)
+      tab="$( colorize red "Pool Status" )"
+      header="${header/Pool Status/${tab}}"
+      ;;
+    *)
+      ;;
+  esac
+
+  # shellcheck disable=SC2154
+  echo -e "${header}" > "${control_term}"
+}
+
 # arg1: text to center
 # prints: left-padded text
 # returns: nothing

--- a/zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -56,7 +56,7 @@ colorize() {
 draw_page() {
   local header tab
 
-  zdebug "Called from function: ${FUNCNAME[1]}"
+  zdebug "Called from function: ${BASH_SOURCE[1]} ${FUNCNAME[1]}"
   header="$( center_string "Boot Environments | Snapshots | Kernels | Pool Status | Logs | Help" )"
 
   case "${FUNCNAME[1]}" in
@@ -76,6 +76,14 @@ draw_page() {
       tab="$( colorize red "Pool Status" )"
       header="${header/Pool Status/${tab}}"
       ;;
+    help_pager)
+      tab="$( colorize red "Help" )"
+      header="${header/Help/${tab}}"
+      ;;
+    log_tail)
+      tab="$( colorize red "Logs" )"
+      header="${header/Logs/${tab}}"
+      ;;
     *)
       ;;
   esac
@@ -89,6 +97,7 @@ draw_page() {
 # returns: nothing
 
 center_string() {
+  [ -z "${COLUMNS}" ] && COLUMNS="$( tput cols )"
   printf "%*s" $(( ( ${#1} + COLUMNS ) / 2 )) "${1}"
 }
 

--- a/zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -53,44 +53,6 @@ colorize() {
   echo -e -n '\033[0m'
 }
 
-draw_page() {
-  local header tab
-  zdebug "Called from function: ${BASH_SOURCE[1]} ${FUNCNAME[1]}"
-  header="$( center_string "Boot Environments | Snapshots | Kernels | Pool Status | Logs | Help" )"
-
-  case "${FUNCNAME[1]}" in
-    draw_be)
-      tab="$( colorize red "Boot Environments" )"
-      header="${header/Boot Environments/${tab}}"
-      ;;
-    draw_kernel)
-      tab="$( colorize red "Kernels" )"
-      header="${header/Kernels/${tab}}"
-      ;;
-    draw_snapshots)
-      tab="$( colorize red "Snapshots" )"
-      header="${header/Snapshots/${tab}}"
-      ;;
-    draw_pool_status)
-      tab="$( colorize red "Pool Status" )"
-      header="${header/Pool Status/${tab}}"
-      ;;
-    help_pager)
-      tab="$( colorize red "Help" )"
-      header="${header/Help/${tab}}"
-      ;;
-    log_tail)
-      tab="$( colorize red "Logs" )"
-      header="${header/Logs/${tab}}"
-      ;;
-    *)
-      ;;
-  esac
-
-  # shellcheck disable=SC2154
-  echo -e "${header}" > "${control_term}"
-}
-
 # arg1: text to center
 # prints: left-padded text
 # returns: nothing
@@ -99,10 +61,6 @@ center_string() {
   [ -z "${COLUMNS}" ] && COLUMNS="$( tput cols )"
   printf "%*s" $(( ( ${#1} + COLUMNS ) / 2 )) "${1}"
 }
-
-# arg1: text to center
-# prints: left-padded text
-# returns: nothing
 
 # arg1: hostid, as hex number without leading "0x"
 # prints: nothing

--- a/zfsbootmenu/lib/zfsbootmenu-lib.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-lib.sh
@@ -159,7 +159,9 @@ draw_kernel() {
       --preview="/libexec/zfsbootmenu-preview ${benv} ${BOOTFS}"  \
       --preview-window="up:${PREVIEW_HEIGHT}" < "${_kernels}" )"; then
     return 1
+    tput clear
   fi
+  tput clear
 
   # shellcheck disable=SC2119
   selected="$( csv_cat <<< "${selected}" )"
@@ -215,7 +217,9 @@ draw_snapshots() {
         --preview="/libexec/zfsbootmenu-preview ${benv} ${BOOTFS} '${context}'" \
         --preview-window="up:$(( PREVIEW_HEIGHT + 1 ))" <<<"${snapshots}" )"; then
     return 1
+    tput clear
   fi
+  tput clear
 
   # shellcheck disable=SC2119
   selected="$( csv_cat <<< "${selected}" )"
@@ -327,6 +331,7 @@ draw_pool_status() {
       --preview="zpool status -v {}" --header="${header}" )"; then
     return 1
   fi
+  tput clear
 
   # shellcheck disable=SC2119
   selected="$( csv_cat <<< "${selected}" )"

--- a/zfsbootmenu/lib/zfsbootmenu-lib.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-lib.sh
@@ -55,7 +55,8 @@ column_wrap() {
   
   local max pad
   max="$( echo -e "${footer}" | awk -v l=0 'length>l {l=length}; END{print l}' )"
-  printf -v pad "%*s" $(( ( COLUMNS - max - 3 ) / 2 )) ''
+  # remove an extra 5 - 3 for 'pad', 2 for the fzf gutter
+  printf -v pad "%*s" $(( ( COLUMNS - max - 5 ) / 2 )) ''
 
   footer="${footer//\[/\\033\[0;32m\[}"
   footer="${footer//\]/\]\\033\[0m}"

--- a/zfsbootmenu/libexec/zfsbootmenu-help
+++ b/zfsbootmenu/libexec/zfsbootmenu-help
@@ -48,6 +48,9 @@ help_pager() {
     --preview-window="right:${PREVIEW_SIZE}:wrap" \
     --header="${header}" \
     --tac --inline-info --ansi --layout="reverse-list"
+
+  # re-draw the header for the page that called us, otherwise it might be missing
+  draw_page "${WANTED}"
 }
 
 doc_base="/usr/share/docs/help-files"

--- a/zfsbootmenu/libexec/zfsbootmenu-help
+++ b/zfsbootmenu/libexec/zfsbootmenu-help
@@ -13,6 +13,7 @@ source /lib/zfsbootmenu-lib.sh >/dev/null 2>&1 || exit 1
 # fzf (-s).
 
 WIDTH="$( tput cols )"
+HEIGHT="$( tput lines )"
 PREVIEW_SIZE="$(( WIDTH - 28 ))"
 [ ${PREVIEW_SIZE} -lt 10 ] && PREVIEW_SIZE=10
 
@@ -37,7 +38,9 @@ help_pager() {
 [ESCAPE] back
 ")"
 
+  draw_page
   printf '%s\n' "${SORTED[@]}" | ${FUZZYSEL} \
+    --height=$(( HEIGHT - 1 )) \
     --prompt 'Topic > ' \
     --with-nth=2.. \
     --bind pgup:preview-up,pgdn:preview-down \


### PR DESCRIPTION
The `draw_page` function is a bit of a hack, it has to write directly to the controlling terminal. This has been tested successfully on both serial outputs and virtualized physical outputs. To avoid weirdness, escape sequences are used to write the string directly to the required rows/columns, overwriting the existing header. Since the headers are always the same length, this just changes the highlighted page. A line return is NOT added; `fzf` does the right thing and starts drawing correctly on the next row, at column 0. `fzf` has to be told that the screen is 1 row shorter than it actually is, since it'll by default run in full screen mode.

Also add a special character `^` to help key text, indicating that the line should be centered on the screen. 

![image](https://user-images.githubusercontent.com/13874853/192603843-24e58568-b316-472d-b324-1fadd6d38983.png)
