### PR TITLE
generate-zbm: allow globs for kernel-version specs

### DIFF
--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -269,11 +269,20 @@ if ( nonempty $runConf{kernel} ) {
 
   # Try to determine a kernel file when one was not provided
   if ( nonempty $runConf{kernel_version} ) {
-    $runConf{kernel} = versionedKernel $runConf{kernel_version};
+    my $exactVersion;
+    ( $runConf{kernel}, $exactVersion ) = versionedKernel $runConf{kernel_version};
+
+    # Make sure a kernel was found
     unless ( nonempty $runConf{kernel} ) {
       print "Unable to find file for kernel version $runConf{kernel_version}\n";
       exit 1;
     }
+
+    # If the kernel version was not exact, allow it to be determined later
+    unless ($exactVersion) {
+      undef $runConf{kernel_version};
+    }
+
   } else {
     $runConf{kernel} = latestKernel;
     unless ( nonempty $runConf{kernel} ) {
@@ -284,26 +293,24 @@ if ( nonempty $runConf{kernel} ) {
 }
 
 # Try to determine kernel_prefix or kernel_version if necessary
-unless ( nonempty $runConf{kernel_prefix} and nonempty $runConf{kernel_version} ) {
+unless ( nonempty $runConf{kernel_version} ) {
 
   # Kernel version comes from either file name or internal strings
+  $runConf{kernel_version} = kernelVersion( $runConf{kernel} );
   unless ( nonempty $runConf{kernel_version} ) {
-    $runConf{kernel_version} = kernelVersion( $runConf{kernel} );
-    unless ( nonempty $runConf{kernel_version} ) {
-      printf "Unable to determine kernel version from %s\n", $runConf{kernel};
-      exit 1;
-    }
+    printf "Unable to determine kernel version from %s\n", $runConf{kernel};
+    exit 1;
   }
+}
 
+unless ( nonempty $runConf{kernel_prefix} ) {
+
+  # Prefix is basename of file, less any "-<version>" suffix
+  $runConf{kernel_prefix} = basename( $runConf{kernel} );
+  $runConf{kernel_prefix} =~ s/-\Q$runConf{kernel_version}\E$//;
   unless ( nonempty $runConf{kernel_prefix} ) {
-
-    # Prefix is basename of file, less any "-<version>" suffix
-    $runConf{kernel_prefix} = basename( $runConf{kernel} );
-    $runConf{kernel_prefix} =~ s/-\Q$runConf{kernel_version}\E$//;
-    unless ( nonempty $runConf{kernel_prefix} ) {
-      printf "Unable to determine kernel prefix from %s\n", $runConf{kernel};
-      exit 1;
-    }
+    printf "Unable to determine kernel prefix from %s\n", $runConf{kernel};
+    exit 1;
   }
 }
 
@@ -587,10 +594,18 @@ sub versionedKernel {
   my ( $kver, ) = @_;
 
   foreach my $prefix (qw(vmlinuz linux vmlinux kernel)) {
-    my $kernel = join( '/', ( $runConf{bootdir}, join( '-', ( $prefix, $kver ) ) ) );
-    if ( -f $kernel ) {
-      return $kernel;
+    my $pattern = join( '/', ( $runConf{bootdir}, join( '-', ( $prefix, $kver ) ) ) );
+
+    # Try an exact match first
+    if ( -f $pattern ) {
+      return $pattern, true;
     }
+
+    # Otherwise, try to glob
+    my @kernels = sort versioncmp glob($pattern);
+
+    next unless @kernels;
+    return pop @kernels, false;
   }
 
   return;

--- a/docs/man/generate-zbm.5.rst
+++ b/docs/man/generate-zbm.5.rst
@@ -78,7 +78,7 @@ Kernel
 
 **Version**
 
-  A specific kernel version to use. The value *%{current}* will be replaced with the output of ``uname -r``. If not set, **generate-zbm** will try to parse the path of the selected kernel filename for a version.
+  A specific kernel version to use, or a glob used to match possible kernel versions. The value *%{current}* will be replaced with the output of ``uname -r``. For globs, the highest version matching the glob will be selected. If not set, **generate-zbm** will try to parse the path of the selected kernel filename for a version.
 
 **Prefix**
 

--- a/releng/docker/image-build.sh
+++ b/releng/docker/image-build.sh
@@ -103,8 +103,9 @@ EOF
 # Install ZFSBootMenu dependencies and components necessary to build images
 buildah run "${container}" \
   sh -c 'xbps-query -Rp run_depends zfsbootmenu | xargs xbps-install -y'
-buildah run "${container}" xbps-install -y \
-  linux5.10 linux5.10-headers gummiboot-efistub curl yq-go bash kbd terminus-font \
+buildah run "${container}" xbps-install -y linux5.10 linux5.10-headers \
+  linux5.15 linux5.15-headers linux6.1 linux6.1-headers \
+  gummiboot-efistub curl yq-go bash kbd terminus-font \
   dracut mkinitcpio dracut-network gptfdisk iproute2 iputils parted curl \
   dosfstools e2fsprogs efibootmgr cryptsetup openssh util-linux kpartx
 


### PR DESCRIPTION
The idea here is to ship a build container with `linux5.{10,15}` and `linux6.1` including pre-built ZFS kmods.

**Example:** local build:

```sh
generate-zbm --kver '5.15.*'
```

**Example:** in-container build:

```sh
podman run --rm ghcr.io/zbm-dev/zbm-builder:latest -- --kver '6.1.*'
```

**Example:** `zbm-builder.sh` build:

```sh
zbm-builder.sh -- -- --kver '5.10.*'
```

**Example:** `zbm-builder.sh` with custom package installation for `linux6.2`:

```
zbm-builder.sh -- -p linux6.2 -p linux6.2-headers -p dkms -- --kver '6.2.*'
```