### PR TITLE
docs: remove zpool.cache usage

### DIFF
--- a/docs/guides/_include/pool-creation.rst
+++ b/docs/guides/_include/pool-creation.rst
@@ -49,10 +49,3 @@ Create the zpool
       * ``keyformat=passphrase`` - By setting the format to ``passphrase``, we can now force a prompt for this in
         ``zfsbootmenu``. It's critical that your passphrase be something you can type on your keyboard, since you will
         need to type it in to unlock the pool on boot.
-
-Enable zpool.cache
-~~~~~~~~~~~~~~~~~~
-
-To more quickly discover and import pools on boot, we need to set a pool cachefile::
-
-   zpool set cachefile=/etc/zfs/zpool.cache zroot

--- a/docs/guides/alpine/_include/distro-install.rst
+++ b/docs/guides/alpine/_include/distro-install.rst
@@ -19,8 +19,6 @@ Copy our files into the new install
       cp /etc/resolv.conf /mnt/etc
       cp /etc/apk/repositories /mnt/etc/apk
       cp /etc/network/interfaces /mnt/etc/network
-      mkdir /mnt/etc/zfs
-      cp /etc/zfs/zpool.cache /mnt/etc/zfs
 
   .. group-tab:: Encrypted
 
@@ -31,7 +29,6 @@ Copy our files into the new install
       cp /etc/apk/repositories /mnt/etc/apk
       cp /etc/network/interfaces /mnt/etc/network
       mkdir /mnt/etc/zfs
-      cp /etc/zfs/zpool.cache /mnt/etc/zfs
       cp /etc/zfs/zroot.key /mnt/etc/zfs
 
 Chroot into the new OS

--- a/docs/guides/alpine/_include/zfs-config.rst
+++ b/docs/guides/alpine/_include/zfs-config.rst
@@ -20,7 +20,6 @@ Configure mkinitfs to load ZFS support
     .. code-block::
 
       echo "/etc/hostid" >> /etc/mkinitfs/features.d/zfshost.files
-      echo "/etc/zfs/zpool.cache" >> /etc/mkinitfs/features.d/zfshost.files
       echo 'features="ata base keymap kms mmc scsi usb virtio zfs zfshost"' > /etc/mkinitfs/mkinitfs.conf
 
   .. group-tab:: Encrypted
@@ -28,7 +27,6 @@ Configure mkinitfs to load ZFS support
     .. code-block::
 
       echo "/etc/hostid" >> /etc/mkinitfs/features.d/zfshost.files
-      echo "/etc/zfs/zpool.cache" >> /etc/mkinitfs/features.d/zfshost.files
       echo "/etc/zfs/zroot.key" >> /etc/mkinitfs/features.d/zfshost.files
       echo 'features="ata base keymap kms mmc scsi usb virtio zfs zfshost"' > /etc/mkinitfs/mkinitfs.conf
 

--- a/docs/guides/debian/_include/distro-install.rst
+++ b/docs/guides/debian/_include/distro-install.rst
@@ -16,8 +16,6 @@ Copy files into the new install
 
       cp /etc/hostid /mnt/etc
       cp /etc/resolv.conf /mnt/etc
-      mkdir /mnt/etc/zfs
-      cp /etc/zfs/zpool.cache /mnt/etc/zfs
 
   .. group-tab:: Encrypted
 
@@ -26,7 +24,6 @@ Copy files into the new install
       cp /etc/hostid /mnt/etc/hostid
       cp /etc/resolv.conf /mnt/etc/
       mkdir /mnt/etc/zfs
-      cp /etc/zfs/zpool.cache /mnt/etc/zfs
       cp /etc/zfs/zroot.key /mnt/etc/zfs
 
 Chroot into the new OS

--- a/docs/guides/fedora/_include/distro-install.rst
+++ b/docs/guides/fedora/_include/distro-install.rst
@@ -25,8 +25,6 @@ Copy files into the new install
       mv /mnt/etc/resolv.conf /mnt/etc/resolv.conf.orig
       cp -L /etc/resolv.conf /mnt/etc
       cp /etc/hostid /mnt/etc
-      mkdir -p /mnt/etc/zfs
-      cp /etc/zfs/zpool.cache /mnt/etc/zfs
 
   .. group-tab:: Encrypted
 
@@ -36,7 +34,6 @@ Copy files into the new install
       cp /etc/hostid /mnt/etc
       cp -L /etc/resolv.conf /mnt/etc
       mkdir -p /mnt/etc/zfs
-      cp /etc/zfs/zpool.cache /mnt/etc/zfs
       cp /etc/zfs/zroot.key /mnt/etc/zfs
 
 Chroot into the new OS

--- a/docs/guides/opensuse/_include/distro-install.rst
+++ b/docs/guides/opensuse/_include/distro-install.rst
@@ -43,8 +43,6 @@ Copy files into the new install
       rm /mnt/etc/resolv.conf
       cp -L /etc/resolv.conf /mnt/etc
       cp /etc/hostid /mnt/etc
-      mkdir -p /mnt/etc/zfs
-      cp /etc/zfs/zpool.cache /mnt/etc/zfs
 
   .. group-tab:: Encrypted
 
@@ -54,7 +52,6 @@ Copy files into the new install
       cp /etc/hostid /mnt/etc
       cp -L /etc/resolv.conf /mnt/etc
       mkdir -p /mnt/etc/zfs
-      cp /etc/zfs/zpool.cache /mnt/etc/zfs
       cp /etc/zfs/zroot.key /mnt/etc/zfs
 
 Chroot into the new OS

--- a/docs/guides/ubuntu/_include/distro-install.rst
+++ b/docs/guides/ubuntu/_include/distro-install.rst
@@ -16,8 +16,6 @@ Copy files into the new install
 
       cp /etc/hostid /mnt/etc
       cp /etc/resolv.conf /mnt/etc
-      mkdir /mnt/etc/zfs
-      cp /etc/zfs/zpool.cache /mnt/etc/zfs
 
   .. group-tab:: Encrypted
 
@@ -26,7 +24,6 @@ Copy files into the new install
       cp /etc/hostid /mnt/etc/hostid
       cp /etc/resolv.conf /mnt/etc/
       mkdir /mnt/etc/zfs
-      cp /etc/zfs/zpool.cache /mnt/etc/zfs
       cp /etc/zfs/zroot.key /mnt/etc/zfs
 
 Chroot into the new OS

--- a/docs/guides/void-linux/_include/distro-install.rst
+++ b/docs/guides/void-linux/_include/distro-install.rst
@@ -19,8 +19,6 @@ Copy our files into the new install
     .. code-block::
 
       cp /etc/hostid /mnt/etc
-      mkdir /mnt/etc/zfs
-      cp /etc/zfs/zpool.cache /mnt/etc/zfs
 
   .. group-tab:: Encrypted
 
@@ -28,7 +26,6 @@ Copy our files into the new install
 
       cp /etc/hostid /mnt/etc
       mkdir /mnt/etc/zfs
-      cp /etc/zfs/zpool.cache /mnt/etc/zfs
       cp /etc/zfs/zroot.key /mnt/etc/zfs
 
 Chroot into the new OS


### PR DESCRIPTION
There's little benefit to setting a zpool cache file for common root-on-ZFS systems. There are benefits on systems with many disks, but those that need it can set it up. For the rest of us, it's just something that can cause headaches.