### PR TITLE
docs/guides/alpine/: initial Alpine guide

### DIFF
--- a/docs/guides/_include/create-filesystems.rst
+++ b/docs/guides/_include/create-filesystems.rst
@@ -41,6 +41,9 @@ Export, then re-import with a temporary mountpoint of ``/mnt``
       zpool export zroot
       zpool import -N -R /mnt zroot
       zfs load-key -L prompt zroot
+
+    .. code-block::
+
       zfs mount zroot/ROOT/${ID}
       zfs mount zroot/home
 

--- a/docs/guides/alpine.rst
+++ b/docs/guides/alpine.rst
@@ -1,0 +1,7 @@
+Alpine Linux
+============
+
+.. toctree::
+  :titlesonly:
+
+  alpine/uefi

--- a/docs/guides/alpine/_include/cleanup.rst
+++ b/docs/guides/alpine/_include/cleanup.rst
@@ -1,0 +1,21 @@
+Prepare for first boot
+----------------------
+
+Exit the chroot, unmount everything
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  exit
+
+.. code-block::
+
+   cut -f2 -d" " /proc/mounts | grep ^/mnt | tac | while read i; do umount -l $i; done
+
+Export the zpool and reboot
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  zpool export zroot
+  reboot

--- a/docs/guides/alpine/_include/commandline.rst
+++ b/docs/guides/alpine/_include/commandline.rst
@@ -1,0 +1,3 @@
+.. code-block::
+
+   zfs set org.zfsbootmenu:commandline="quiet loglevel=4" zroot/ROOT

--- a/docs/guides/alpine/_include/distro-install.rst
+++ b/docs/guides/alpine/_include/distro-install.rst
@@ -1,0 +1,63 @@
+Install Alpine 
+--------------
+
+.. code-block::
+
+   apk --arch x86_64 -X http://dl-cdn.alpinelinux.org/alpine/latest-stable/main \
+    -U --allow-untrusted --root /mnt --initdb add alpine-base
+
+Copy our files into the new install
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+  .. group-tab:: Unencrypted
+
+    .. code-block::
+
+      cp /etc/hostid /mnt/etc
+      cp /etc/resolv.conf /mnt/etc
+      cp /etc/apk/repositories /mnt/etc/apk
+      cp /etc/network/interfaces /mnt/etc/network
+      mkdir /mnt/etc/zfs
+      cp /etc/zfs/zpool.cache /mnt/etc/zfs
+
+  .. group-tab:: Encrypted
+
+    .. code-block::
+
+      cp /etc/hostid /mnt/etc
+      cp /etc/resolv.conf /mnt/etc
+      cp /etc/apk/repositories /mnt/etc/apk
+      cp /etc/network/interfaces /mnt/etc/network
+      mkdir /mnt/etc/zfs
+      cp /etc/zfs/zpool.cache /mnt/etc/zfs
+      cp /etc/zfs/zroot.key /mnt/etc/zfs
+
+Chroot into the new OS
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+   mount --rbind /dev /mnt/dev
+   mount --rbind /sys /mnt/sys
+   mount --rbind /proc /mnt/proc
+   chroot /mnt
+
+Set a root password
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  passwd
+
+Enable startup targets
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  rc-update add hwdrivers sysinit
+  rc-update add networking
+  rc-update add hostname
+  apk add udev
+  setup-devd udev

--- a/docs/guides/alpine/_include/efi-boot-method.rst
+++ b/docs/guides/alpine/_include/efi-boot-method.rst
@@ -1,0 +1,27 @@
+Configure EFI boot entries
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+  .. group-tab:: Direct
+
+    .. code-block:: bash
+
+        apk add efibootmgr
+
+    .. include:: ../_include/configure-efibootmgr.rst
+  
+  .. group-tab:: rEFInd
+
+    .. code-block:: bash
+
+      cat <<EOF >> /etc/apk/repositories
+      http://dl-cdn.alpinelinux.org/alpine/edge/testing
+      EOF
+
+      apk update
+      apk add refind
+
+    .. include:: ../_include/configure-refind.rst
+
+.. include:: ../_include/efi-seealso.rst

--- a/docs/guides/alpine/_include/live-environment.rst
+++ b/docs/guides/alpine/_include/live-environment.rst
@@ -1,0 +1,29 @@
+Configure Live Environment
+--------------------------
+
+.. include:: ../_include/os-release.rst
+
+Add package repositories
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+	cat <<EOF > /etc/apk/repositories
+	http://dl-cdn.alpinelinux.org/alpine/latest-stable/main/
+	https://dl-cdn.alpinelinux.org/alpine/latest-stable/main/
+	EOF
+	apk update
+
+Setup additional tools 
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  apk add zfs sgdisk wipefs eudev
+  modprobe zfs
+  setup-devd udev
+
+.. include:: ../_include/zgenhostid.rst
+
+..
+  vim: softtabstop=2 shiftwidth=2 textwidth=120

