### PR TITLE
Adapt Debian guide to follow Void install guide layouts

### DIFF
--- a/docs/guides/debian/uefi-install.rst
+++ b/docs/guides/debian/uefi-install.rst
@@ -9,26 +9,32 @@ Debian Bullseye UEFI Installation
 Preparation
 -----------
 
-Download the `Debian Bullseye (11) Live image <https://www.debian.org/CD/live/>`_ and write it to a USB drive. Grab the
-most recent image.
+This guide can be used to install Debian onto a single disk with or without ZFS encryption.
 
-Disable Secure Boot on your system. Because ZFS modules are built using the ``zfs-dkms`` package, the modules will not
-be signed and will be unusable in a Secure Boot setup. The modules may be signed for use with Secure Boot, but that is
-beyond the scope of this document.
+It assumes the following:
 
-Blindly copying and pasting this commands most likely will not work. take some time to understand ZFS and boot proccess.
-First read the whole guide at least once and then start the installation.
+* Your system uses UEFI to boot
+* Your system is x86_64
+* ``/dev/sda`` is the onboard SSD, used for both ZFS and EFI
+* You're mildly comfortable with ZFS, EFI and discovering system facts on your own (``lsblk``, ``dmesg``, ``gdisk``, ...)
+
+Download the latest `Debian Bullseye (11) Live image <https://www.debian.org/CD/live/>`_, write it to a USB drive and
+boot your system in EFI mode. You can confirm you've booted in EFI mode by running ``efibootmgr``.
 
 Early Setup
 -----------
 
-Boot the USB/CD/DVD/... drive containing the live image.
+Switch to a root shell
+~~~~~~~~~~~~~~~~~~~~~~
 
-Log in as root. most of the following commands need root access::
+.. code-block::
 
   sudo su --login
 
-Configure APT and update the package database::
+Configure and update APT
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
 
   cat <<EOF > /etc/apt/sources.list
   deb http://deb.debian.org/debian bullseye main contrib
@@ -36,159 +42,192 @@ Configure APT and update the package database::
   EOF
   apt update
 
-You may see faster downloads replacing ``deb.debian.org`` with a local mirror. If you want to use HTTPS transport, make
-sure that the ``ca-certificates`` and ``apt-transport-https`` packages are installed and your mirror has a valid
-certificate; otherwise, apt will refuse to use the mirror.
+.. note::
 
-Install fundamental packages in live system::
+  You may see faster downloads replacing ``deb.debian.org`` with a local mirror. If you want to use HTTPS transport, make
+  sure that the ``ca-certificates`` and ``apt-transport-https`` packages are installed and your mirror has a valid
+  certificate; otherwise, apt will refuse to use the mirror.
 
-  apt install debootstrap gdisk parted dkms linux-headers-$(uname -r)
+Install helpers
+~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  apt install debootstrap gdisk dkms linux-headers-$(uname -r)
   apt install zfsutils-linux
 
-Disk Preparation
+SSD prep work
 ----------------
 
-For disk operations, it is assumed that the environment variable ``TARGET_DISK`` points to a single disk on which you
-wish to create a ZFS pool.
-
-Create partition table
-~~~~~~~~~~~~~~~~~~~~~~
+Create partitions on ``/dev/sda``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. caution::
 
-  This action will delete all data on your drive.
-
-This example creates two partitions: one EFI system partition and another on which the ZFS pool will be stored. Adjust
-this to suit your needs. You may find it easier to use ``cgdisk`` insteade of ``sgdisk`` to partition your drive.
+  This action will delete all data on ``/dev/sda``
 
 .. code-block::
 
-  sgdisk --zap-all $TARGET_DISK
-  sgdisk -n1:1m:+512m -t1:ef00 $TARGET_DISK
-  sgdisk -n2:0:0 -t2:bf00 $TARGET_DISK
+  sgdisk --zap-all /dev/sda
+  sgdisk -n1:1m:+512m -t1:ef00 /dev/sda
+  sgdisk -n2:0:0 -t2:bf00 /dev/sda
 
-Running ``lsblk`` will confirm that the kernel has recognized the new partitions. If the output does not contain created
-partitions, run ``partprobe`` to inform the kernel of partition table changes. If that didnt work, reboot.
+ZFS pool creation
+-----------------
 
-Format EFI system partition (ESP)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Create the zpool
+~~~~~~~~~~~~~~~~
 
