### PR TITLE
Explicitly require bash, blacklist dash

### DIFF
--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -7,7 +7,7 @@ check() {
 }
 
 depends() {
-  echo udev-rules
+  echo bash udev-rules
   return 0
 }
 

--- a/etc/zfsbootmenu/dracut.conf.d/zfsbootmenu.conf
+++ b/etc/zfsbootmenu/dracut.conf.d/zfsbootmenu.conf
@@ -1,3 +1,3 @@
 nofsck="yes"
 add_dracutmodules+=" zfsbootmenu "
-omit_dracutmodules+=" btrfs zfs resume systemd systemd-initrd dracut-systemd plymouth "
+omit_dracutmodules+=" btrfs zfs resume systemd systemd-initrd dracut-systemd plymouth dash "


### PR DESCRIPTION
I don't know what broke the Debian and Ubuntu installations in https://github.com/zbm-dev/zfsbootmenu/issues/335 and I can't reproduce the issue in our testbed, even when I bump Ubuntu from "jammy" to "kinetic". However, clearly something has caused the affected images to link `/bin/sh` to dash. This breaks our KCL parsing, which is done in a sourced dracut hook before we explicitly exec into bash and take control.

The dracut `bash` module will force installation of `/bin/bash` and, if `/bin/sh` isn't linked, link to bash. Adding `bash` to the required dependencies of the ZBM dracut module seems like a no-brainer. The `bash` module was added to dracut in 2013 so we should not have any issues.

When I spun up a testbed, I noticed that the initramfs generated by my system also included the `dash` module. Like `bash`, this module installs dash and, if `/bin/sh` isn't linked, link to dash. This creates the possibilityh of an ordering problem where `dash` is processed first; they are currently named `00bash` and `00dash` so lexicographical ordering should ensure `bash` is processed first. However, I don't know if there are other means for sorting and processing modules that could cause problems.

In response, I have blacklisted the `dash` module. I don't know if there are adverse consequences to this and am on the fence. Maybe we just hard depend on `bash` and wait for additional reports of broken systems to take more aggressive action.

Another alternative is to defer ZBM KCL parsing until we exec into our own preinit. This probably doesn't change anything from our perspective and means we don't have to care about whether dash is `/bin/sh` or not.

Thoughts?