### PR TITLE
docs/guides/: change early EFI boot check

### DIFF
--- a/docs/guides/_include/efi-boot-check.rst
+++ b/docs/guides/_include/efi-boot-check.rst
@@ -1,0 +1,6 @@
+Confirm EFI support:
+
+.. parsed-literal::
+
+  # **dmesg | grep -i efivars**
+  [    0.301784] Registered efivars operations

--- a/docs/guides/debian/single-disk-detached-uefi.rst
+++ b/docs/guides/debian/single-disk-detached-uefi.rst
@@ -28,7 +28,9 @@ It assumes the following:
 * You're mildly comfortable with ZFS, EFI and discovering system facts on your own (``lsblk``, ``dmesg``, ``gdisk``, ...)
 
 Download the latest `Debian Bullseye (11) Live image <https://www.debian.org/CD/live/>`_, write it to a USB drive and
-boot your system in EFI mode. You can confirm you've booted in EFI mode by running ``efibootmgr``.
+boot your system in EFI mode.
+
+.. include:: ../_include/efi-boot-check.rst
 
 .. include:: _include/early-prep.rst
 

--- a/docs/guides/debian/single-disk-uefi.rst
+++ b/docs/guides/debian/single-disk-uefi.rst
@@ -27,7 +27,9 @@ It assumes the following:
 * You're mildly comfortable with ZFS, EFI and discovering system facts on your own (``lsblk``, ``dmesg``, ``gdisk``, ...)
 
 Download the latest `Debian Bullseye (11) Live image <https://www.debian.org/CD/live/>`_, write it to a USB drive and
-boot your system in EFI mode. You can confirm you've booted in EFI mode by running ``efibootmgr``.
+boot your system in EFI mode.
+
+.. include:: ../_include/efi-boot-check.rst
 
 .. include:: _include/early-prep.rst
 

--- a/docs/guides/void-linux/single-disk-detached-uefi.rst
+++ b/docs/guides/void-linux/single-disk-detached-uefi.rst
@@ -28,7 +28,9 @@ created on a removable disk. It assumes the following:
 .. include:: ../_include/intro.rst
 
 Download the latest `hrmpf <https://github.com/leahneukirchen/hrmpf/releases>`_, write it to USB drive and boot your
-system in EFI mode. You can confirm you've booted in EFI mode by running ``efibootmgr``. 
+system in EFI mode.
+
+.. include:: ../_include/efi-boot-check.rst
 
 .. include:: _include/zfs-prep.rst
 

--- a/docs/guides/void-linux/single-disk-uefi.rst
+++ b/docs/guides/void-linux/single-disk-uefi.rst
@@ -28,7 +28,9 @@ It assumes the following:
 .. include:: ../_include/intro.rst
 
 Download the latest `hrmpf <https://github.com/leahneukirchen/hrmpf/releases>`_, write it to USB drive and boot your
-system in EFI mode. You can confirm you've booted in EFI mode by running ``efibootmgr``.
+system in EFI mode.
+
+.. include:: ../_include/efi-boot-check.rst
 
 .. include:: _include/zfs-prep.rst
 


### PR DESCRIPTION
Neither `hrmpf` or the Debian live CDs mount `efivarfs` by default, so `efibootmgr` fails as an early check. Checking `dmesg` for that string seems to be a reliable check to differentiate BIOS vs EFI booting.