### PR TITLE
Automatically select initramfs generator when not forced

### DIFF
--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -55,7 +55,6 @@ my ( %runConf, %config );
 
 $runConf{config} = "/etc/zfsbootmenu/config.yaml";
 $runConf{bootdir} = "/boot";
-$runConf{usecpio} = false;
 
 GetOptions(
   "version|v=s" => \$runConf{version},
@@ -68,7 +67,7 @@ GetOptions(
   "config|c=s"  => \$runConf{config},
   "enable"      => \$runConf{enable},
   "disable"     => \$runConf{disable},
-  "initcpio|i"  => \$runConf{usecpio},
+  "initcpio|i!" => \$runConf{usecpio},
   "hookd|H=s@"  => \$runConf{cpio_hookd},
   "debug|d"     => \$runConf{debug},
   "help|h"      => sub {
@@ -120,13 +119,21 @@ unless ( $config{Global}{ManageImages} ) {
   exit;
 }
 
-unless ( $runConf{usecpio} ) {
+unless ( defined $runConf{usecpio} ) {
 
-  # If usecpio wasn't set by cmdline, load from the config
+  # If usecpio wasn't set by cmdline, try loading from the config
   if ( defined $config{Global}{InitCPIO} ) {
     $runConf{usecpio} = $config{Global}{InitCPIO};
   } else {
-    $runConf{usecpio} = false;
+    my @output = execute(qw(sh -c "command -v dracut"));
+    my $status = pop(@output);
+    if ( $status eq 0 ) {
+      print "No initramfs generator specified; using dracut\n";
+      $runConf{usecpio} = false;
+    } else {
+      print "No initramfs generator specified; using mkinitcpio\n";
+      $runConf{usecpio} = true;
+    }
   }
 }
 
@@ -1052,7 +1059,11 @@ Manually specify the output image prefix; supersedes I<Kernel.Prefix>
 
 =item B<--initcpio|-i>
 
-Use mkinitcpio instead of dracut.
+Force the use of mkinitcpio instead of dracut.
+
+=item B<--no-initcpio|-i>
+
+Force the use of dracut instead of mkinitcpio.
 
 =item B<--confd|-C> I<config-path>
 

--- a/etc/zfsbootmenu/config.yaml
+++ b/etc/zfsbootmenu/config.yaml
@@ -4,7 +4,6 @@ Global:
   DracutConfDir: /etc/zfsbootmenu/dracut.conf.d
   PreHooksDir: /etc/zfsbootmenu/generate-zbm.pre.d
   PostHooksDir: /etc/zfsbootmenu/generate-zbm.post.d
-  InitCPIO: false
   InitCPIOConfig: /etc/zfsbootmenu/mkinitcpio.conf
 Components:
   ImageDir: /boot/efi/EFI/zbm

--- a/testing/helpers/chroot-arch.sh
+++ b/testing/helpers/chroot-arch.sh
@@ -28,10 +28,10 @@ trap 'gpgconf --homedir /etc/pacman.d/gnupg --kill all; exit' EXIT INT TERM
 pacman-key --init
 pacman-key --populate
 
-# Do this in two stages to avoid dracut providing the initramfs virtual
+# Install everything needed to build a mkinitcpio image
 pacman --noconfirm -Sy linux linux-headers mkinitcpio vi openssh \
-  fakeroot automake autoconf pkg-config gcc make libtool binutils curl
-pacman --noconfirm -Sy dkms git dracut fzf kexec-tools cpanminus
+  fzf fakeroot automake autoconf pkg-config gcc libtool binutils \
+  make curl dkms git kexec-tools cpanminus
 
 # Install ZFS command-line utilities
 runuser -u nobody -- /bin/sh -c "cd /tmp && \
@@ -68,7 +68,7 @@ mkinitcpio -p linux
 
 if [ -x /root/zbm-populate.sh ]; then
   # Arch installs cpanm in the vendor_perl subdirectory
-  PATH="${PATH}:/usr/bin/site_perl:/usr/bin/vendor_perl" INITCPIO=yes /root/zbm-populate.sh
+  PATH="${PATH}:/usr/bin/site_perl:/usr/bin/vendor_perl" /root/zbm-populate.sh
   rm /root/zbm-populate.sh
 fi
 

--- a/testing/helpers/zbm-populate.sh
+++ b/testing/helpers/zbm-populate.sh
@@ -11,15 +11,17 @@ fi
 
 # Adjust the configuration for convenient builds
 if [ -f /etc/zfsbootmenu/config.yaml ]; then
-  if [ -z "${INITCPIO}" ]; then
-	  use_initcpio="false"
-  else
-	  use_initcpio="true";
-  fi
-
   sed -e 's/Versions:.*/Versions: false/' \
       -e 's/ManageImages:.*/ManageImages: true/' \
-      -e "s/InitCPIO:.*/InitCPIO: ${use_initcpio}/" \
       -e 's@ImageDir:.*@ImageDir: /zfsbootmenu/build@' \
       -e '/BootMountPoint:/d' -i /etc/zfsbootmenu/config.yaml
+
+  case "${INITCPIO}" in
+    [Yy][Ee][Ss]|[Yy]|[Oo][Nn]|1)
+      sed -e "s/InitCPIO:.*/InitCPIO: true/" -i /etc/zfsbootmenu/config.yaml
+      ;;
+    [Nn][Oo]|[Nn]|[Oo][Ff][Ff]|0)
+      sed -e "s/InitCPIO:.*/InitCPIO: false/" -i /etc/zfsbootmenu/config.yaml
+      ;;
+  esac
 fi


### PR DESCRIPTION
If no command-line or configuration option to force one of dracut or mkinitcpio is specified, prefer dracut if the command is available and mkinitcpio otherwise.