### PR TITLE
zfsbootmenu: manage efivarfs when needed

### DIFF
--- a/docs/online/recovery-shell.rst
+++ b/docs/online/recovery-shell.rst
@@ -28,6 +28,10 @@ Common Commands
 
   Mount the filesystem at a unique location and print the mount point.
 
+**mount_efivarfs** *mode*
+
+  Mount or remount *efivarfs* as read-write or read-only.
+
 **help**
 
   View the online help system.

--- a/zfsbootmenu/bin/zfs-chroot
+++ b/zfsbootmenu/bin/zfs-chroot
@@ -8,6 +8,8 @@ cleanup() {
     umount "${_fs}" || zerror "unable to unmount ${_fs}"
   done
 
+  mount_efivarfs
+
   _mnt=()
   trap - HUP INT QUIT ABRT EXIT
 }
@@ -37,6 +39,19 @@ if ! mountpoint="$( allow_rw=yes mount_zfs "${selected}" )"; then
   exit 1
 fi
 
+pool="${selected%%/*}"
+
+# Snapshots and read-only pools always produce read-only mounts
+if is_snapshot "${selected}" || ! is_writable "${pool}"; then
+  writemode="$( colorize green "read-only")"
+  efivarmode="ro"
+else
+  writemode="$( colorize red "read/write")"
+  efivarmode="rw"
+fi
+
+notices+=( "* $( colorize orange "${selected}" ) is mounted ${writemode}" )
+
 # Track submounts so we know how to clean up on exit
 trap cleanup HUP INT QUIT ABRT EXIT
 _mnt=( "${mountpoint}" )
@@ -55,19 +70,19 @@ mount -t sysfs sys "${mountpoint}/sys" \
 mount -B /dev "${mountpoint}/dev" \
   && _mnt=( "${mountpoint}/dev" "${_mnt[@]}" )
 
+
+if mount_efivarfs "${efivarmode}" ; then
+  efivarfs="${mountpoint}/sys/firmware/efi/efivars"
+  mount_efivarfs "${efivarmode}" "${efivarfs}" \
+    && _mnt=( "${efivarfs}" "${_mnt[@]}" )
+
+  notices+=( "\n* $( colorize orange "efivarfs" ) is mounted ${writemode}" )
+fi
+
 # Not all /dev filesystems have /dev/pts
 [ -d "${mountpoint}/dev/pts" ] \
   && mount -t devpts pts "${mountpoint}/dev/pts" \
   && _mnt=( "${mountpoint}/dev/pts" "${_mnt[@]}" )
-
-pool="${selected%%/*}"
-
-# Snapshots and read-only pools always produce read-only mounts
-if is_snapshot "${selected}" || ! is_writable "${pool}"; then
-  writemode="$( colorize green "read-only")"
-else
-  writemode="$( colorize red "read/write")"
-fi
 
 _SHELL=
 if [ -x "${mountpoint}/bin/bash" ] \
@@ -88,7 +103,8 @@ if [ -z "${_SHELL}" ]; then
   exit 1
 fi
 
-echo -e "$( colorize orange "${selected}") is mounted ${writemode}, /tmp is shared and read/write\n"
+notices+=( "\n* $( colorize orange "/tmp" ) is mounted $( colorize red "read/write")" )
+echo -e "${notices[*]}\n"
 
 # regardless of shell, set PS1
 # shellcheck disable=SC2086

--- a/zfsbootmenu/help-files/132/recovery-shell.ansi
+++ b/zfsbootmenu/help-files/132/recovery-shell.ansi
@@ -28,6 +28,10 @@
 
     Mount the filesystem at a unique location and print the mount point.
 
+  [1mmount_efivarfs[0m [33mmode[0m
+
+    Mount or remount [33mefivarfs[0m as read-write or read-only.
+
   [1mhelp[0m
 
     View the online help system.

--- a/zfsbootmenu/help-files/52/recovery-shell.ansi
+++ b/zfsbootmenu/help-files/52/recovery-shell.ansi
@@ -33,6 +33,11 @@
     Mount the filesystem at a unique location and
     print the mount point.
 
+  [1mmount_efivarfs[0m [33mmode[0m
+
+    Mount or remount [33mefivarfs[0m as read-write or
+    read-only.
+
   [1mhelp[0m
 
     View the online help system.

--- a/zfsbootmenu/help-files/92/recovery-shell.ansi
+++ b/zfsbootmenu/help-files/92/recovery-shell.ansi
@@ -28,6 +28,10 @@
 
     Mount the filesystem at a unique location and print the mount point.
 
+  [1mmount_efivarfs[0m [33mmode[0m
+
+    Mount or remount [33mefivarfs[0m as read-write or read-only.
+
   [1mhelp[0m
 
     View the online help system.

--- a/zfsbootmenu/lib/zfsbootmenu-completions.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-completions.sh
@@ -101,3 +101,14 @@ _zkexec() {
 
 }
 complete -F _zkexec zkexec
+
+_mount_efivarfs() {
+  local STATE
+  COMPREPLY=()
+
+  [ "${#COMP_WORDS[@]}" != "2" ] && return
+
+  STATE=("ro" "rw")
+  COMPREPLY=( $( compgen -W "${STATE[*]}" -- "${COMP_WORDS[1]}" ) )
+}
+complete -F _mount_efivarfs mount_efivarfs

--- a/zfsbootmenu/libexec/zfsbootmenu-init
+++ b/zfsbootmenu/libexec/zfsbootmenu-init
@@ -26,6 +26,9 @@ unset src sources
 
 mkdir -p "${BASE:=/zfsbootmenu}"
 
+# explicitly mount efivarfs as read-only
+mount_efivarfs "ro"
+
 # Attempt to load spl normally
 if ! _modload="$( modprobe spl 2>&1 )" ; then
   zdebug "${_modload}"


### PR DESCRIPTION
`initcpio` mounts `efivarfs` as read-write, `dracut` doesn't mount it at all. Inside zfsbootmenu-init, we now check if the system is in EFI mode and then mount (or remount) `efivarfs` as read-only.

When chrooting into a boot environment, `efivarfs` is mounted in the chroot as read-only if the zpool is read-only, and read-write if the zpool is read-write.

When entering a recovery shell, `efivarfs` is re-mounted as read-write if `efibootmgr` is present in the initramfs. Exiting the shell remounts it as read-only.