### PR TITLE
testing: Allow environment customization, better choose initramfs generators

### DIFF
--- a/testing/helpers/chroot-debian.sh
+++ b/testing/helpers/chroot-debian.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+: "${RELEASE:=bullseye}"
+: "${APT_REPOS:=main contrib}"
+
 cat << EOF > /etc/apt/sources.list
-deb http://deb.debian.org/debian bullseye main contrib
-deb-src http://deb.debian.org/debian bullseye main contrib
+deb http://deb.debian.org/debian ${RELEASE} ${APT_REPOS}
+deb-src http://deb.debian.org/debian ${RELEASE} ${APT_REPOS}
 EOF
 
 apt-get update

--- a/testing/helpers/chroot-ubuntu.sh
+++ b/testing/helpers/chroot-ubuntu.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 
+: "${RELEASE:=jammy}"
+: "${APT_REPOS:=main restricted universe multiverse}"
+
 cat << EOF > /etc/apt/sources.list
-deb http://us.archive.ubuntu.com/ubuntu jammy main restricted universe multiverse
-deb-src http://us.archive.ubuntu.com/ubuntu jammy main restricted universe multiverse
+deb http://us.archive.ubuntu.com/ubuntu ${RELEASE} ${APT_REPOS}
+deb-src http://us.archive.ubuntu.com/ubuntu ${RELEASE} ${APT_REPOS}
 EOF
 
-cat << EOF > /etc/apt/sources.list.d/jammy-backports.list
-deb http://us.archive.ubuntu.com/ubuntu jammy-backports main restricted universe multiverse
-deb-src http://us.archive.ubuntu.com/ubuntu jammy-backports main restricted universe multiverse
+cat << EOF > /etc/apt/sources.list.d/${RELEASE}-backports.list
+deb http://us.archive.ubuntu.com/ubuntu ${RELEASE}-backports ${APT_REPOS}
+deb-src http://us.archive.ubuntu.com/ubuntu ${RELEASE}-backports ${APT_REPOS}
 EOF
 
 apt-get update

--- a/testing/helpers/install-debian.sh
+++ b/testing/helpers/install-debian.sh
@@ -7,11 +7,11 @@ if [ -z "${CHROOT_MNT}" ] || [ ! -d "${CHROOT_MNT}" ]; then
 fi
 
 if [[ "$0" =~ "ubuntu" ]]; then
-  SUITE="jammy"
+  SUITE="${RELEASE:-jammy}"
   MIRROR="http://us.archive.ubuntu.com/ubuntu/"
   CONFIGURATOR="configure-ubuntu.sh"
 else
-  SUITE="bullseye"
+  SUITE="${RELEASE:-bullseye}"
   MIRROR="http://ftp.us.debian.org/debian/"
   CONFIGURATOR="configure-debian.sh"
 fi


### PR DESCRIPTION
Adding a `-E` flag to `testing/setup.sh` allows us to pass environment variables to the image build process, which means we can parameterize releases and do all sorts of other good stuff. I tested a setup with

```sh
./setup.sh -a -o debian -E RELEASE=buster -D /tmp/debs
./setup.sh -i -x -o ubuntu -E RELEASE=kinetic -D /tmp/debs
```

and was greeted with a shockingly old Debian installation followed by a newer Ubuntu than we install by default.

While I was at it, I rethought how we choose initramfs generators, meaning things work as expected if `dracut` isn't locally installed.