### PR TITLE
Add Ubuntu 22.04 installation instructions

### DIFF
--- a/docs/guides/_include/zgenhostid.rst
+++ b/docs/guides/_include/zgenhostid.rst
@@ -3,4 +3,4 @@ Generate ``/etc/hostid``
 
 .. code-block::
 
-  zgenhostid 0x00bab10c
+  zgenhostid -f 0x00bab10c

--- a/docs/guides/ubuntu.rst
+++ b/docs/guides/ubuntu.rst
@@ -1,0 +1,7 @@
+Ubuntu
+======
+
+.. toctree::
+  :titlesonly:
+
+  ubuntu/uefi

--- a/docs/guides/ubuntu/_include/commandline.rst
+++ b/docs/guides/ubuntu/_include/commandline.rst
@@ -1,0 +1,3 @@
+.. code-block::
+
+   zfs set org.zfsbootmenu:commandline="quiet loglevel=4" zroot/ROOT

--- a/docs/guides/ubuntu/_include/distro-install.rst
+++ b/docs/guides/ubuntu/_include/distro-install.rst
@@ -1,0 +1,112 @@
+Install Ubuntu
+--------------
+
+.. code-block:: bash
+
+  debootstrap jammy /mnt
+
+Copy files into the new install
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+  .. group-tab:: Unencrypted
+
+    .. code-block:: bash
+
+      cp /etc/hostid /mnt/etc
+      cp /etc/resolv.conf /mnt/etc
+      mkdir /mnt/etc/zfs
+      cp /etc/zfs/zpool.cache /mnt/etc/zfs
+
+  .. group-tab:: Encrypted
+
+    .. code-block:: bash
+
+      cp /etc/hostid /mnt/etc/hostid
+      cp /etc/resolv.conf /mnt/etc/
+      mkdir /mnt/etc/zfs
+      cp /etc/zfs/zpool.cache /mnt/etc/zfs
+      cp /etc/zfs/zroot.key /mnt/etc/zfs
+
+Chroot into the new OS
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  mount -t proc proc /mnt/proc
+  mount -t sysfs sys /mnt/sys
+  mount -B /dev /mnt/dev
+  mount -t devpts pts /mnt/dev/pts
+  chroot /mnt /bin/bash
+
+Basic Ubuntu Configuration
+--------------------------
+
+Set a hostname
+~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  echo 'YOURHOSTNAME' > /etc/hostname
+  echo -e '127.0.1.1\tYOURHOSTNAME' >> /etc/hosts
+
+Set a root password
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  passwd
+
+Configure ``apt``. Use other mirrors if you prefer.
+
+.. code-block:: bash
+
+  cat <<EOF > /etc/apt/sources.list
+  # Uncomment the deb-src entries if you need source packages
+
+  deb http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse
+  # deb-src http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse
+
+  deb http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse
+  # deb-src http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse
+
+  deb http://archive.ubuntu.com/ubuntu/ jammy-security main restricted universe multiverse
+  # deb-src http://archive.ubuntu.com/ubuntu/ jammy-security main restricted universe multiverse
+
+  deb http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse
+  # deb-src http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse
+
+  deb http://archive.canonical.com/ubuntu/ jammy partner
+  # deb-src http://archive.canonical.com/ubuntu/ jammy partner
+  EOF
+
+Update the repository cache and system
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  apt update
+  apt upgrade
+
+Install additional base packages
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  apt install --no-install-recommends linux-generic locales keyboard-configuration console-setup
+
+.. note::
+  The `--no-install-recommends` flag is used here to avoid installing recommended, but not strictly needed, packages
+  (including `grub2`).
+
+Configure packages to customize local and console properties
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  dpkg-reconfigure locales tzdata keyboard-configuration console-setup
+
+.. note::
+
+  You should always enable the `en_US.UTF-8` locale because some programs require it.

--- a/docs/guides/ubuntu/_include/efi-boot-method.rst
+++ b/docs/guides/ubuntu/_include/efi-boot-method.rst
@@ -1,0 +1,26 @@
+Configure EFI boot entries
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+   mount -t efivarfs efivarfs /sys/firmware/efi/efivars
+
+.. tabs::
+
+  .. group-tab:: Direct
+
+    .. code-block:: bash
+
+      apt install efibootmgr
+
+    .. include:: ../_include/configure-efibootmgr.rst
+  
+  .. group-tab:: rEFInd
+
+    .. code-block::
+
+      apt install refind
+
+    .. include:: ../_include/configure-refind.rst
+
+.. include:: ../_include/efi-seealso.rst

--- a/docs/guides/ubuntu/_include/live-environment.rst
+++ b/docs/guides/ubuntu/_include/live-environment.rst
@@ -1,0 +1,27 @@
+Configure Live Environment
+--------------------------
+
+Open a root shell
+~~~~~~~~~~~~~~~~~
+
+Open a terminal on the live installer session, then:
+
+.. code-block::
+
+  sudo -i
+
+.. include:: ../_include/efi-boot-check.rst
+
+.. include:: ../_include/os-release.rst
+
+Install helpers
+~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  apt update
+  apt install debootstrap gdisk zfsutils-linux
+
+.. include:: ../_include/zgenhostid.rst
+..
+ vim: softtabstop=2 shiftwidth=2 textwidth=120

