### PR TITLE
Add support for !!, so ONLY the preferred pool is imported

### DIFF
--- a/docs/pod/zfsbootmenu.7.pod
+++ b/docs/pod/zfsbootmenu.7.pod
@@ -18,9 +18,25 @@ These options are set on the kernel command line when booting the initramfs or U
 
 When creating an initramfs or UEFI bundle, the I</etc/hostid> from the system is copied into the target. If this image will be used on another system with a different hostid, replace B<E<lt>hostidE<gt>> with the desired hostid, as an eight-digit hexadecimal number, to override the value contained within the image.
 
+=item B<zbm.prefer>
+
+ZFSBootMenu will attempt to import as many pools as possible to identify boot environments and will, by default, look for the I<bootfs> property on the first imported pool (sorted alphabetically) to select the default boot environment. This option controls this behavior.
+
+=over 2
+
 =item B<zbm.prefer=E<lt>poolE<gt>>
 
-ZFSBootMenu will attempt to import as many pools as possible to identify boot environments and will, by default, look for the I<bootfs> property on the first imported pool (sorted alphabetically) to select the default boot environment. If you have multiple pools, replace B<E<lt>poolE<gt>> with the name of your preferred pool to override the default. If B<E<lt>poolE<gt>> is the name of a pool followed by a literal I<!> character, ZFSBootMenu will insist on successfully importing the named pool before attempting to import any others.
+The simplest form attempts to import B<E<lt>poolE<gt>> before any other pool. The I<bootfs> value from this pool will control the default boot environment.
+
+=item B<zbm.prefer=E<lt>poolE<gt>I<!>>
+
+If a literal I<!> has been appended to the pool name, ZFSBootMenu will insist on successfully importing the named pool before attempting to import any others.
+
+=item B<zbm.prefer=E<lt>poolE<gt>I<!!>>
+
+If a literal I<!!> has been appended to the pool name, ZFSBootMenu will insist on successfully importing the named pool and no others. 
+
+=back
 
 =item B<zbm.import_delay=E<lt>timeE<gt>>
 