-For this step, it is assumed that the environment variable ``TARGET_ESP`` points to the first partition created in the
-preceding step.
+.. tabs::
+
+  .. group-tab:: Encrypted
+
+    .. code-block::
+
+      echo 'SomeKeyphrase' > /etc/zfs/zroot.key
+      chmod 000 /etc/zfs/zroot.key
+
+      zpool create -f -o ashift=12 \
+       -O compression=lz4 \
+       -O acltype=posixacl \
+       -O xattr=sa \
+       -O relatime=on \
+       -O encryption=aes-256-gcm \
+       -O keylocation=file:///etc/zfs/zroot.key \
+       -O keyformat=passphrase \
+       -o autotrim=on \
+       -m none zroot /dev/sda2
+
+    It's out of the scope of this guide to cover all of the pool creation options used - feel free to tailor them to suit
+    your system. However, the following options need to be addressed:
+
+    * ``encryption=aes-256-gcm`` - You can adjust the algorithm as you see fit, but this will likely be the most performant
+      on modern x86_64 hardware.
+    * ``keylocation=file:///etc/zfs/zroot.key`` - This sets our pool encryption passphrase to the file
+      ``/etc/zfs/zroot.key``, which we created in a previous step. This file will live inside your initramfs stored *on* the
+      ZFS boot environment.
+    * ``keyformat=passphrase`` - By setting the format to ``passphrase``, we can now force a prompt for this in
+      ``zfsbootmenu``. It's critical that your passphrase be something you can type on your keyboard, since you will need to
+      type it in to unlock the pool on boot.
+
+  .. group-tab:: Unencrypted
+
+    .. code-block::
+
+      zpool create -f -o ashift=12 \
+       -O compression=lz4 \
+       -O acltype=posixacl \
+       -O xattr=sa \
+       -O relatime=on \
+       -o autotrim=on \
+       -m none zroot /dev/sda2
+
+Create our initial file systems
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block::
 
-  mkfs -t vfat -F 32 -s 1 -n EFI $TARGET_ESP
-
-The ``-s 1`` flag is only necessary for drives which present 4 KiB logical sectors ("4Kn" drives) to meet the minimum
-cluster size (given the partition size of 512 MiB) for FAT32. It also works fine on drives which present 512 B sectors.
-
-Create a ZFS pool
-~~~~~~~~~~~~~~~~~
-
-If you want encryption, store a pool passphrase in a key file::
-
-  echo '<your-passphrase-here>' > /etc/zfs/zroot.key
-  chmod 000 /etc/zfs/zroot.key
-
-Create the pool. When specifying devices for ZFS vdevs, it is generally advisable to use persistent disk names created
-by ``udev`` in one of the ``/dev/disk`` subdirectories. Both ``by-id`` and (on GPT disks) ``by-partuuid`` subdirectories
-are good choices as ZFS vdev targets. Using ordinary block device nodes may cause import problems if your disk
-configuration eventually changes. For this example, it is assumed that the environment variable ``TARGET_VDEV`` contains
-the path to the second partition created above.
-
-.. code-block::
-
-  zpool create -f \
-        -o ashift=12 \
-        -o autotrim=on \
-        -O encryption=aes-256-gcm \
-        -O keylocation=file:///etc/zfs/zroot.key \
-        -O keyformat=passphrase \
-        -O acltype=posixacl \
-        -O compression=lz4 \
-        -O normalization=formD \
-        -O relatime=on \
-        -O xattr=sa \
-        -O mountpoint=none \
-        -R /mnt \
-        zroot $TARGET_VDEV
-
-If you are not using encryption, omit the following options:
-
-.. code-block::
-
-  -O encryption=aes-256-gcm
-  -O keylocation=file:///etc/zfs/zroot.key
-  -O keyformat=passphrase
-
-Create filesystems to hold the Debian boot environment and home directories::
-
-  zfs create zroot/ROOT
-  zfs create -o canmount=noauto -o mountpoint=/ zroot/ROOT/debian
-  zfs mount zroot/ROOT/debian
+  zfs create -o mountpoint=none zroot/ROOT
+  zfs create -o mountpoint=/ -o canmount=noauto zroot/ROOT/debian
   zfs create -o mountpoint=/home zroot/home
 
 .. note::
 
-  It is important to set ``canmount=noauto`` on any filesystem with ``mountpoint=/`` to prevent the ZFS automount
-  process from attempting to mount more than one boot environment at the root of the filesystem. It is also possible to
-  set ``mountpoint=legacy`` on boot environments, but filesystems with ``mountpoint=legacy`` will not be examined by
-  ZFSBootMenu unless the property ``org.zfsbootmenu:active=on`` is also set.
+  It is important to set the property ``canmount=noauto`` on any file systems with ``mountpoint=/`` (that is, on
+  any additional boot environments you create). Without this property, Debian will attempt to automount all ZFS file
+  systems and fail when multiple file systems attempt to mount at ``/``; this will prevent your system from booting.
+  Automatic mounting of ``/`` is not required because the root file system is explicitly mounted in the boot process.
 
