### PR TITLE
Pool compatibility support in testing / built images

### DIFF
--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -95,6 +95,11 @@ install() {
     inst_simple "${doc}" "/usr/share/docs/${relative}"
   done <<<"$( find "${zfsbootmenu_module_root}/help-files" -type f )"
 
+  compat_dirs=( "/etc/zfs/compatibility.d" "/usr/share/zfs/compatibility.d/" )
+  for compat_dir in "${compat_dirs[@]}"; do
+    # shellcheck disable=2164
+    [ -d "${compat_dir}" ] && tar -cf - "${compat_dir}" | ( cd "${initdir}" ; tar xfp - )
+  done
   _ret=0
 
   # Core ZFSBootMenu functionality

--- a/initcpio/install/zfsbootmenu
+++ b/initcpio/install/zfsbootmenu
@@ -184,6 +184,11 @@ build() {
         add_file "${_file}" "/libexec/teardown.d/${_file##*/}"
     done
 
+    compat_dirs=( "/etc/zfs/compatibility.d" "/usr/share/zfs/compatibility.d/" )
+    for compat_dir in "${compat_dirs[@]}"; do
+        [ -d "${compat_dir}" ] && add_full_dir "${compat_dir}"
+    done
+
     # Copy host-specific ZFS configs
     [[ -f /etc/hostid ]] && add_file "/etc/hostid"
     [[ -f /etc/zfs/vdev_id.conf ]] && add_file "/etc/zfs/vdev_id.conf"

--- a/testing/helpers/image.sh
+++ b/testing/helpers/image.sh
@@ -98,10 +98,8 @@ if [ -z "${EXISTING_POOL}" ]; then
     ENCRYPT_OPTS+=( "-O" "keylocation=file://${ENCRYPT_KEYFILE}" )
   fi
 
-  if [ -n "${LEGACY_POOL}" ]; then
-    LEGACY_OPTS=( "-o" "compatibility=zol-0.8" )
-  else
-    LEGACY_OPTS=()
+  if [ -n "${POOL_COMPAT}" ]; then
+    COMPAT=( "-o" "compatibility=${POOL_COMPAT}" )
   fi
 
   if zpool create -f -m none \
@@ -111,7 +109,7 @@ if [ -z "${EXISTING_POOL}" ]; then
         -O relatime=on \
         -o autotrim=on \
         -o cachefile=none \
-        "${LEGACY_OPTS[@]}" \
+        "${POOL_COMPAT:+${COMPAT[@]}}" \
         "${ENCRYPT_OPTS[@]}" \
         "${zpool_name}" "${LOOP_DEV}"; then
     export ZBM_POOL="${zpool_name}"


### PR DESCRIPTION
Expand pool compatibility support in the testing framework. By default, `Debian` and `Ubuntu` test environments will use a pool compatibility of `openzfs-2.0-linux`, which lines up with the version available in the latest releases. The `POOL_COMPAT` environment variable can be manually set (or overridden in the case of the previous distributions) to any specific value.

Dracut and initcpio now also copy these files in to the ZBM image so that they can be read/used in the recovery shell.