### PR TITLE
Move boot environments to ${BASE}/environments/

### DIFF
--- a/zfsbootmenu/lib/zfsbootmenu-lib.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-lib.sh
@@ -589,7 +589,7 @@ populate_be_list() {
   ret=1
   for fs in "${candidates[@]}"; do
     # Remove any existing cmdline cache
-    rm -f "${BASE}/${fs}/cmdline"
+    rm -f "$( be_location "${fs}" )/cmdline"
 
     # Unlock if necessary
     load_key "${fs}" || continue


### PR DESCRIPTION
It's only a matter of time until a pool name conflicts with a file that we create in `/zfsbootmenu`. Moving the pool/dataset directory layout to `/zfsbootmenu/environments` puts them in a directory free of potential conflicts. A helper function, `be_location` has been added that returns the on-disk path for where a filesystem _should_ be mounted/live. This avoids having to manually construct this string when `mount_zfs` isn't in use.