### PR TITLE
Key management: properly normalize Booleans, make cache mutex per-PID

### DIFF
--- a/zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -1547,7 +1547,7 @@ cache_key() {
   fi
 
   keycache="${BASE}/.keys/${keysrc}"
-  mutex="${keycache}/.cachemutex"
+  mutex="${keycache}/.cachemutex.$$"
 
   if [ -e "${mutex}" ]; then
     # Attempting to load key source could lead to infinite recursion
@@ -1695,7 +1695,7 @@ load_key() {
   if [ -e "/${key}" ]; then
     # Prefer the actual path to the key file
     keypath="/${key}"
-  elif keysource="$( be_keysource "${fs}" )" && [ "${NO_CACHE}" -eq 0 ]; then
+  elif keysource="$( be_keysource "${fs}" )" && ! [ "${NO_CACHE}" -eq 1 ]; then
     # Otherwise, try to pre-seed a cache location
     # Don't care if this succeeds because it may already be cached
     cache_key "${fs}" "${keylocation}"


### PR DESCRIPTION
The cache mutex exists to avoid infinite recursion when attempting to load a key for an encryption root from its key source. However, the recursion is only a concern when the load is done in the same PID that is trying to do the caching. In other cases, such as when a remote user has terminated a local instance and is not attempting to unlock a pool, a generic mutex will prevent all key caching. Making the mutex per-PID avoids this conflict.