### PR TITLE
[WIP] Testing, review, documentation for v2.1.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,58 @@
+# ZFSBootMenu v2.1.0 (2022-12-19)
+
+## Deprecated features
+
+* `syslinux` support as a core part of `generate-zbm` will be removed in the next release. [contrib/syslinux-update.sh](https://github.com/zbm-dev/zfsbootmenu/blob/master/contrib/syslinux-update.sh) should be used to create `syslinux.cfg` moving forward. Refer to the script for usage documentation.
+* Awareness of platform endianness when writing `/etc/hostid` was rendered moot when support for `skim` was removed because `fzf` is only supported on little-endian systems. All hostid writes assume little-endian byte order by default.
+
+## New features
+
+* The command line option `zbm.prefer` has been extended with a `!!` marker to import exactly one pool when multiple are available on a system. Refer to [docs/pod/zfsbootmenu.7.pod](https://github.com/zbm-dev/zfsbootmenu/blob/master/docs/pod/zfsbootmenu.7.pod) for more details.
+* Users of the binary releases are now able to use their own custom hooks with the new `zbm.hookroot` command line option. Using this, a partition and directory specification can be provided which allows for additional scripts to be loaded at runtime. Refer to [docs/pod/zfsbootmenu.7.pod](https://github.com/zbm-dev/zfsbootmenu/blob/master/docs/pod/zfsbootmenu.7.pod) for more details.
+* [contrib/remote-ssh-build.sh](https://github.com/zbm-dev/zfsbootmenu/blob/master/contrib/remote-ssh-build.sh) has been provided by a new contributor. This script helps ease the creation of a custom EFI file with an embedded SSH server and keys.
+* A global application header has been added to highlight the pages that are available and the currently selected page.
+* Unless explicitly configured, `generate-zbm` will now default to `dracut` but fall back to `mkinitcpio` when it cannot find `dracut` in the path.
+* The build container `ghcr.io/zbm-dev/zbm-builder` has been substantially improved, making it easier to manage custom images built in a controlled, compatible environment using podman or docker.
+
+## Fixes
+
+* On some systems, Dracut was incorrectly using `dash` where `bash` should be used. Forbidding the inclusion of `dash` with Dracut resolves this issue.
+* The `drm` Dracut module has been blacklisted. ZFSBootMenu should never attempt to load firmware for video cards.
+* When using ZFSBootMenu to pin a kernel, ensure that an anchor is attached to the end of the pin. This resolves incorrect matches on systems that have unversioned kernels.
+* To avoid a potential conflict between ZFS pool names and files/directories created by ZFSBootMenu, all detected boot environment mountpoints have been moved to a dedicated `environments/` sub-directory.
+
+## Significant commits in this release
+* 8e6ca4a - set_default_kernel: properly clear default when no kernel is specified (Andrew J. Hesford)
+* 0b40f44 - interface: enable left/right arrow key navigation (Zach Dykstra)
+* 235eb17 - Stop installing zpool.cache (Andrew J. Hesford)
+* 5427883 - Improve containerized builds (Andrew J. Hesford)
+* c023517 - Automatically select initramfs generator when not forced (Andrew J. Hesford)
+* 6223804 - Update artifact uploader to latest version (Zach Dykstra)
+* 00ef434 - Add/use border label feature flag (Zach Dykstra)
+* 562b14a - Fix booting test VMs on some hardware (Zach Dykstra)
+* 8d3bbff - Fix kernel selection after introducing $BASE/environments (Alexander Lobakin)
+* b743893 - contrib/README.md: document contrib scripts (Andrew J. Hesford)
+* a3f15ed - generate-zbm: deprecate syslinux support (Andrew J. Hesford)
+* 9f85003 - Include the OpenSSH client in recovery images (Zach Dykstra)
+* 91900d3 - Explicitly require bash, blacklist dash (Andrew J. Hesford)
+* 3399f4b - Move dataset mountpoint to $BASE/environments/ (Zach Dykstra)
+* 7eb7780 - Allow imports of hooks from external sources at runtime (Andrew J. Hesford)
+* 57b46a2 - Extend capabilities of zbm.prefer (Zach Dykstra)
+* af1c74b - Remove diff from early days of playing around (Zach Dykstra)
+* 3da5547 - Center key bind text on horizontal layout fzf screens (Zach Dykstra)
+* df8ab05 - Support busybox as /bin/sh in chroot (Zach Dykstra)
+* 2fa207e - fix: ensure $uefi_stub is defined before checking if it is a file (Zach Dykstra)
+* 906ce3b - Add anchor to end of string when pinning a kernel (Zach Dykstra)
+* 9c91afa - Make default efi path distro agnostic (gardar)
+* 333b6d8 - Wrapper Build Script for ZBM with SSH access (Gerhard Roethlin)
+* 05dbf11 - Show /etc/zbm-commit-hash in zreport (Zach Dykstra)
+* d4b35a0 - zbm-build.sh: don't upgrade packages when installing custom software (Andrew J. Hesford)
+* 10e3624 - Exploit common configurations for recovery/release images (Andrew J. Hesford)
+* 1be8ed0 - Drop drm module from standard dracut config (Andrew J. Hesford)
+* 9b57d8a - testing: move Ubuntu to 22.04 LTS, make column available to Debian/Ubuntu (Andrew J. Hesford)
+* feb6a26 - documentation: provide a link to the wiki (Zach Dykstra)
+* f2d3336 - Add a contrib script to snapshot the BE prior to boot (Zach Dykstra)
+
 # ZFSBootMenu v2.0.0 (2022-06-28)
 
 ZFSBootMenu 2.0.0 introduces a major internal reorganization that allows images to be built with initramfs generators other than dracut and includes some helpful command-line utilities. This release is based on Linux 5.10.125 and ZFS 2.1.5.

--- a/testing/TPSReport.md
+++ b/testing/TPSReport.md
@@ -129,7 +129,7 @@ From the main menu, perform the following checks:
 - [ ] Pressing `[CTRL+W]` toggles the pool holding the selected BE between
   read-only and read/write.
 
-- [ ] Pressing `[CTRL+O]` cycles through name/creation/used sort order
+- [ ] Pressing `[CTRL+O]` cycles through name/creation/used sort order.
 
 ## Pool Status Checks
 
@@ -144,7 +144,7 @@ From the main menu, perform the following checks:
 - [ ] Pressing `[CTRL+J]` jumps into an interactive chroot for the selected
   snapshot, or fails if the snapshot is missing a shell.
 
-- [ ] Pressing `[CTRL+D]` shows the diff viewer
+- [ ] Pressing `[CTRL+D]` shows the diff viewer:
     - Selecting one snapshot will show a diff between the snapshot and the filesystem
     - Selecting two snapshots will show the diff between them
     - The diff screen updates dynamically and is interruptable
@@ -175,13 +175,13 @@ From the main menu, perform the following checks:
     - Entering a non-empty name triggers a new snapshot
     - The new snapshot appears in the list of snapshots
 
-- [ ] Pressing `[CTRl+R]` presents the rollback creation prompt
+- [ ] Pressing `[CTRl+R]` presents the rollback creation prompt:
     - The selected snapshot is listed, highlighted in red
     - Entering anything but `ROLLBACK` cancels the operation
     - Entering `ROLLBACK` rolls the dataset back to the snapshot
     - The selected snapshot is no longer listed on the Snapshot screen
 
-- [ ] Pressing `[CTRL+O]` cycles through name/creation/used sort order
+- [ ] Pressing `[CTRL+O]` cycles through name/creation/used sort order.
 
 - [ ] Pressing `[ESCAPE]` returns to the main menu.
 
@@ -210,6 +210,9 @@ of the kernel list. That BE should be selected when entering the list.
 - [ ] Pressing `[CTRL+H]` displays the help browser, preselecting the section
   corresponding to the current menu screen.
 
+- [ ] Pressing the left/right arrow keys moves to the next/previous screen shown
+  in the header. Screens will not wrap around.
+
 ## General Testing
 
 - [ ] If every encryption root specifies an `org.zfsbootmenu:keysource`
@@ -229,43 +232,50 @@ of the kernel list. That BE should be selected when entering the list.
   prompt each time. (Keys must not have been already cached before a keysource
   property is cleared, or the previously cached keys will continue to be used.)
 
-- [ ] ZBM can be forced to spin until the pool defined via zbm.prefer=pool!
+- [ ] ZBM can be forced to spin until the pool defined via `zbm.prefer=pool!`
   is available. During the wait period, the user can exit to a recovery shell
-  via `[ESCAPE]`
+  via `[ESCAPE]`.
 
-- [ ] ZBM can be forced to import *only* a specific pool via zbm.prefer=pool!!.
+- [ ] ZBM can be forced to import the pool defined via `zbm.prefer=pool!!` with
+  all other pools ignored/skipped. This will spin until the pool is available, and
+  can be broken via `[ESCAPE]`.
 
-- [ ] Invalid `spl_hostid` or `spl.spl_hostid` values do not cause ZBM to fail
+- [ ] Invalid `spl_hostid` or `spl.spl_hostid` values do not cause ZBM to fail.
 
-- [ ] Adding `zbm.skip` to the KCL causes ZBM to immediately boot BOOTFS, otherwise
-  show the main menu.
+- [ ] Adding `zbm.skip` to the KCL causes ZBM to immediately boot BOOTFS,
+  otherwise show the main menu.
 
 - [ ] Adding `zbm.show` to the KCL causes ZBM to always show the main menu.
 
-- [ ] Adding `rd.vconsole.keymap=fr` causes the ZBM keymap to change when booted in 
-  GTK mode. This can be verified by dropping to the recovery shell and typing qwerty.
+- [ ] Adding `rd.vconsole.keymap=fr` causes the ZBM keymap to change when booted
+  in GTK mode. This can be verified by dropping to the recovery shell and typing
+  qwerty.
 
-## Recovery shell and SSH access
+## Recovery Shell and SSH Access
 
-- [ ] Basic tab completion for some internal functions is available in the recovery
-  shell
+- [ ] Basic tab completion for some internal functions is available in the
+  recovery shell.
 
 - [ ] SSH'ing in to dracut-crypt enabled ZBM build should result in a functional
-  shell, with a proper path and prompt set
+  shell, with a proper path and prompt set.
 
-- [ ] A running copy of ZBM can be taken over by executing `zbm` from an SSH session
-    - If the running copy can't be correctly stopped, `zbm` will spin until it gets a lock
-      or the user cancels the attempt
+- [ ] A running copy of ZBM can be taken over from a remote session:
+
+    - Executing `zbm` or `zfsbootmenu` from the remote login will attempt to
+      stop any currently running instance.
+
+    - Until the running instance is stopped, the new invocation will spin with
+      a timed message until it succeeds or the user cancels the attempt.
 
 ## OS-Specific Image Creation
 
-- [ ] For each supported distribution [Void, Void Musl, Arch, Ubuntu, Debian], verify
-  that `module-setup.sh` is able to correctly install all required binaries in the
-  initramfs.
+- [ ] For each supported distribution [Void, Void Musl, Arch, Ubuntu, Debian],
+  verify that `module-setup.sh` is able to correctly install all required
+  binaries in the initramfs.
 
 - [ ] For each supported distribution, verify that `generate-zbm` can successfully
   produce an versioned and unversioned initramfs and a unified EFI bundle.
 
 - [ ] For each supported distribution, verify that the components and EFI bundles
-  are able to correctly boot other systems. The check stages listed above should be
-  used and any functionality that is missing or broken noted.
+  are able to correctly boot other systems. The check stages listed above should
+  be used and any functionality that is missing or broken noted.


### PR DESCRIPTION
Lets get the v2.1.0 party started. 

- [ ] A very basic changelog update has been added, this still needs to be fleshed out fully and reviewed for grammar issues.
- [x] An updated builder image needs to be created and pushed to the container image repository
- [x] With the myriad different ways to build ZBM that are now available, we'll need to revamp our testing strategy.  The core of ZBM is pretty stable itself, but all of the ancillary helpers/tools need a full audit to ensure that they're working as expected.
- [x] zbm-efi-kcl should be shipped as a release artifact, and made available via https://get.zfsbootmenu.org (easily doable once we publish a release)
- [ ] Generate new screenshots; one in a terminal and one in the qemu gtk output (emulating a Linux console)
- [ ] Update https://github.com/zbm-dev/zfsbootmenu/wiki/Void-Linux----Single-disk-syslinux-MBR to use the new syslinux process AFTER 2.1.0 is released
- [ ] ??
