### PR TITLE
Fix draw_diff not exiting correctly

### DIFF
--- a/zfsbootmenu/bin/zlogtail
+++ b/zfsbootmenu/bin/zlogtail
@@ -22,7 +22,7 @@ fi
 if [ -n "${HAS_BORDER_LABEL}" ]; then
   fuzzy_default_options+=(
     "--border-label-pos=top" "--border=top"
-    "--border-label=\"$( global_header zlogtail )\""
+    "--border-label=\"$( global_header )\""
     "--color=border:white"
   )
 fi

--- a/zfsbootmenu/lib/zfsbootmenu-lib.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-lib.sh
@@ -75,12 +75,11 @@ column_wrap() {
 global_header() {
   local header page tab replacement
 
-  # Accept a parameter to explicitly set a page to be shown
-  if [ -n "${1}" ]; then
-    page="${1}"
-  else
-    # Name of the calling function
-    page="${FUNCNAME[1]}"
+  page="${FUNCNAME[1]}"
+
+  # 'main' isn't unique, so switch to the name of the script
+  if [ "${page}" = "main" ]; then
+    page="${0##*/}"
   fi
 
   # Set the entire string to one color

--- a/zfsbootmenu/libexec/zfsbootmenu-diff
+++ b/zfsbootmenu/libexec/zfsbootmenu-diff
@@ -1,0 +1,76 @@
+#!/bin/bash
+# vim: softtabstop=2 shiftwidth=2 expandtab
+
+# shellcheck disable=SC1091
+source /lib/profiling-lib.sh >/dev/null 2>&1 || true
+source /etc/zfsbootmenu.conf >/dev/null 2>&1 || exit 1
+source /lib/kmsg-log-lib.sh >/dev/null 2>&1 || exit 1
+source /lib/zfsbootmenu-core.sh >/dev/null 2>&1 || exit 1
+source /lib/zfsbootmenu-lib.sh >/dev/null 2>&1 || exit 1
+
+# prevent ctrl-c from killing us, so that zfs diff can exit cleanly
+trap '' SIGINT
+
+snapshot="${1}"
+if [ -z "${snapshot}" ]; then
+  zerror "snapshot is undefined"
+  exit 1
+fi
+
+# if a second parameter was passed in and it's a snapshot, compare
+# creation dates and make sure diff_target is newer than snapshot
+if [ -n "${2}" ] ; then
+  sd="$( zfs get -H -p -o value creation "${snapshot}" )"
+  td="$( zfs get -H -p -o value creation "${2}" )"
+  if [ "${sd}" -lt "${td}" ] ; then
+    diff_target="${2}"
+  else
+    diff_target="${snapshot}"
+    snapshot="${2}"
+  fi
+else
+  diff_target="${snapshot%%@*}"
+fi
+
+zdebug "snapshot: ${snapshot}"
+zdebug "diff target: ${diff_target}"
+
+pool="${snapshot%%/*}"
+zdebug "pool: ${pool}"
+
+if ! set_rw_pool "${pool}"; then
+  zerror "unable to set ${pool} read/write"
+  exit 1 
+fi
+
+base_fs="${snapshot%%@*}"
+zdebug "base filesystem: ${base_fs}"
+
+CLEAR_SCREEN=1 load_key "${base_fs}"
+
+if ! mnt="$( mount_zfs "${base_fs}" )" ; then
+  zerror "unable to mount ${base_fs}"
+  exit 1 
+fi
+
+zdebug "executing: zfs diff -F -H ${snapshot} ${diff_target}"
+coproc zfs_diff ( zfs diff -F -H "${snapshot}" "${diff_target}" )
+
+# Bash won't use an FD referenced in a variable on the left side of a pipe
+exec 3>&"${zfs_diff[0]}"
+
+# shellcheck disable=SC2154
+line_one="$( center_string "---${snapshot}" )"
+left_pad="${line_one//---${snapshot}/}"
+line_one="$( colorize red "${line_one}" )"
+line_two="${left_pad}$( colorize green "+++${diff_target}" )"
+
+sed "s,${mnt},," <&3 | HELP_SECTION=diff-viewer ${FUZZYSEL:-fzf} --prompt "> " \
+  ${HAS_BORDER_LABEL:+--border-label="$( global_header )"} \
+  --preview="echo -e '${line_one}\n${line_two}'" --no-sort \
+  --preview-window="up:${PREVIEW_HEIGHT},border-sharp" || true
+
+[ -n "${zfs_diff_PID}" ] && kill "${zfs_diff_PID}"
+wait "${zfs_diff_PID}" >/dev/null 2>&1
+
+umount "${mnt}"


### PR DESCRIPTION
`draw_diff` needs to be able to trap SIGINT to gracefully handle exiting when `zfs diff` blocks. It was mildly cleaned up to reflect that it's now a full-fledged script instead of a function call.

This highlighted that `global_header` was a bit sloppy in how it needed to detect the caller. I've switched it to use the basename of the calling script if the function is `main`.