### PR TITLE
Fix kernel selection after introducing $BASE/environments

### DIFF
--- a/zfsbootmenu/lib/zfsbootmenu-lib.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-lib.sh
@@ -135,7 +135,7 @@ draw_kernel() {
     return 130
   fi
 
-  _kernels="${BASE}/${benv}/kernels"
+  _kernels="$( be_location "${benv}" )/kernels"
   if [ ! -r "${_kernels}" ] ; then
     zerror "kernel file ${_kernels} missing"
     return 130


### PR DESCRIPTION
After commit 3399f4bdc6ca, ZBM no longer allows user to select a kernel to boot, with the log error message:

```
ZFSBootMenu: kernel file zfsbootmenu/<pool and bootenv here>/kernels missing
```

That is due to that the path to the kernels list hasn't been updated to use `be_location()` and still uses the old `"zfsbootmenu/<pool>"` scheme. Doing `ln -s` from the recovery shell solves the problem.
Adjust that place accordingly to fix the issue.