### PR TITLE
zfs-chroot: add read-write prompt

### DIFF
--- a/zfsbootmenu/bin/zfs-chroot
+++ b/zfsbootmenu/bin/zfs-chroot
@@ -33,13 +33,23 @@ selected="${1}"
 zdebug "started with ${selected}"
 
 [ -n "${selected}" ] || exit 0
+pool="${selected%%/*}"
+
+if ! is_snapshot "${selected}" && ! is_writable "${pool}" ; then
+  if ! timed_prompt -d 10 \
+    -e "Enter r/w chroot" \
+    -r "Enter r/o chroot" \
+    -p "Entering chroot in $( colorize yellow "%0.2d" ) seconds" ; then
+      set_rw_pool "${pool}"
+  fi
+fi
+
+clear
 
 if ! mountpoint="$( allow_rw=yes mount_zfs "${selected}" )"; then
   zerror "failed to mount ${selected}"
   exit 1
 fi
-
-pool="${selected%%/*}"
 
 # Snapshots and read-only pools always produce read-only mounts
 if is_snapshot "${selected}" || ! is_writable "${pool}"; then


### PR DESCRIPTION
When entering a chroot for a regular dataset and the pool is read-only, provide a timed_prompt that lets the user choose between entering a read-only chroot (return key/enter key) or a read-write chroot (escape key). If the dataset is a snapshot or the pool is already read-write, do not show the prompt.

Fixes #428