--- a/docs/guides/ubuntu/_include/zbm-install-deps.rst
+++ b/docs/guides/ubuntu/_include/zbm-install-deps.rst
@@ -1,0 +1,20 @@
+Install all packages required to build a ZFSBootMenu image on Ubuntu:
+
+.. code-block:: bash
+
+  apt install \
+    libsort-versions-perl \
+    libboolean-perl \
+    libyaml-pp-perl \
+    git \
+    fzf \
+    make \
+    mbuffer \
+    kexec-tools \
+    dracut-core \
+    efibootmgr \
+    bsdextrautils
+
+.. note::
+
+  Choose 'No' when asked if kexec-tools should handle reboots.

--- a/docs/guides/ubuntu/_include/zbm-install.rst
+++ b/docs/guides/ubuntu/_include/zbm-install.rst
@@ -1,0 +1,22 @@
+Install ZFSBootMenu
+~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+  .. group-tab:: Prebuilt
+
+    .. code-block:: bash
+
+      apt install curl
+
+    .. include:: ../_include/zbm-install-prebuilt.rst
+
+  .. group-tab:: Source
+
+    .. include:: _include/zbm-install-deps.rst
+
+    .. include:: ../_include/zbm-install-source.rst
+
+    .. include:: ../_include/configure-gen-zbm.rst
+
+    .. include:: ../_include/gen-initramfs.rst

--- a/docs/guides/ubuntu/_include/zfs-config.rst
+++ b/docs/guides/ubuntu/_include/zfs-config.rst
@@ -1,0 +1,46 @@
+ZFS Configuration
+-----------------
+
+Install required packages
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  apt install dosfstools zfs-initramfs zfsutils-linux
+
+Enable systemd ZFS services
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  systemctl enable zfs.target
+  systemctl enable zfs-import-cache
+  systemctl enable zfs-mount
+  systemctl enable zfs-import.target
+
+Configure ``initramfs-tools``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+  .. group-tab:: Unencrypted
+
+    No required steps
+
+  .. group-tab:: Encrypted
+
+    .. code-block::
+
+      echo "UMASK=0077" > /etc/initramfs-tools/conf.d/umask.conf
+
+    .. note::
+
+      Because the encryption key is stored in ``/etc/zfs`` directory, it will automatically be copied into the system
+      initramfs.
+
+Rebuild the initramfs
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  update-initramfs -c -k all

--- a/docs/guides/ubuntu/uefi.rst
+++ b/docs/guides/ubuntu/uefi.rst
@@ -1,0 +1,48 @@
+Jammy (22.04) UEFI
+==================
+
+.. |distribution| replace:: ubuntu
+
+.. contents:: Contents
+  :depth: 2
+  :local:
+  :backlinks: none
+
+This guide can be used to install Ubuntu onto a single disk with or without ZFS encryption.
+
+The end result will be a pristine Ubuntu install with no GUI or anything other than the base system. You'll be able to
+install `ubuntu-desktop`, `ubuntu-server-minimal` or whatever takes your fancy afterwards.
+
+It assumes the following:
+
+* Your system uses UEFI to boot
+* Your system is x86_64
+* You're mildly comfortable with ZFS, EFI and discovering system facts on your own (``lsblk``, ``dmesg``, ``gdisk``, ...)
+
+Download the latest `Ubuntu Desktop Jammy (22.04) Live image <https://ubuntu.com/download/desktop/>`_, write it to a USB drive and
+boot your system in EFI mode. You can use the server installation media if you want, although instructions are provided for
+installation using the desktop installer live session.
+
+.. include:: _include/live-environment.rst
+
+.. include:: ../_include/define-env.rst
+
+.. include:: ../_include/disk-preparation.rst
+
+.. include:: ../_include/pool-creation.rst
+
+.. include:: ../_include/create-filesystems.rst
+
+.. include:: _include/distro-install.rst
+
+.. include:: _include/zfs-config.rst
+
+.. include:: ../_include/zbm-setup.rst
+
+.. include:: ../_include/setup-esp.rst
+
+.. include:: _include/zbm-install.rst
+
+.. include:: _include/efi-boot-method.rst
+
+.. include:: ../_include/cleanup.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,6 +49,7 @@
   guides/general
   guides/void-linux
   guides/debian
+  guides/ubuntu
   guides/fedora
   guides/opensuse
   guides/third-party


### PR DESCRIPTION
As per title. 

The guide is almost identical to Debian's, with some changes:

 * Remove dkms related instructions throughout as Ubuntu's kernel comes with ZFS modules already available
 * Different installation environment instructions (using Ubuntu desktop's live installation media)
 * Different apt sources
 * Debootstrap
 * Other ubuntu-specific instructions

Tested (qemu/kvm):

 * Encrypted: with and without refind
 * Non-encrypted: with and without refind
 * ZFSBootMenu installation from sources