### PR TITLE
deprecation: remove big endian checks

### DIFF
--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -324,15 +324,7 @@ if ( $runConf{hostid}{module} ne "00000000" and -f $etc_hostid ) {
   read SPL, my $hostid, 4;
   close SPL;
 
-  if ( unpack( 'c', pack( 's', 1 ) ) eq 1 ) {
-
-    # little endian
-    $runConf{hostid}{etc} = sprintf( "%08x", unpack( 'L<4', $hostid ) );
-  } else {
-
-    # big endian
-    $runConf{hostid}{etc} = sprintf( "%08x", unpack( 'L>4', $hostid ) );
-  }
+  $runConf{hostid}{etc} = sprintf( "%08x", unpack( 'L<4', $hostid ) );
 
   if ( $runConf{hostid}{module} ne $runConf{hostid}{etc} ) {
     print "SPL ($runConf{hostid}{module}) and system ($runConf{hostid}{etc}) hostids do not match!\n";

--- a/docs/pod/zfsbootmenu.7.pod
+++ b/docs/pod/zfsbootmenu.7.pod
@@ -50,7 +50,7 @@ This option controls how the pool import process should take place.
 
 =item B<zbm.import_policy=hostid>
 
-Set this option to allow run-time reconfiguration of the SPL hostid. If a pool is preferred via B<zbm.prefer> and the pool can not be imported with a preconfigured hostid, the system will attempt to adopt the hostid of the system that last imported the pool. If a preferred pool is not set and no pools can be imported using a preconfigured hostid, the system will adopt the hostid of the first otherwise-importable pool. After adopting a detected hostid, ZFSBootMenu will subsequently attempt to import as many pools as possible. This option is forbidden on big-endian systems. This is the default import policy.
+Set this option to allow run-time reconfiguration of the SPL hostid. If a pool is preferred via B<zbm.prefer> and the pool can not be imported with a preconfigured hostid, the system will attempt to adopt the hostid of the system that last imported the pool. If a preferred pool is not set and no pools can be imported using a preconfigured hostid, the system will adopt the hostid of the first otherwise-importable pool. After adopting a detected hostid, ZFSBootMenu will subsequently attempt to import as many pools as possible. This is the default import policy.
 
 =item B<zbm.import_policy=strict>
 
@@ -64,9 +64,7 @@ Set this option to attempt to force pool imports. When set, this invokes I<zpool
 
 =item B<zbm.set_hostid>
 
-On little-endian systems, setting this option will cause ZFSBootMenu to set the I<spl.spl_hostid> command-line parameter for the selected boot environment to the hostid used to import its pool. The SPL kernel module will use this value as the hostid of the booted environment regardless of the contents of I</etc/hostid>. As a special case, if the hostid to be set is zero, ZFSBootMenu will instead set I<spl_hostid=00000000>, which should be used by dracut-based initramfs images to write an all-zero I</etc/hostid> in the initramfs prior to importing the boot pool. This option is on by default.
-
-This option has no effect on big-endian systems.
+Setting this option will cause ZFSBootMenu to set the I<spl.spl_hostid> command-line parameter for the selected boot environment to the hostid used to import its pool. The SPL kernel module will use this value as the hostid of the booted environment regardless of the contents of I</etc/hostid>. As a special case, if the hostid to be set is zero, ZFSBootMenu will instead set I<spl_hostid=00000000>, which should be used by dracut-based initramfs images to write an all-zero I</etc/hostid> in the initramfs prior to importing the boot pool. This option is on by default.
 
 B<Note:> Setting I<spl.spl_hostid> to a non-zero value on the kernel commandline will make the ZFS kernel modules B<ignore> any value set in I</etc/hostid>. To restore standard ZFS behavior on a running system, execute
 

--- a/zfsbootmenu/hook/zfsbootmenu-parse-commandline.sh
+++ b/zfsbootmenu/hook/zfsbootmenu-parse-commandline.sh
@@ -19,11 +19,6 @@ done
 
 unset src sources
 
-if [ -z "${BYTE_ORDER}" ]; then
-  zwarn "unable to determine platform endianness; assuming little-endian"
-  BYTE_ORDER="le"
-fi
-
 # shellcheck disable=SC2154
 if [ -n "${embedded_kcl}" ]; then
   mkdir -p /etc/cmdline.d/
@@ -91,13 +86,7 @@ fi
 if import_policy=$( get_zbm_arg zbm.import_policy ) ; then
   case "${import_policy}" in
     hostid)
-      if [ "${BYTE_ORDER}" = "be" ]; then
-        zwarn "invalid option for big endian systems"
-        zinfo "setting import_policy to strict"
-        import_policy="strict"
-      else
-        zinfo "setting import_policy to hostid matching"
-      fi
+      zinfo "setting import_policy to hostid matching"
       ;;
     force)
       zinfo "setting import_policy to force"
@@ -202,10 +191,7 @@ if zbm_hook_root=$( get_zbm_arg zbm.hookroot ) ; then
 fi
 
 # shellcheck disable=SC2034
-if [ "${BYTE_ORDER}" = "be" ]; then
-  zbm_set_hostid=0
-  zinfo "big endian detected, disabling automatic replacement of spl_hostid"
-elif get_zbm_bool 1 zbm.set_hostid ; then
+if get_zbm_bool 1 zbm.set_hostid ; then
   zbm_set_hostid=1
   zinfo "enabling automatic replacement of spl_hostid"
 else

--- a/zfsbootmenu/install-helpers.sh
+++ b/zfsbootmenu/install-helpers.sh
@@ -72,18 +72,6 @@ zfsbootmenu_optional_modules=(
 create_zbm_conf() {
   # Create core ZBM configuration file
 
-  local endian ival
-  ival="$( echo -n 3 | od -tx2 -N2 -An )"
-  ival="${ival//[[:space:]]/}"
-  if [ "${ival}" = "3300" ]; then
-    endian="be"
-  else
-    if [ "${ival}" != "0033" ]; then
-      warning "unable to determine platform endianness; assuming little-endian"
-    fi
-    endian="le"
-  fi
-
   # Check if fuzzy finder supports the refresh-preview flag
   # Added in fzf 0.22.0
   local has_refresh
@@ -117,7 +105,6 @@ create_zbm_conf() {
 	EOF
 
   cat >> "${BUILDROOT}/etc/zfsbootmenu.conf" <<-EOF
-	export BYTE_ORDER="${endian:-le}"
 	export HAS_REFRESH="${has_refresh}"
 	export HAS_DISABLED="${has_disabled}"
 	export HAS_BORDER="${has_border}"


### PR DESCRIPTION
With the removal of `skim` support, we no longer have a fuzzy finder for 64bit Big Endian systems. As such, there's no need to do any endianness checks in a few option paths.

#376 will need a minor bump to track the zfsbootmenu man page change.