-Set the default boot environment to tell ZFSBootMenu what it should prefer to boot::
+  Also note that, unlike many ZFS properties, ``canmount`` is not inheritable. Therefore, setting ``canmount=noauto`` on
+  ``zroot/ROOT`` is not sufficient, as any subsequent boot environments you create will default to ``canmount=on``. It is
+  necessary to explicitly set the ``canmount=noauto`` on every boot environment you create.
 
-  zpool set bootfs=zroot/ROOT/debian zroot
+Export, then re-import with a temporary mountpoint of ``/mnt``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Re-import the pool with a temporary root to populate the filesystems::
+.. tabs::
 
-  zpool export zroot
-  zpool import -N -R /mnt zroot
-  zfs load-key zroot # only if encrypted
-  zfs mount zroot/ROOT/debian
-  zfs mount -a
+  .. group-tab:: Encrypted
 
-Mount EFI system partition where it will reside in the target system::
+    .. code-block::
 
-  mkdir -p /mnt/boot/efi
-  mount $TARGET_ESP /mnt/boot/efi
+      zpool export zroot
+      zpool import -N -R /mnt zroot
+      zfs load-key -L prompt zroot
+      zfs mount zroot/ROOT/debian
+      zfs mount zroot/home
 
-Install the Debian base::
+  .. group-tab:: Unencrypted
+
+    .. code-block::
+
+      zpool export zroot
+      zpool import -N -R /mnt zroot
+      zfs mount zroot/ROOT/debian
+      zfs mount zroot/home
+
+Verify that everything is mounted correctly
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  # mount | grep mnt
+  zroot/ROOT/debian on /mnt type zfs (rw,relatime,xattr,posixacl)
+  zroot/home on /mnt/home type zfs (rw,relatime,xattr,posixacl)
+
+
+Install Debian
+--------------
+
+.. code-block::
 
   debootstrap bullseye /mnt
 
-If you want, you can specify a mirror by appending its URL to the above command.
+Copy files into the new install
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Copy the pool key (for an encrypted pool) and resolv.conf into the new installation::
+.. tabs::
 
-  cp /etc/resolv.conf /mnt/etc/
-  mkdir -p /mnt/etc/zfs
-  cp /etc/zfs/zroot.key /mnt/etc/zfs/
+  .. group-tab:: Encrypted
 
-Set a hostname and add it to the hosts file::
+    .. code-block::
 
-  echo 'YOURHOSTNAME' > /mnt/etc/hostname
-  echo -e '127.0.1.1\tYOURHOSTNAME' >> /mnt/etc/hosts
+      cp /etc/hostid /mnt/etc/hostid
+      cp /etc/resolv.conf /mnt/etc/
+      mkdir -p /mnt/etc/zfs
+      cp /etc/zfs/zroot.key /mnt/etc/zfs/
 
-Bind virtual filesystems from the live environment into the target hierarchy, then chroot into the target system::
+  .. group-tab:: Unencrypted
+
+    .. code-block::
+
+      cp /etc/hostid /mnt/etc/hostid
+      cp /etc/resolv.conf /mnt/etc
+
+Chroot into the new OS
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
 
   for i in dev sys proc run; do
       mount --rbind /$i /mnt/$i
       mount --make-rslave /mnt/$i
   done
-  chroot /mnt env TARGET_ESP="$TARGET_ESP" TARGET_VDEV="$TARGET_VDEV" bash --login
+  chroot /mnt bash --login
 
-Customize the installation
+Basic Debian Configuration
 --------------------------
 
-At this point, the installation process looks like any other Linux setup procedure. Major steps are highlighted for
-convenience, but the process may be adapted as you see fit.
+Set a hostname
+~~~~~~~~~~~~~~
 
-Basic configuration
+.. code-block::
+
+  echo 'YOURHOSTNAME' > /etc/hostname
+  echo -e '127.0.1.1\tYOURHOSTNAME' >> /etc/hosts
+
+Set a root password
 ~~~~~~~~~~~~~~~~~~~
-
-Set a root password for installed system. you can disable login as root later, when you have created another user with
-``sudo`` privilege.
 
 .. code-block::
 
@@ -212,21 +251,24 @@ Configure ``apt``. Use other mirrors if you prefer.
   deb-src http://deb.debian.org/debian bullseye-backports main contrib
   EOF
 
