### PR TITLE
Use fzf border labels

### DIFF
--- a/zfsbootmenu/bin/zfsbootmenu
+++ b/zfsbootmenu/bin/zfsbootmenu
@@ -96,6 +96,14 @@ fuzzy_default_options=(
   "--bind" "\"ctrl-alt-l:execute[ /bin/zlogtail ]${HAS_REFRESH:++refresh-preview}\""
 )
 
+if [ -n "${HAS_BORDER_LABEL}" ]; then
+  # shellcheck disable=SC2016
+  fuzzy_default_options+=(
+    "--border-label-pos=top" "--border=top"
+    "--color=border:white" "--separator=''"
+  )
+fi
+
 # shellcheck disable=SC2016,SC2086
 if [ ${loglevel:-4} -eq 7 ] ; then
   fuzzy_default_options+=(

--- a/zfsbootmenu/bin/zlogtail
+++ b/zfsbootmenu/bin/zlogtail
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# shellcheck disable=SC1091
+source /lib/zfsbootmenu-lib.sh >/dev/null 2>&1 || exit 1
+
 [ -f "${BASE}/have_errors" ] && rm "${BASE}/have_errors"
 [ -f "${BASE}/have_warnings" ] && rm "${BASE}/have_warnings"
 
@@ -13,6 +16,14 @@ fuzzy_default_options+=(
 if [ -n "${HAS_DISABLED}" ]; then
   fuzzy_default_options+=(
     "--disabled"
+  )
+fi
+
+if [ -n "${HAS_BORDER_LABEL}" ]; then
+  fuzzy_default_options+=(
+    "--border-label-pos=top" "--border=top"
+    "--border-label=\"$( global_header zlogtail )\""
+    "--color=border:white"
   )
 fi
 

--- a/zfsbootmenu/install-helpers.sh
+++ b/zfsbootmenu/install-helpers.sh
@@ -98,6 +98,13 @@ create_zbm_conf() {
     has_disabled=1
   fi
 
+  # Check if fuzzy finder supports border labels
+  # Added in fzf 0.35.0
+  local has_border_label
+  if echo "abc" | fzf -f "abc" --border-label=test --exit-0 >/dev/null 2>&1; then
+    has_border_label=1
+  fi
+
   local has_column
   if command -v column >/dev/null 2>&1 ; then
     has_column=1
@@ -113,6 +120,7 @@ create_zbm_conf() {
 	export BYTE_ORDER="${endian:-le}"
 	export HAS_REFRESH="${has_refresh}"
 	export HAS_DISABLED="${has_disabled}"
+	export HAS_BORDER_LABEL="${has_border_label}"
 	export HAS_COLUMN="${has_column}"
 	EOF
 }

--- a/zfsbootmenu/libexec/zfsbootmenu-help
+++ b/zfsbootmenu/libexec/zfsbootmenu-help
@@ -42,8 +42,9 @@ help_pager() {
     --with-nth=2.. \
     --bind pgup:preview-up,pgdn:preview-down \
     --preview="$0 -s {1}" \
-    --preview-window="right:${PREVIEW_SIZE}:wrap" \
+    --preview-window="right:${PREVIEW_SIZE}:wrap,border-sharp" \
     --header="${header}" \
+    --border=top --border-label="$( global_header )" \
     --tac --inline-info --ansi --layout="reverse-list"
 }
 


### PR DESCRIPTION
`fzf` 0.35 introduced border/preview labels. Global (e.g. top row) text can now be set for any invocation of `fzf`. This means that we can now have a header that displays which screen you're on when in the main `zfsbootmenu` interface. The recovery shell and zdebug/trace screen, and any screens requiring custom input (cloning a snapshot, pool rollback, etc) do not have a header.

![image](https://user-images.githubusercontent.com/13874853/201505016-584f97eb-8d05-4bdd-93fa-fff09470142c.png)

Included in this WIP are the following changes:

* Test if the border label option exists, gate it behind `HAS_BORDER_LABEL`
* Add a `draw_page`  (would `global_header` make more sense?) function that determines which page to highlight based on the name of the caller. Easy to extend / keep all of the logic central to one place.
* Changes the preview border from rounded to sharp, and then sets it to white. This now makes the preview border visible on the Linux console, instead of being invisible / lost space.

I believe I've accounted for every usage of fzf and preview windows. The colors used for the page text could possibly be tweaked - both the selected page and the unselected page colors. The start/end of the page string could maybe use some gussying up.