### PR TITLE
docs/guides/debian/: add initial bookworm guide

### DIFF
--- a/docs/guides/debian.rst
+++ b/docs/guides/debian.rst
@@ -4,4 +4,5 @@ Debian
 .. toctree::
   :titlesonly:
 
-  debian/uefi
+  debian/bullseye-uefi
+  debian/bookworm-uefi

--- a/docs/guides/debian/_include/bookworm/distro-install.rst
+++ b/docs/guides/debian/_include/bookworm/distro-install.rst
@@ -1,0 +1,99 @@
+Install Debian
+--------------
+
+.. code-block:: bash
+
+  debootstrap bookworm /mnt
+
+Copy files into the new install
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+  .. group-tab:: Unencrypted
+
+    .. code-block:: bash
+
+      cp /etc/hostid /mnt/etc
+      cp /etc/resolv.conf /mnt/etc
+
+  .. group-tab:: Encrypted
+
+    .. code-block:: bash
+
+      cp /etc/hostid /mnt/etc/hostid
+      cp /etc/resolv.conf /mnt/etc/
+      mkdir /mnt/etc/zfs
+      cp /etc/zfs/zroot.key /mnt/etc/zfs
+
+Chroot into the new OS
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  mount -t proc proc /mnt/proc
+  mount -t sysfs sys /mnt/sys
+  mount -B /dev /mnt/dev
+  mount -t devpts pts /mnt/dev/pts
+  chroot /mnt /bin/bash
+
+Basic Debian Configuration
+--------------------------
+
+Set a hostname
+~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  echo 'YOURHOSTNAME' > /etc/hostname
+  echo -e '127.0.1.1\tYOURHOSTNAME' >> /etc/hosts
+
+Set a root password
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  passwd
+
+Configure ``apt``. Use other mirrors if you prefer.
+
+.. code-block:: bash
+
+  cat <<EOF > /etc/apt/sources.list
+  deb http://deb.debian.org/debian bookworm main contrib
+  deb-src http://deb.debian.org/debian bookworm main contrib
+
+  deb http://deb.debian.org/debian-security bookworm-security main contrib
+  deb-src http://deb.debian.org/debian-security/ bookworm-security main contrib
+
+  deb http://deb.debian.org/debian bookworm-updates main contrib
+  deb-src http://deb.debian.org/debian bookworm-updates main contrib
+
+  deb http://deb.debian.org/debian bookworm-backports main contrib
+  deb-src http://deb.debian.org/debian bookworm-backports main contrib
+  EOF
+
+Update the repository cache
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  apt update
+
+Install additional base packages
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  apt install locales keyboard-configuration console-setup
+
+Configure packages to customize local and console properties
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  dpkg-reconfigure locales tzdata keyboard-configuration console-setup
+
+.. note::
+
+  You should always enable the `en_US.UTF-8` locale because some programs require it.

--- a/docs/guides/debian/_include/bookworm/live-environment.rst
+++ b/docs/guides/debian/_include/bookworm/live-environment.rst
@@ -1,0 +1,41 @@
+Configure Live Environment
+--------------------------
+
+Switch to a root shell
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  sudo -i
+
+.. include:: ../_include/os-release.rst
+
+Configure and update APT
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  cat <<EOF > /etc/apt/sources.list
+  deb http://deb.debian.org/debian bookworm main contrib
+  deb-src http://deb.debian.org/debian bookworm main contrib
+  EOF
+  apt update
+
+.. note::
+
+  You may see faster downloads replacing ``deb.debian.org`` with a local mirror. If you want to use HTTPS transport, make
+  sure that the ``ca-certificates`` and ``apt-transport-https`` packages are installed and your mirror has a valid
+  certificate; otherwise, apt will refuse to use the mirror.
+
+Install helpers
+~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  apt install debootstrap gdisk dkms linux-headers-$(uname -r)
+  apt install zfsutils-linux
+
+.. include:: ../_include/zgenhostid.rst
+
+..
+ vim: softtabstop=2 shiftwidth=2 textwidth=120

--- a/docs/guides/debian/_include/bullseye/distro-install.rst
+++ b/docs/guides/debian/_include/bullseye/distro-install.rst
@@ -1,0 +1,99 @@
+Install Debian
+--------------
+
+.. code-block:: bash
+
+  debootstrap bullseye /mnt
+
+Copy files into the new install
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+  .. group-tab:: Unencrypted
+
+    .. code-block:: bash
+
+      cp /etc/hostid /mnt/etc
+      cp /etc/resolv.conf /mnt/etc
+
+  .. group-tab:: Encrypted
+
+    .. code-block:: bash
+
+      cp /etc/hostid /mnt/etc/hostid
+      cp /etc/resolv.conf /mnt/etc/
+      mkdir /mnt/etc/zfs
+      cp /etc/zfs/zroot.key /mnt/etc/zfs
+
+Chroot into the new OS
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  mount -t proc proc /mnt/proc
+  mount -t sysfs sys /mnt/sys
+  mount -B /dev /mnt/dev
+  mount -t devpts pts /mnt/dev/pts
+  chroot /mnt /bin/bash
+
+Basic Debian Configuration
+--------------------------
+
+Set a hostname
+~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  echo 'YOURHOSTNAME' > /etc/hostname
+  echo -e '127.0.1.1\tYOURHOSTNAME' >> /etc/hosts
+
+Set a root password
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  passwd
+
+Configure ``apt``. Use other mirrors if you prefer.
+
+.. code-block:: bash
+
+  cat <<EOF > /etc/apt/sources.list
+  deb http://deb.debian.org/debian bullseye main contrib
+  deb-src http://deb.debian.org/debian bullseye main contrib
+
+  deb http://deb.debian.org/debian-security bullseye-security main contrib
+  deb-src http://deb.debian.org/debian-security/ bullseye-security main contrib
+
+  deb http://deb.debian.org/debian bullseye-updates main contrib
+  deb-src http://deb.debian.org/debian bullseye-updates main contrib
+
+  deb http://deb.debian.org/debian bullseye-backports main contrib
+  deb-src http://deb.debian.org/debian bullseye-backports main contrib
+  EOF
+
+Update the repository cache
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  apt update
+
+Install additional base packages
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  apt install locales keyboard-configuration console-setup
+
+Configure packages to customize local and console properties
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  dpkg-reconfigure locales tzdata keyboard-configuration console-setup
+
+.. note::
+
+  You should always enable the `en_US.UTF-8` locale because some programs require it.