-Do not use HTTPS as a transport protocol yet. The packages ``ca-certificates`` and ``apt-transport-https`` are not
-installed. After installing and configuring the ``locales`` package, it will be possible to install ``ca-certificates``
-and ``apt-transport-https`` and switch to HTTPS transports.
+Update the repository cache
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Update the repository cache and install upgrades if any are available::
+.. code::
 
   apt update
-  apt full-upgrade
 
-Install essential packages and ``bash-completion`` to make typing commands easier::
+Install additional base packages
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  apt install locales console-setup bash-completion
-  . /usr/share/bash-completion/bash_completion
+.. code::
 
-Configure packages to customize local and console properties::
+  apt install locales keyboard-configuration console-setup
+
+Configure packages to customize local and console properties
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
 
   dpkg-reconfigure locales tzdata keyboard-configuration console-setup
 
@@ -234,63 +276,100 @@ Configure packages to customize local and console properties::
 
   You should always enable the `en_US.UTF-8` locale because some programs require it.
 
-Install packages necessary to support ZFS::
+ZFS Configuration
+-----------------
 
-  apt install linux-headers-amd64 linux-image-amd64 refind git zfs-initramfs
+Install required packages
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  apt install linux-headers-amd64 linux-image-amd64 git zfs-initramfs dosfstools
   echo "REMAKE_INITRD=yes" > /etc/dkms/zfs.conf
 
-When rEFInd offers to make edits to your ESP partition, check to make sure that it mounted the correct partition::
+Set up pool caching
+~~~~~~~~~~~~~~~~~~~
 
-  mount | grep /boot
-
-On systems with multiple bootable drives, rEFInd may mount more than one ESP partition when it makes changes. You may
-have to manually copy the ``/boot/efi/EFI/refind`` directory to a temporary directory, unmount the unwanted ESP
-partitions so only the ``$TARGET_ESP`` partition is mounted, and then move the directory back.
-
-Verify that your ZFS pool passphrase is stored in ``/etc/zfs/zroot.key`` and that permissions are 000::
-
-  echo -n ZFS passphrase: && cat /etc/zfs/zroot.key
-  echo -n Permissions: && ls -aFl /etc/zfs/zroot.key
-
-Set the ``cachefile`` property for your pool::
+To more quickly discover and import pools on boot, we need to set a pool cachefile::
 
   zpool set cachefile=/etc/zfs/zpool.cache zroot
 
-Enable systemd zfs services::
+Configure our default boot environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  zpool set bootfs=zroot/ROOT/debian zroot
+
+Enable systemd ZFS services
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
 
   systemctl enable zfs.target
   systemctl enable zfs-import-cache
   systemctl enable zfs-mount
   systemctl enable zfs-import.target
 
-Create ``/etc/fstab`` to make sure your EFI system partition will be mounted::
-
-  cat > /etc/fstab <<EOF
-  $(blkid -s PARTUUID -o export $TARGET_ESP | grep '^PARTUUID=') /boot/efi vfat defaults 0 1
-  EOF
-
 Configure ``initramfs-tools``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Because the encryption key is stored in ``/etc/zfs`` directory, it will automatically be copied into the system
-initramfs.
+.. tabs::
 
-.. note::
+  .. group-tab:: Encrypted
 
-  The pool key will be stored in kernel initramfs in plain text. Never move this initramfs image off of the encrypted
-  pool! In addition, it is strongly recommended that the initramfs be created with permissions that prevent users from
-  inspecting its contents::
+    .. code-block::
 
-    echo "UMASK=0077" > /etc/initramfs-tools/conf.d/umask.conf
+      echo "UMASK=0077" > /etc/initramfs-tools/conf.d/umask.conf
 
-Set up ZFSBootMenu
-~~~~~~~~~~~~~~~~~~
+    .. note::
 
-Set a desired kernel command line for the boot environment, *e.g.*::
+      Because the encryption key is stored in ``/etc/zfs`` directory, it will automatically be copied into the system
+      initramfs.
+
+  .. group-tab:: Unencrypted
+
+    No required steps
+
+
+Rebuild the initramfs
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  update-initramfs -c -k all
+
+Set ZFSBootMenu properties on datasets
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Assign command-line arguments to be used when booting the final kernel. Because ZFS properties are inherited, assign the
+common properties to the ``ROOT`` dataset so all children will inherit common arguments by default.
+
+.. code-block::
 
   zfs set org.zfsbootmenu:commandline="quiet" zroot/ROOT
 