--- a/zfsbootmenu/help-files/132/zfsbootmenu.7.pod
+++ b/zfsbootmenu/help-files/132/zfsbootmenu.7.pod
@@ -16,11 +16,22 @@ general systems to boot without setting any values.
     on another system with a different hostid, replace [1m<hostid>[0m with the desired hostid, as an eight-digit hexadecimal number, to
     override the value contained within the image.
 
-[1mzbm.prefer=<pool>[0m
+[1mzbm.prefer[0m
     ZFSBootMenu will attempt to import as many pools as possible to identify boot environments and will, by default, look for the
-    [33mbootfs[0m property on the first imported pool (sorted alphabetically) to select the default boot environment. If you have multiple
-    pools, replace [1m<pool>[0m with the name of your preferred pool to override the default. If [1m<pool>[0m is the name of a pool followed by
-    a literal [33m![0m character, ZFSBootMenu will insist on successfully importing the named pool before attempting to import any others.
+    [33mbootfs[0m property on the first imported pool (sorted alphabetically) to select the default boot environment. This option controls
+    this behavior.
+
+    [1mzbm.prefer=<pool>[0m
+      The simplest form attempts to import [1m<pool>[0m before any other pool. The [33mbootfs[0m value from this pool will control the default
+      boot environment.
+
+    [1mzbm.prefer=<pool>[33m![0m[0m
+      If a literal [33m![0m has been appended to the pool name, ZFSBootMenu will insist on successfully importing the named pool before
+      attempting to import any others.
+
+    [1mzbm.prefer=<pool>[33m!![0m[0m
+      If a literal [33m!![0m has been appended to the pool name, ZFSBootMenu will insist on successfully importing the named pool and no
+      others.
 
 [1mzbm.import_delay=<time>[0m
     Should ZFSBootMenu fail to successfully import any pool, it will repeat import attempts indefinitely until at least one pool can

--- a/zfsbootmenu/help-files/52/zfsbootmenu.7.pod
+++ b/zfsbootmenu/help-files/52/zfsbootmenu.7.pod
@@ -24,19 +24,30 @@ without setting any values.
     hexadecimal number, to override the value
     contained within the image.
 
-[1mzbm.prefer=<pool>[0m
+[1mzbm.prefer[0m
     ZFSBootMenu will attempt to import as many pools
     as possible to identify boot environments and
     will, by default, look for the [33mbootfs[0m property
     on the first imported pool (sorted
     alphabetically) to select the default boot
-    environment. If you have multiple pools, replace
-    [1m<pool>[0m with the name of your preferred pool to
-    override the default. If [1m<pool>[0m is the name of a
-    pool followed by a literal [33m![0m character,
-    ZFSBootMenu will insist on successfully
-    importing the named pool before attempting to
-    import any others.
+    environment. This option controls this behavior.
+
+    [1mzbm.prefer=<pool>[0m
+      The simplest form attempts to import [1m<pool>[0m
+      before any other pool. The [33mbootfs[0m value from
+      this pool will control the default boot
+      environment.
+
+    [1mzbm.prefer=<pool>[33m![0m[0m
+      If a literal [33m![0m has been appended to the pool
+      name, ZFSBootMenu will insist on successfully
+      importing the named pool before attempting to
+      import any others.
+
+    [1mzbm.prefer=<pool>[33m!![0m[0m
+      If a literal [33m!![0m has been appended to the pool
+      name, ZFSBootMenu will insist on successfully
+      importing the named pool and no others.
 
 [1mzbm.import_delay=<time>[0m
     Should ZFSBootMenu fail to successfully import

--- a/zfsbootmenu/help-files/92/zfsbootmenu.7.pod
+++ b/zfsbootmenu/help-files/92/zfsbootmenu.7.pod
@@ -18,14 +18,23 @@ Default options were chosen to allow general systems to boot without setting any
     replace [1m<hostid>[0m with the desired hostid, as an eight-digit hexadecimal number, to
     override the value contained within the image.
 
-[1mzbm.prefer=<pool>[0m
+[1mzbm.prefer[0m
     ZFSBootMenu will attempt to import as many pools as possible to identify boot
     environments and will, by default, look for the [33mbootfs[0m property on the first imported
-    pool (sorted alphabetically) to select the default boot environment. If you have
-    multiple pools, replace [1m<pool>[0m with the name of your preferred pool to override the
-    default. If [1m<pool>[0m is the name of a pool followed by a literal [33m![0m character, ZFSBootMenu
-    will insist on successfully importing the named pool before attempting to import any
-    others.
+    pool (sorted alphabetically) to select the default boot environment. This option
+    controls this behavior.
+
+    [1mzbm.prefer=<pool>[0m
+      The simplest form attempts to import [1m<pool>[0m before any other pool. The [33mbootfs[0m value
+      from this pool will control the default boot environment.
+
+    [1mzbm.prefer=<pool>[33m![0m[0m
+      If a literal [33m![0m has been appended to the pool name, ZFSBootMenu will insist on
+      successfully importing the named pool before attempting to import any others.
+
+    [1mzbm.prefer=<pool>[33m!![0m[0m
+      If a literal [33m!![0m has been appended to the pool name, ZFSBootMenu will insist on
+      successfully importing the named pool and no others.
 
 [1mzbm.import_delay=<time>[0m
     Should ZFSBootMenu fail to successfully import any pool, it will repeat import attempts

--- a/zfsbootmenu/hook/zfsbootmenu-parse-commandline.sh
+++ b/zfsbootmenu/hook/zfsbootmenu-parse-commandline.sh
@@ -231,13 +231,23 @@ case "${root}" in
   ;;
 esac
 
-# Pool preference ending in ! indicates a hard requirement
-bpool="${root%\!}"
-if [ "${bpool}" != "${root}" ]; then
-  # shellcheck disable=SC2034
-  zbm_require_bpool=1
-  root="${bpool}"
-fi
+# pool! : this pool must be imported before all others
+# pool!!: this pool, and no others, must be imported
+
+# shellcheck disable=SC2034
+case "${root}" in
+  *!!)
+    zbm_require_bpool="only"
+    root="${root%!!}"
+    ;;
+  *!)
+    zbm_require_bpool="yes"
+    root="${root%!}"
+    ;;
+  *)
+    zbm_require_bpool=""
+    ;;
+esac
 
 # Make sure Dracut is happy that we have a root
 if [ ${wait_for_zfs} -eq 1 ]; then

--- a/zfsbootmenu/libexec/zfsbootmenu-init
+++ b/zfsbootmenu/libexec/zfsbootmenu-init
@@ -105,7 +105,10 @@ while true; do
 
   # shellcheck disable=SC2154
   if check_for_pools; then
-    if [ -n "${try_pool}" ]; then
+    if [ "${zbm_require_bpool}" = "only" ]; then
+      zdebug "only importing ${try_pool}"
+      break
+    elif [ -n "${try_pool}" ]; then
       # If a single pool was requested and imported, try importing others
       try_pool=""
       continue
@@ -127,7 +130,7 @@ while true; do
     # allow another pass to pick up others with the same hostid
     try_pool=""
     continue
-  elif [ -n "${try_pool}" ] && [ "${zbm_require_bpool:-0}" -ne 1 ]; then
+  elif [ -n "${try_pool}" ] && [ -z "${zbm_require_bpool}" ]; then
     # If a specific pool was tried unsuccessfully but is not a requirement,
     # allow another pass to try any other importable pools
     try_pool=""


### PR DESCRIPTION
Extend the modifiers for `zbm.prefer` to include `!!`. The single `!` behavior is preserved, requiring the named pool to be imported. Once that import has completed successfully, no other imports are attempted. This has been minimally tested on a two pool test environment. There might be a nicer way to do the `!` / `!!` check, but this seems to work well enough.