### PR TITLE
docs/guides/opensuse/: Initial Leap 15.4 guides

### DIFF
--- a/docs/guides/_include/create-filesystems.rst
+++ b/docs/guides/_include/create-filesystems.rst
@@ -52,3 +52,10 @@ Verify that everything is mounted correctly
   # **mount | grep mnt**
   zroot/ROOT/\ |distribution| on /mnt type zfs (rw,relatime,xattr,posixacl)
   zroot/home on /mnt/home type zfs (rw,relatime,xattr,posixacl)
+
+Update device symlinks
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  udevadm trigger

--- a/docs/guides/opensuse.rst
+++ b/docs/guides/opensuse.rst
@@ -1,0 +1,7 @@
+openSUSE 
+========
+
+.. toctree::
+  :titlesonly:
+
+  opensuse/uefi

--- a/docs/guides/opensuse/_include/commandline.rst
+++ b/docs/guides/opensuse/_include/commandline.rst
@@ -1,0 +1,3 @@
+.. code-block::
+
+   zfs set org.zfsbootmenu:commandline="quiet loglevel=4 rhgb" zroot/ROOT

--- a/docs/guides/opensuse/_include/distro-install.rst
+++ b/docs/guides/opensuse/_include/distro-install.rst
@@ -1,0 +1,80 @@
+Install Leap 
+------------
+
+Enable software repositories
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+  
+  zypper --root /mnt ar https://download.opensuse.org/distribution/leap/$(lsb_release -rs)/repo/non-oss non-oss
+  zypper --root /mnt ar https://download.opensuse.org/distribution/leap/$(lsb_release -rs)/repo/oss oss
+  zypper --root /mnt ar https://download.opensuse.org/update/leap/$(lsb_release -rs)/oss update-oss
+  zypper --root /mnt ar https://download.opensuse.org/update/leap/$(lsb_release -rs)/non-oss update-nonoss
+  zypper --root /mnt ar https://download.opensuse.org/repositories/filesystems/$(lsb_release -rs)/filesystems.repo
+  zypper --root /mnt refresh
+
+.. note::
+
+  Enter **a** to always trust the key.
+
+Add base packages
+~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+	zypper --root /mnt install -t pattern enhanced_base
+
+Add package management
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+	zypper --root /mnt install zypper yast2
+
+Copy files into the new install
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+  .. group-tab:: Unencrypted
+
+    .. code-block:: bash
+
+      rm /mnt/etc/resolv.conf
+      cp -L /etc/resolv.conf /mnt/etc
+      cp /etc/hostid /mnt/etc
+      mkdir -p /mnt/etc/zfs
+      cp /etc/zfs/zpool.cache /mnt/etc/zfs
+
+  .. group-tab:: Encrypted
+
+    .. code-block:: bash
+
+      rm /mnt/etc/resolv.conf
+      cp /etc/hostid /mnt/etc
+      cp -L /etc/resolv.conf /mnt/etc
+      mkdir -p /mnt/etc/zfs
+      cp /etc/zfs/zpool.cache /mnt/etc/zfs
+      cp /etc/zfs/zroot.key /mnt/etc/zfs
+
+Chroot into the new OS
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  mount -t proc proc /mnt/proc
+  mount -t sysfs sys /mnt/sys
+  mount -B /dev /mnt/dev
+  mount -t devpts pts /mnt/dev/pts
+  chroot /mnt /bin/bash
+
+Basic system configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  update-ca-certificates
+  echo 'LANG=en_US.UTF-8' > /etc/locale.conf
+  echo 'YOURHOSTNAME' > /etc/hostname
+  echo -e '127.0.1.1\tYOURHOSTNAME' >> /etc/hosts
+  passwd

--- a/docs/guides/opensuse/_include/efi-boot-method.rst
+++ b/docs/guides/opensuse/_include/efi-boot-method.rst
@@ -1,0 +1,26 @@
+Configure EFI boot entries
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+   mount -t efivarfs efivarfs /sys/firmware/efi/efivars
+
+.. tabs::
+
+  .. code-block::
+
+    zypper -n install efibootmgr
+
+  .. group-tab:: Direct
+
+    .. include:: ../_include/configure-efibootmgr.rst
+  
+  .. group-tab:: rEFInd
+
+    .. code-block::
+
+      zypper -n install refind 
+
+    .. include:: ../_include/configure-refind.rst
+
+.. include:: ../_include/efi-seealso.rst

