### PR TITLE
zfsbootmenu-core: try to load keys in mount_zfs

### DIFF
--- a/zfsbootmenu/bin/zfs-chroot
+++ b/zfsbootmenu/bin/zfs-chroot
@@ -41,12 +41,11 @@ if ! is_snapshot "${selected}" && ! is_writable "${pool}" ; then
     -r "Enter r/o chroot" \
     -p "Entering chroot in $( colorize yellow "%0.2d" ) seconds" ; then
       set_rw_pool "${pool}"
-      CLEAR_SCREEN=1 load_key "${selected}"
   fi
 fi
 
-reset
-clear
+tput reset
+tput clear
 
 if ! mountpoint="$( allow_rw=yes mount_zfs "${selected}" )"; then
   zerror "failed to mount ${selected}"

--- a/zfsbootmenu/libexec/zfsbootmenu-diff
+++ b/zfsbootmenu/libexec/zfsbootmenu-diff
@@ -46,8 +46,6 @@ fi
 base_fs="${snapshot%%@*}"
 zdebug "base filesystem: ${base_fs}"
 
-CLEAR_SCREEN=1 load_key "${base_fs}"
-
 if ! mnt="$( mount_zfs "${base_fs}" )" ; then
   zerror "unable to mount ${base_fs}"
   exit 1 


### PR DESCRIPTION
Attempting to load encryption keys when mounting a ZFS filesystem avoids the need to manually load keys in a few places and ensure that mount_zfs tries hard to do the right thing even when run interactively.

Because mount_zfs is also called from cache_key and it might be problematic to enter some indirect recursion when manipulating ZFS keys, setting NO_LOAD_KEY=1 will tell mount_zfs to skip this attempt and just fail when the BE is locked.

This isn't really tested, but it should also work.

(While I was at it, I replaced `reset` and `clear` in `zfs-chroot` with equivalent `tput` commands in case the wrappers aren't installed or the aliases set in the recovery `bashrc` don't make their way into the invocation.