### PR TITLE
Improve version handling, restore functionality in make-binary.sh

### DIFF
--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -70,11 +70,17 @@ GetOptions(
   "initcpio|i!" => \$runConf{usecpio},
   "hookd|H=s@"  => \$runConf{cpio_hookd},
   "debug|d"     => \$runConf{debug},
+  "showver|V"   => \$runConf{showver},
   "help|h"      => sub {
     pod2usage( -verbose => 2 );
     exit;
   },
-);
+) or exit 1;
+
+if ( defined $runConf{showver} and $runConf{showver} ) {
+  printf "%s\n", $VERSION;
+  exit 0;
+}
 
 if ( -r $runConf{config} ) {
   eval {
@@ -301,7 +307,7 @@ unless ( nonempty $runConf{kernel_prefix} and nonempty $runConf{kernel_version} 
   }
 }
 
-printf "Creating ZFSBootMenu %s from kernel %s\n", $runConf{version}, $runConf{kernel};
+printf "Creating ZFSBootMenu %s from kernel %s\n", $VERSION, $runConf{kernel};
 
 my $spl_hostid = "/sys/module/spl/parameters/spl_hostid";
 if ( -f $spl_hostid ) {
@@ -1043,7 +1049,7 @@ Where noted, command-line options supersede options in the B<generate-zbm>(5) co
 
 =item B<--version|-v> I<zbm-version>
 
-Override the ZFSBootMenu version; supersedes I<Global.Version>
+Override the ZFSBootMenu version in output files; supersedes I<Global.Version>
 
 =item B<--kernel|-k> I<kernel-path>
 
@@ -1106,6 +1112,10 @@ Set the I<Global.ManageImages> option to false, disabling image generation.
 =item B<--debug|d>
 
 Enable debug output
+
+=item B<--showver|V>
+
+Print ZFSBootMenu version and quit.
 
 =back
 

--- a/docs/pod/generate-zbm.5.pod
+++ b/docs/pod/generate-zbm.5.pod
@@ -44,7 +44,7 @@ In general, this should be the location of your EFI System Partition. B<generate
 
 =item B<Version>
 
-A specific ZFSBootMenu version string to use in producing images. In the string, the value I<%{current}> will be replaced with the release version of ZFSBootMenu. The default value is simply I<%{current}>.
+A specific ZFSBootMenu version string to use in versioned output images. In the string, the value I<%{current}> will be replaced with the release version of ZFSBootMenu. The default value is simply I<%{current}>.
 
 =item B<DracutFlags>
 


### PR DESCRIPTION
I broke make-binary.sh with recent changes to the build-container entrypoint. This should be resolved, but my changes need another set of eyes.

While I was at it, I added a `--showver` flag to `generate-zbm` that prints the program version and clarified that `--version` or `Global.Versions` only have meaning in versioned output products. The "Creating ZFSBootMenu" message now always uses the internal version string.

This addition allows us to run some of the releng scripts as, e.g.,

```sh
./releng/make-binary.sh "$(bin/generate-zbm --showver)"
```

Eventually, we can allow some of the releng scripts that need a version (but not `tag-release.sh`, because that has the responsibility of actually setting `$VERSION` in `generate-zbm`) to just call `bin/generate-zbm --showver` directly if no version is provided on the command-line, but I can't do this cleanly with DRY and don't want to think about it now.