### PR TITLE
Stop installing zpool.cache

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -60,8 +60,7 @@ The default behavior of `zbm-builder.sh` will:
 
 1. Pull the default builder image, `ghcr.io/zbm-dev/zbm-builder:latest`.
 2. If `./hostid` does not exist, copy `/etc/hostid` (if it exists) to `./hostid`.
-3. If `./zpool.cache` does not exist, copy `/etc/zfs/zpool.cache` to `./zpool.cache`.
-4. Spawn an ephemeral container from the builder image and run its build process:
+3. Spawn an ephemeral container from the builder image and run its build process:
     1. Bind-mount the working directory into the container to expose local configurations to the builder
     2. If `./config.yaml` exists, inform the builder to use that custom configuration instead of the default
     3. Run the internal build script to produce output in the `./build` subdirectory

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -168,14 +168,9 @@ install() {
     exit 1
   fi
 
-  # zpool.cache, vdev_id.conf and hostid files are host-specific
+  # vdev_id.conf and hostid files are host-specific
   # and do not belong in public release images
   if [ -z "${release_build}" ]; then
-    if [ -e /etc/zfs/zpool.cache ]; then
-      inst /etc/zfs/zpool.cache
-      type mark_hostonly >/dev/null 2>&1 && mark_hostonly /etc/zfs/zpool.cache
-    fi
-
     if [ -e /etc/zfs/vdev_id.conf ]; then
       inst /etc/zfs/vdev_id.conf
       type mark_hostonly >/dev/null 2>&1 && mark_hostonly /etc/zfs/vdev_id.conf

--- a/initcpio/install/zfsbootmenu
+++ b/initcpio/install/zfsbootmenu
@@ -186,7 +186,6 @@ build() {
 
     # Copy host-specific ZFS configs
     [[ -f /etc/hostid ]] && add_file "/etc/hostid"
-    [[ -f /etc/zfs/zpool.cache ]] && add_file "/etc/zfs/zpool.cache"
     [[ -f /etc/zfs/vdev_id.conf ]] && add_file "/etc/zfs/vdev_id.conf"
     [[ -f /etc/modprobe.d/zfs.conf ]] && add_file "/etc/modprobe.d/zfs.conf"
 

--- a/releng/docker/README.md
+++ b/releng/docker/README.md
@@ -185,10 +185,9 @@ each level of configurations to mask or augment earlier defaults.
 > `mkinitcpio.conf` that manually sources these snippets to emulate the
 > standard configuration behavior of dracut.
 
-In addition, host-specific files are linked if each exists:
+In addition, the hostid file is linked if it exists:
 
     /etc/hostid -> ${BUILDROOT}/hostid
-    /etc/zfs/zpool.cache -> ${BUILDROOT}/zfs/zpool.cache
 
 When launched, the container entrypoint will run any executable files it finds
 in `${BUILDROOT}/rc.d`. This provides a means to "terraform" the build
@@ -227,7 +226,7 @@ the `/etc/zfsbootmenu/build` directory, copy the desired files and run the
 container with the appropriate volume mount:
 
 ```sh
-cp /etc/hostid /etc/zfs/zpool.cache /etc/zfsbootmenu/build
+cp /etc/hostid /etc/zfsbootmenu/build
 podman run -v /etc/zfsbootmenu/build:/build zbm
 ```
 

--- a/releng/docker/build-init.sh
+++ b/releng/docker/build-init.sh
@@ -170,20 +170,12 @@ CONFIGEVALS+=(
   "del(.Global.BootMountPoint)"
 )
 
-# Use provided hostid and zpool.cache files
+# Use provided hostid
 if [ -r "${BUILDROOT}/hostid" ]; then
   ln -Tsf "${BUILDROOT}/hostid" /etc/hostid \
     || error "failed to link hostid"
 else
   rm -f /etc/hostid
-fi
-
-if [ -r "${BUILDROOT}/zpool.cache" ]; then
-  mkdir -p /etc/zfs
-  ln -Tsf "${BUILDROOT}/zpool.cache" /etc/zfs/zpool.cache \
-    || error "failed to link zpool.cache"
-else
-  rm -f /etc/zfs/zpool.cache
 fi
 
 # Link all configuration files in standard location;


### PR DESCRIPTION
None of the `zpool import` instances actually use the cache file, so there is no value in including it in the initramfs.

I am also open to considering an alternative. The best alternative that I can think of wraps `zpool import` with a custom function along the lines of

```bash
import_zpool() {
  if [ -s "/etc/zfs/zpool.cache" ]; then
    zdebug "attempting 'zpool import' with cache file"
    local output
    if output="$(zpool import -c /etc/zfs/zpool.cache "$@")" && [ -n "${output}" ]; then
      echo "${output}"
      return 0
    fi
    zdebug "import failed with cache file, reattempting without cache"
  fi

  zpool import "$@"
}
```

Either we try to use the cache file if it's available, or we remove it. Do you have a preference? 