### PR TITLE
zbm-builder.sh: Add support for running on hosts with SELinux enabled

### DIFF
--- a/docs/guides/general/container-building.rst
+++ b/docs/guides/general/container-building.rst
@@ -108,6 +108,11 @@ Building a ZFSBootMenu Image
 To build a default image, invoke ``zbm-builder.sh`` with no arguments. For example, from the directory that contains the
 script, run ``./zbm-builder.sh`` to produce a default kernel/initramfs pair in the ``./build`` subdirectory.
 
+To build on a host with SELinux enabled, the ``-M z -O -e=DRACUT_NO_XATTR=1`` options are needed. The `z` mount flag will
+relabel both the build (``-b``) and source (``-l``) directories with the ``container_file_t`` type so that the container
+is able to access the files. The ``DRACUT_NO_XATTR`` will prevent dracut from trying to set xattrs on temporary files
+within the container. Specifically, a container is never allowed to set the ``security.selinux`` xattr.
+
 The default behavior of ``zbm-builder.sh`` will:
 
 1. Pull the default builder image, ``ghcr.io/zbm-dev/zbm-builder:latest``.


### PR DESCRIPTION
This commit updates `zbm-builder.sh` to include a new `-M` option for specifying podman/docker volume mount flags. On systems with SELinux enabled, `-M z` must be specified so that the volume will be relabeled with the `container_file_t` SELinux type. Otherwise, the directory contents are not accessible within the container.

In addition, when using `-l <source dir>`, `-O -e=DRACUT_NO_XATTR=1` must be specified. By default, when dracut copies files to its temporary directory, it runs:

    cp --preserve=mode,xattr,timestamps,ownership <...>

This environment variable makes dracut disable the `xattr` flag. This is necessary because cp would try to preserve the `security.selinux` xattr, which is never allowed inside a container. This should have no impact on the generated initramfs image because ZFSBootMenu does not use any custom xattrs and cpio is incapable of storing them anyway. mkinitcpio does not try to set xattrs, so no workaround is needed for that.