-Install ZFSBootMenu. There is no pre-built package for Debian, so we need to install from source.::
+Install and configure ZFSBootMenu
+---------------------------------
+
+Create and mount an ESP
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  mkfs.vfat -F32 /dev/sda1
+
+  cat <<EOF >/etc/fstab
+  $(blkid -s PARTUUID -o export /dev/sda1 | grep '^PARTUUID=') /boot/efi vfat defaults 0 1
+  EOF
+
+  mkdir /boot/efi
+  mount /boot/efi
+
+Install ZFSBootMenu
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
 
   mkdir -p /usr/local/src
   cd /usr/local/src
@@ -298,53 +377,70 @@ Install ZFSBootMenu. There is no pre-built package for Debian, so we need to ins
   cd zfsbootmenu
   make core dracut
 
-Configure ZFSBootMenu to build images. (It may be easier to modify the configuration in an editor).
+Install required ZFSBootMenu dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block::
 
-  sed -i -e "s|ManageImages: false|ManageImages: true|" /etc/zfsbootmenu/config.yaml
-
-Install required dependencies::
-
-  apt install libconfig-inifiles-perl libsort-versions-perl libboolean-perl libyaml-pp-perl fzf mbuffer kexec-tools dracut-core
-
-Choose 'No' when asked if kexec-tools should handle reboots.
+  apt install libsort-versions-perl \
+    libboolean-perl \
+    libyaml-pp-perl \
+    fzf \
+    mbuffer \
+    kexec-tools \
+    dracut-core \
+    efibootmgr \
+    bsdextrautils
 
 .. note::
 
-  Do not install ``dracut`` instead of ``dracut-core`` because the former conflicts with ``initramfs-tools``, requires
-  advanced configuration to boot your system. The ``dracut-core`` package coexists with ``initramfs-tools``, does not
-  alter standard system behavior, and provides everything needed by ZFSBootMenu.
+  Choose 'No' when asked if kexec-tools should handle reboots.
 
-Generate the system initramfs::
+Adjust ``/etc/zfsbootmenu/config.yaml``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  update-initramfs -c -k all
+.. code-block:: yaml
 
-Generate a ZFSBootMenu image::
+   Global:
+    ManageImages: true
+    BootMountPoint: /boot/efi
+    DracutConfDir: /etc/zfsbootmenu/dracut.conf.d
+    PreHooksDir: /etc/zfsbootmenu/generate-zbm.pre.d
+    PostHooksDir: /etc/zfsbootmenu/generate-zbm.post.d
+    InitCPIOConfig: /etc/zfsbootmenu/mkinitcpio.conf
+  Components:
+    ImageDir: /boot/efi/EFI/zbm
+    Versions: 3
+    Enabled: false
+  EFI:
+    ImageDir: /boot/efi/EFI/zbm
+    Versions: false
+    Enabled: true
+  Kernel:
+    CommandLine: ro quiet loglevel=0
+
+Generate the initial ZFSBootMenu images
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
 
   generate-zbm
+  cp /boot/efi/EFI/zbm/vmlinuz.EFI /boot/efi/EFI/zbm/vmlinuz-backup.EFI
 
-Configure rEFInd to boot the ZFSBootMenu image::
+Add UEFI boot entries
+~~~~~~~~~~~~~~~~~~~~~
 
-  cat > /boot/efi/EFI/zbm/refind_linux.conf <<EOF
-  "Boot default"  "zbm.prefer=zroot zbm.skip loglevel=4"
-  "Boot to menu"  "zbm.prefer=zroot zbm.show loglevel=4"
-  EOF
+.. code-block::
 
-(Optional) You may need to add rEFInd to your EFI boot order manually::
+  efibootmgr -c -d /dev/sda -p 1 -L "ZFSBootMenu (Backup)" -l \\EFI\\ZBM\\VMLINUZ-BACKUP.EFI
+  efibootmgr -c -d /dev/sda -p 1 -L "ZFSBootMenu" -l \\EFI\\ZBM\\VMLINUZ.EFI
 
-  apt install efibootmgr
+Exit the chroot and reboot
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  # List existing boot items
-  efibootmgr
-
-  # Add refind as a boot item
-  efibootmgr -c -d $TARGET_ESP -l "\\EFI\\refind\\refind_x64.efi" -L rEFInd
-
-Exit the chroot and reboot::
+.. code-block::
 
   exit
   cd /
   umount -R /mnt
-  zpool export -a
   reboot


### PR DESCRIPTION
The existing Debian guide had stylistic and step variations that made it stand out compared to the Void guides. This is a first pass at normalizing it to that standard.

This work precedes #390, which introduces templated re-usable snippets. That PR will expand on the work done here and use as many repeatable `_includes` as possible.

* `rEFInd` has been stripped out because the package provided by Debian seems to be buggy.
* Encrypted/Unencrypted tabs for a choose-your-own-adventure are used
* More fat has been trimmed from the steps/explanations