--- a/docs/guides/debian/_include/bullseye/live-environment.rst
+++ b/docs/guides/debian/_include/bullseye/live-environment.rst
@@ -1,0 +1,41 @@
+Configure Live Environment
+--------------------------
+
+Switch to a root shell
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  sudo -i
+
+.. include:: ../_include/os-release.rst
+
+Configure and update APT
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  cat <<EOF > /etc/apt/sources.list
+  deb http://deb.debian.org/debian bullseye main contrib
+  deb-src http://deb.debian.org/debian bullseye main contrib
+  EOF
+  apt update
+
+.. note::
+
+  You may see faster downloads replacing ``deb.debian.org`` with a local mirror. If you want to use HTTPS transport, make
+  sure that the ``ca-certificates`` and ``apt-transport-https`` packages are installed and your mirror has a valid
+  certificate; otherwise, apt will refuse to use the mirror.
+
+Install helpers
+~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  apt install debootstrap gdisk dkms linux-headers-$(uname -r)
+  apt install zfsutils-linux
+
+.. include:: ../_include/zgenhostid.rst
+
+..
+ vim: softtabstop=2 shiftwidth=2 textwidth=120

--- a/docs/guides/debian/bookworm-uefi.rst
+++ b/docs/guides/debian/bookworm-uefi.rst
@@ -1,4 +1,4 @@
-Bullseye UEFI
+Bookworm (12) UEFI
 =============
 
 .. |distribution| replace:: debian
@@ -16,12 +16,12 @@ It assumes the following:
 * Your system is x86_64
 * You're mildly comfortable with ZFS, EFI and discovering system facts on your own (``lsblk``, ``dmesg``, ``gdisk``, ...)
 
-Download the latest `Debian Bullseye (11) Live image <https://www.debian.org/CD/live/>`_, write it to a USB drive and
+Download the latest `Debian Bookworm (12) Live image <https://www.debian.org/CD/live/>`_, write it to a USB drive and
 boot your system in EFI mode.
 
 .. include:: ../_include/efi-boot-check.rst
 
-.. include:: _include/live-environment.rst
+.. include:: _include/bookworm/live-environment.rst
 
 .. include:: ../_include/define-env.rst
 
@@ -31,7 +31,7 @@ boot your system in EFI mode.
 
 .. include:: ../_include/create-filesystems.rst
 
-.. include:: _include/distro-install.rst
+.. include:: _include/bookworm/distro-install.rst
 
 .. include:: _include/zfs-config.rst
 

--- a/docs/guides/debian/bullseye-uefi.rst
+++ b/docs/guides/debian/bullseye-uefi.rst
@@ -1,0 +1,46 @@
+Bullseye (11) UEFI
+=============
+
+.. |distribution| replace:: debian
+
+.. contents:: Contents
+  :depth: 2
+  :local:
+  :backlinks: none
+
+This guide can be used to install Debian onto a single disk with or without ZFS encryption.
+
+It assumes the following:
+
+* Your system uses UEFI to boot
+* Your system is x86_64
+* You're mildly comfortable with ZFS, EFI and discovering system facts on your own (``lsblk``, ``dmesg``, ``gdisk``, ...)
+
+Download the latest `Debian Bullseye (11) Live image <https://cdimage.debian.org/mirror/cdimage/archive/11.7.0-live/amd64/iso-hybrid/>`_, write it to a USB drive and
+boot your system in EFI mode.
+
+.. include:: ../_include/efi-boot-check.rst
+
+.. include:: _include/bullseye/live-environment.rst
+
+.. include:: ../_include/define-env.rst
+
+.. include:: ../_include/disk-preparation.rst
+
+.. include:: ../_include/pool-creation.rst
+
+.. include:: ../_include/create-filesystems.rst
+
+.. include:: _include/bullseye/distro-install.rst
+
+.. include:: _include/zfs-config.rst
+
+.. include:: ../_include/zbm-setup.rst
+
+.. include:: ../_include/setup-esp.rst
+
+.. include:: _include/zbm-install.rst
+
+.. include:: _include/efi-boot-method.rst
+
+.. include:: ../_include/cleanup.rst


### PR DESCRIPTION
Prepare for the upcoming Debian 12 (Bookworm) release by adding a guide for it. Links for CD Images in both the Bullseye and Bookworm guides need to be fixed so that they point to the right resources after Debian 12 is officially released.

We can possibly create links for Bullseye images to some persistent directory at https://cdimage.debian.org/mirror/cdimage/archive/ . I'll need to poke around the cdimage.debian.org in more detail to find a stable URL, though.

Closes #425 