--- a/docs/guides/opensuse/_include/live-environment.rst
+++ b/docs/guides/opensuse/_include/live-environment.rst
@@ -1,0 +1,39 @@
+Configure Live Environment
+--------------------------
+
+Disable automounting
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+	gsettings set org.gnome.desktop.media-handling automount false
+
+Switch to a root account
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  sudo -i
+
+.. include:: ../_include/os-release.rst
+
+Enable filesystems repository
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+	zypper -n addrepo https://download.opensuse.org/repositories/filesystems/$(lsb_release -rs)/filesystems.repo
+	zypper refresh 
+
+Install updated ZFS packages
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+	zypper -n install zfs zfs-kmp-default
+	modprobe zfs	
+
+.. include:: ../_include/zgenhostid.rst
+
+..
+ vim: softtabstop=2 shiftwidth=2 textwidth=120

--- a/docs/guides/opensuse/_include/zbm-install-deps.rst
+++ b/docs/guides/opensuse/_include/zbm-install-deps.rst
@@ -1,0 +1,12 @@
+Install all packages required to build a ZFSBootMenu image on Fedora:
+
+.. code-block:: bash
+
+  zypper -n install -y \
+    perl-YAML-PP \
+    perl-Sort-Versions \
+    perl-boolean \
+    git \
+    fzf \
+    mbuffer \
+    kexec-tools

--- a/docs/guides/opensuse/_include/zbm-install.rst
+++ b/docs/guides/opensuse/_include/zbm-install.rst
@@ -1,0 +1,18 @@
+Install ZFSBootMenu
+~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+  .. group-tab:: Prebuilt
+
+    .. include:: ../_include/zbm-install-prebuilt.rst
+
+  .. group-tab:: Source
+
+    .. include:: _include/zbm-install-deps.rst
+
+    .. include:: ../_include/zbm-install-source.rst
+
+    .. include:: ../_include/configure-gen-zbm.rst
+
+    .. include:: ../_include/gen-initramfs.rst

--- a/docs/guides/opensuse/_include/zfs-config.rst
+++ b/docs/guides/opensuse/_include/zfs-config.rst
@@ -1,0 +1,49 @@
+ZFS Configuration
+-----------------
+
+Configure Dracut to load ZFS support
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+  .. group-tab:: Unencrypted
+
+    .. code-block::
+
+      cat << EOF > /etc/dracut.conf.d/zol.conf
+      nofsck="yes"
+      add_dracutmodules+=" zfs "
+      omit_dracutmodules+=" btrfs "
+      EOF
+
+  .. group-tab:: Encrypted
+
+    .. code-block::
+
+      cat << EOF > /etc/dracut.conf.d/zol.conf
+      nofsck="yes"
+      add_dracutmodules+=" zfs "
+      omit_dracutmodules+=" btrfs "
+      install_items+=" /etc/zfs/zroot.key "
+      EOF
+
+Install kernel packages
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  zypper -n install kernel-default kernel-firmware
+
+Install ZFS
+~~~~~~~~~~~
+
+.. code-block::
+
+  zypper -n install zfs zfs-kmp-default
+
+Build Kernel Modules
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  dracut --regenerate-all --force

--- a/docs/guides/opensuse/uefi.rst
+++ b/docs/guides/opensuse/uefi.rst
@@ -1,0 +1,49 @@
+Leap 15.4 UEFI
+==============
+
+.. |distribution| replace:: leap
+
+.. contents:: Contents
+  :depth: 2
+  :local:
+  :backlinks: none
+
+Preparation
+-----------
+
+This guide can be used to install openSUSE Leap onto a single disk with or without ZFS encryption.
+
+It assumes the following:
+
+* Your system uses UEFI to boot
+* Your system is x86_64
+* You're mildly comfortable with ZFS, EFI and discovering system facts on your own (``lsblk``, ``dmesg``, ``gdisk``, ...)
+
+Download `openSUSE Leap 15.4 <https://download.opensuse.org/distribution/leap/15.4/appliances/iso/openSUSE-Leap-15.4-GNOME-Live-x86_64-Media.iso>`_
+, write it to a USB drive and boot your system in EFI mode.
+
+.. include:: ../_include/efi-boot-check.rst
+
+.. include:: _include/live-environment.rst
+
+.. include:: ../_include/define-env.rst
+
+.. include:: ../_include/disk-preparation.rst
+
+.. include:: ../_include/pool-creation.rst
+
+.. include:: ../_include/create-filesystems.rst
+
+.. include:: _include/distro-install.rst
+
+.. include:: _include/zfs-config.rst
+
+.. include:: ../_include/zbm-setup.rst
+
+.. include:: ../_include/setup-esp.rst
+
+.. include:: _include/zbm-install.rst
+
+.. include:: _include/efi-boot-method.rst
+
+.. include:: ../_include/cleanup.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,6 +50,7 @@
   guides/void-linux
   guides/debian
   guides/fedora
+  guides/opensuse
   guides/third-party
 
 .. toctree::


### PR DESCRIPTION
openSUSE Leap guide. Oof.

- Adds `udevadm trigger` to the global filesystem creation block, to be executed after zpool create.