--- a/docs/guides/alpine/_include/setup-esp.rst
+++ b/docs/guides/alpine/_include/setup-esp.rst
@@ -1,0 +1,18 @@
+Create a ``vfat`` filesystem
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  mkfs.vfat -F32 "$BOOT_DEVICE"
+
+Create an fstab entry and mount
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  cat << EOF >> /etc/fstab
+  $BOOT_DEVICE /boot/efi vfat defaults 0 0
+  EOF
+
+  mkdir -p /boot/efi
+  mount /boot/efi

--- a/docs/guides/alpine/_include/zbm-install.rst
+++ b/docs/guides/alpine/_include/zbm-install.rst
@@ -1,0 +1,12 @@
+Install ZFSBootMenu
+~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+  .. group-tab:: Prebuilt
+
+    .. code-block:: bash
+
+      apk add curl
+
+    .. include:: ../_include/zbm-install-prebuilt.rst

--- a/docs/guides/alpine/_include/zfs-config.rst
+++ b/docs/guides/alpine/_include/zfs-config.rst
@@ -1,0 +1,40 @@
+ZFS Configuration
+-----------------
+
+Install ZFS
+~~~~~~~~~~~
+
+.. code-block::
+
+  apk add zfs zfs-lts 
+  rc-update add zfs-import sysinit
+  rc-update add zfs-mount sysinit
+
+Configure mkinitfs to load ZFS support
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+  .. group-tab:: Unencrypted
+
+    .. code-block::
+
+      echo "/etc/hostid" >> /etc/mkinitfs/features.d/zfshost.files
+      echo "/etc/zfs/zpool.cache" >> /etc/mkinitfs/features.d/zfshost.files
+      echo 'features="ata base keymap kms mmc scsi usb virtio zfs zfshost"' > /etc/mkinitfs/mkinitfs.conf
+
+  .. group-tab:: Encrypted
+
+    .. code-block::
+
+      echo "/etc/hostid" >> /etc/mkinitfs/features.d/zfshost.files
+      echo "/etc/zfs/zpool.cache" >> /etc/mkinitfs/features.d/zfshost.files
+      echo "/etc/zfs/zroot.key" >> /etc/mkinitfs/features.d/zfshost.files
+      echo 'features="ata base keymap kms mmc scsi usb virtio zfs zfshost"' > /etc/mkinitfs/mkinitfs.conf
+
+Regenerate initramfs
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+   mkinitfs -c /etc/mkinitfs/mkinitfs.conf "$(ls /lib/modules)"

--- a/docs/guides/alpine/uefi.rst
+++ b/docs/guides/alpine/uefi.rst
@@ -1,0 +1,49 @@
+UEFI
+====
+
+.. |distribution| replace:: alpine
+
+.. contents:: Contents
+  :depth: 2
+  :local:
+  :backlinks: none
+
+This guide can be used to install Alpine onto a single disk with with or without ZFS encryption. 
+
+It assumes the following:
+
+* Your system uses UEFI to boot
+* Your system is x86_64
+* You're mildly comfortable with ZFS, EFI and discovering system facts on your own (``lsblk``, ``dmesg``, ``gdisk``,
+  ...)
+
+.. include:: ../_include/intro.rst
+
+Download the latest `Alpine Extended ISO <https://www.alpinelinux.org/downloads/>`_, write it to USB drive and boot your
+system in EFI mode.
+
+.. include:: ../_include/efi-boot-check.rst
+
+.. include:: _include/live-environment.rst
+
+.. include:: ../_include/define-env.rst
+
+.. include:: ../_include/disk-preparation.rst
+
+.. include:: ../_include/pool-creation.rst
+
+.. include:: ../_include/create-filesystems.rst
+
+.. include:: _include/distro-install.rst
+
+.. include:: _include/zfs-config.rst
+
+.. include:: ../_include/zbm-setup.rst
+
+.. include:: _include/setup-esp.rst
+
+.. include:: _include/zbm-install.rst
+
+.. include:: _include/efi-boot-method.rst
+
+.. include:: _include/cleanup.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,7 @@
 
   guides/general
   guides/void-linux
+  guides/alpine
   guides/debian
   guides/ubuntu
   guides/fedora


### PR DESCRIPTION
I know very little about Alpine. This guide was created by merging the steps in:

* [OpenZFS Alpine install guide](https://openzfs.github.io/openzfs-docs/Getting%20Started/Alpine%20Linux/Root%20on%20ZFS/1-preparation.html)
* [testing/helpers/install-alpine.sh](https://github.com/zbm-dev/zfsbootmenu/blob/master/testing/helpers/install-alpine.sh)
* [testing/helpers/chroot-alpine.sh](https://github.com/zbm-dev/zfsbootmenu/blob/master/testing/helpers/chroot-alpine.sh)