### PR TITLE
zsnapshot: recovery environment helper tool

### DIFF
--- a/docs/online/recovery-shell.rst
+++ b/docs/online/recovery-shell.rst
@@ -16,6 +16,10 @@ Common Commands
 
   Directly *kexec* a kernel and initramfs from a boot environment, allowing any kernel and initramfs to be loaded into memory and immediately booted.
 
+**zsnapshots** *dataset*
+
+  Access the snapshot browser for a dataset, allowing cloning and rollback operations to be initiated.
+
 **zreport**
 
   List ZFS module, pool and dataset details for bug reports.

--- a/releng/rst2help.sh
+++ b/releng/rst2help.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# vim: softtabstop=2 shiftwidth=2 expandtab
+
 set -e
 
 td="zfsbootmenu/help-files"
@@ -7,7 +9,8 @@ for size in 52 92 132 ; do
   for doc in docs/online/*.rst docs/man/zfsbootmenu.7.rst; do
     [ -d "${td}/${size}" ] || mkdir -p "${td}/${size}"
     file="$( basename -s .rst "${doc}" ).ansi"
-    echo "Converting ${doc}"
+    echo "Converting ${doc} for ${size} columns"
+    #shellcheck disable=SC2016
     COLUMNS="${size}" rst2ansi <(sed -E 's/:(doc|manpage):`([^<`]+)( <[^>]+>)?`/`\2`/g' "${doc}") | \
         sed '1s/ - \(.*\)$/\n\n\o033\[1m\1\o033\[0m/;s/\[3m/\[33m/g' > "${td}/${size}/${file}"
   done

--- a/zfsbootmenu/bin/zfsbootmenu
+++ b/zfsbootmenu/bin/zfsbootmenu
@@ -9,6 +9,7 @@ sources=(
   /lib/zfsbootmenu-lib.sh
   /lib/kmsg-log-lib.sh
   /etc/profile
+  /lib/fzf-defaults.sh
 )
 
 for src in "${sources[@]}"; do
@@ -75,48 +76,6 @@ if [ -d /libexec/setup.d ]; then
   done
   unset _hook
 fi
-
-# Override control_term if executing over SSH
-# shellcheck disable=SC2034
-[ -n "${SSH_TTY}" ] && control_term="${SSH_TTY}"
-
-# Single quote the help binds so that $HELP_SECTION expands when the key combo
-# is pressed, and not now.
-# Double quote the zlogtail lines so that they expand immediately
-
-# shellcheck disable=SC2016
-fuzzy_default_options=(
-  "--ansi" "--no-clear" "--cycle" "--color=16"
-  "--layout=reverse-list" "--inline-info" "--tac"
-  "--bind" '"alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} ]"'
-  "--bind" '"ctrl-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} ]"'
-  "--bind" '"ctrl-alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} ]"'
-  "--bind" "\"alt-l:execute[ /bin/zlogtail ]${HAS_REFRESH:++refresh-preview}\""
-  "--bind" "\"ctrl-l:execute[ /bin/zlogtail ]${HAS_REFRESH:++refresh-preview}\""
-  "--bind" "\"ctrl-alt-l:execute[ /bin/zlogtail ]${HAS_REFRESH:++refresh-preview}\""
-)
-
-if [ -n "${HAS_BORDER}" ]; then
-  # shellcheck disable=SC2016
-  fuzzy_default_options+=(
-    "--border-label-pos=top" "--border=top"
-    "--color=border:white" "--separator=''"
-  )
-fi
-
-# shellcheck disable=SC2016,SC2086
-if [ ${loglevel:-4} -eq 7 ] ; then
-  fuzzy_default_options+=(
-    "--bind" '"alt-t:execute[ /sbin/ztrace > ${control_term} ]"'
-    "--bind" '"ctrl-t:execute[ /sbin/ztrace > ${control_term} ]"'
-    "--bind" '"ctrl-alt-t:execute[ /sbin/ztrace > ${control_term} ]"'
-    "--bind" '"f12:execute[ /libexec/zfunc emergency_shell \"debugging shell\" > ${control_term} ]"'
-  )
-fi
-
-export FUZZYSEL=fzf
-export PREVIEW_HEIGHT=2
-export FZF_DEFAULT_OPTS="${fuzzy_default_options[*]}"
 
 # Clear screen before a possible password prompt
 tput clear

--- a/zfsbootmenu/bin/zsnapshots
+++ b/zfsbootmenu/bin/zsnapshots
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+sources=(
+  /lib/profiling-lib.sh
+  /etc/zfsbootmenu.conf
+  /lib/kmsg-log-lib.sh
+  /lib/zfsbootmenu-core.sh
+  /lib/zfsbootmenu-lib.sh
+  /lib/fzf-defaults.sh
+)
+
+for src in "${sources[@]}"; do
+  # shellcheck disable=SC1090
+  if ! source "${src}" >/dev/null 2>&1 ; then
+    echo -e "\033[0;31mWARNING: ${src} was not sourced; unable to proceed\033[0m"
+    exit
+  fi
+done
+
+# Replace the global_header function with a stub
+global_header() {
+  echo -n -e "\\033[1;33m[ Recover from snapshot ]"
+}
+
+if [ $# -ne 1 ] ; then
+ echo "Usage: $0 filesystem"
+ exit
+fi
+
+fs="${1}"
+
+COLUMNS="$( tput cols )"
+
+while true; do
+  if ! selection="$( draw_snapshots "${fs}" )" ; then
+    tput clear
+    exit
+  fi
+
+  # shellcheck disable=SC2162
+  IFS=, read subkey selected_snap <<< "${selection}"
+  selected_snap="${selected_snap%,*}"
+  
+  case "${subkey}" in
+    "left"|"right")
+      continue
+      ;;
+  esac
+
+  if is_snapshot "${selected_snap}" ; then
+    snapshot_dispatcher "${selected_snap}" "${subkey}"
+  fi
+done

--- a/zfsbootmenu/help-files/132/recovery-shell.ansi
+++ b/zfsbootmenu/help-files/132/recovery-shell.ansi
@@ -16,6 +16,10 @@
     Directly [33mkexec[0m a kernel and initramfs from a boot environment, allowing any kernel and initramfs to be loaded into memory and
     immediately booted.
 
+  [1mzsnapshots[0m [33mdataset[0m
+
+    Access the snapshot browser for a dataset, allowing cloning and rollback operations to be initiated.
+
   [1mzreport[0m
 
     List ZFS module, pool and dataset details for bug reports.

--- a/zfsbootmenu/help-files/52/recovery-shell.ansi
+++ b/zfsbootmenu/help-files/52/recovery-shell.ansi
@@ -20,6 +20,12 @@
     initramfs to be loaded into memory and
     immediately booted.
 
+  [1mzsnapshots[0m [33mdataset[0m
+
+    Access the snapshot browser for a dataset,
+    allowing cloning and rollback operations to
+    be initiated.
+
   [1mzreport[0m
 
     List ZFS module, pool and dataset details for

--- a/zfsbootmenu/help-files/92/recovery-shell.ansi
+++ b/zfsbootmenu/help-files/92/recovery-shell.ansi
@@ -16,6 +16,11 @@
     Directly [33mkexec[0m a kernel and initramfs from a boot environment, allowing any kernel and
     initramfs to be loaded into memory and immediately booted.
 
+  [1mzsnapshots[0m [33mdataset[0m
+
+    Access the snapshot browser for a dataset, allowing cloning and rollback operations to
+    be initiated.
+
   [1mzreport[0m
 
     List ZFS module, pool and dataset details for bug reports.

--- a/zfsbootmenu/lib/fzf-defaults.sh
+++ b/zfsbootmenu/lib/fzf-defaults.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# vim: softtabstop=2 shiftwidth=2 expandtab
+
+# Override control_term if executing over SSH
+# shellcheck disable=SC2034
+[ -n "${SSH_TTY}" ] && control_term="${SSH_TTY}"
+
+# shellcheck disable=SC2016
+fuzzy_default_options=(
+  "--ansi" "--no-clear" "--cycle" "--color=16"
+  "--layout=reverse-list" "--inline-info" "--tac"
+  "--bind" '"alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} ]"'
+  "--bind" '"ctrl-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} ]"'
+  "--bind" '"ctrl-alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} ]"'
+  "--bind" "\"alt-l:execute[ /bin/zlogtail ]${HAS_REFRESH:++refresh-preview}\""
+  "--bind" "\"ctrl-l:execute[ /bin/zlogtail ]${HAS_REFRESH:++refresh-preview}\""
+  "--bind" "\"ctrl-alt-l:execute[ /bin/zlogtail ]${HAS_REFRESH:++refresh-preview}\""
+)
+
+if [ -n "${HAS_BORDER}" ]; then
+  # shellcheck disable=SC2016
+  fuzzy_default_options+=(
+    "--border-label-pos=top" "--border=top"
+    "--color=border:white" "--separator=''"
+  )
+fi
+
+# shellcheck disable=SC2016,SC2086
+if [ ${loglevel:-4} -eq 7 ] ; then
+  fuzzy_default_options+=(
+    "--bind" '"alt-t:execute[ /sbin/ztrace > ${control_term} ]"'
+    "--bind" '"ctrl-t:execute[ /sbin/ztrace > ${control_term} ]"'
+    "--bind" '"ctrl-alt-t:execute[ /sbin/ztrace > ${control_term} ]"'
+    "--bind" '"f12:execute[ /libexec/zfunc emergency_shell \"debugging shell\" > ${control_term} ]"'
+  )
+fi
+
+export FUZZYSEL=fzf
+export PREVIEW_HEIGHT=2
+export FZF_DEFAULT_OPTS="${fuzzy_default_options[*]}"

--- a/zfsbootmenu/lib/zfsbootmenu-completions.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-completions.sh
@@ -71,6 +71,20 @@ _mount_zfs() {
 }
 complete -F _mount_zfs mount_zfs
 
+_zsnapshots() {
+  local ZFS
+  COMPREPLY=()
+
+  [ "${#COMP_WORDS[@]}" != "2" ] && return
+
+  for FS in $( zfs list -H -o name ) ; do
+    ZFS+=("${FS}")
+  done
+
+  COMPREPLY=( $( compgen -W "${ZFS[*]}" -- "${COMP_WORDS[1]}" ) )
+}
+complete -F _zsnapshots zsnapshots
+
 _zkexec() {
   local ARG index
   COMPREPLY=()

--- a/zfsbootmenu/libexec/zfsbootmenu-preview
+++ b/zfsbootmenu/libexec/zfsbootmenu-preview
@@ -11,7 +11,7 @@ ENV="${1}"
 BOOTFS="${2}"
 
 # shellcheck disable=SC2034
-IFS=' ' read -r _fs selected_kernel _initramfs <<<"$( select_kernel "${ENV}")"
+IFS=' ' read -r _fs selected_kernel _initramfs <<<"$( select_kernel "${ENV}" || echo "- missing -" )"
 selected_kernel="${selected_kernel##*/}"
 
 if [ "${BOOTFS}" = "${ENV}" ]; then


### PR DESCRIPTION
In the event that no boot environments with a valid /boot are found, recovery might be as simple as interacting with an older snapshot. The recovery shell tool `zsnapshot` attempts to make that easier by allowing access to the main snapshot interface for a given dataset.

fzf defaults suitable for the main interfaces were moved to a lib file that can be sourced. These defaults allow smaller tools to match the same behavior that fzf has when invoked from /bin/zfsbootmenu .

select_kernel now returns 1 when the 'kernels' file for a boot environment can't be found, with nothing printed. The caller is expected to handle that condition accordingly.

Fixes #418