### PR TITLE
docs/guides/: document additional EFI resources

### DIFF
--- a/docs/guides/_include/configure-efibootmgr.rst
+++ b/docs/guides/_include/configure-efibootmgr.rst
@@ -7,8 +7,3 @@
   efibootmgr -c -d "$BOOT_DISK" -p "$BOOT_PART" \
     -L "ZFSBootMenu" \
     -l \\EFI\\ZBM\\VMLINUZ.EFI
-  
-.. note::
-
-  Some systems are known to have issues with EFI entries and may not boot correctly. If
-  this is the case, move **/boot/efi/EFI/zbm/vmlinuz.EFI** to **/boot/efi/EFI/BOOT/BOOTX64.EFI**.

--- a/docs/guides/_include/efi-seealso.rst
+++ b/docs/guides/_include/efi-seealso.rst
@@ -1,0 +1,9 @@
+.. seealso::
+
+  Some systems can have issues with EFI boot entries. If you reboot and do not see the above entries in your EFI
+  selection screen (usually accessible through an F key during POST), you might need to use a well-known EFI
+  file name. See :doc:`Portable EFI </guides/general/portable>` for help with this. Your existing ESP can be used, in place
+  of an external USB drive.
+
+  Refer to :doc:`zbm-efi-kcl.8 </man/zbm-efi-kcl.8>` and :doc:`zfsbootmenu.7 </man/zfsbootmenu.7>` for details on
+  configuring the boot-time behavior of ZFSBootMenu.

--- a/docs/guides/debian/_include/efi-boot-method.rst
+++ b/docs/guides/debian/_include/efi-boot-method.rst
@@ -22,3 +22,5 @@ Configure EFI boot entries
       apt install refind
 
     .. include:: ../_include/configure-refind.rst
+
+.. include:: ../_include/efi-seealso.rst

--- a/docs/guides/void-linux/_include/efi-boot-method.rst
+++ b/docs/guides/void-linux/_include/efi-boot-method.rst
@@ -22,3 +22,5 @@ Configure EFI boot entries
       xbps-install -S refind
 
     .. include:: ../_include/configure-refind.rst
+
+.. include:: ../_include/efi-seealso.rst


### PR DESCRIPTION
`guides/general/portable` might need to be expanded to cover an ESP on a local disk as well as one on a USB drive.