### PR TITLE
refactor remote access guide

### DIFF
--- a/docs/guides/general.rst
+++ b/docs/guides/general.rst
@@ -8,6 +8,7 @@ General
   general/container-building
   general/native-encryption
   general/uefi-booting
+  general/mkinitcpio
   general/remote-access
   general/portable
 

--- a/docs/guides/general/container-example.rst
+++ b/docs/guides/general/container-example.rst
@@ -158,7 +158,7 @@ ZFSBootMenu images is largely the same as the
 :doc:`process for host-built images </guides/general/remote-access>`, but care must be taken to ensure that all
 necessary components are available within the build directory.
 
-- The :ref:`core configuration changes <remote-mkinitcpio-core>` should be **ignored**. They are unnecessary with the
+- The :doc:`core configuration changes <mkinitcpio>` should be **ignored**. They are unnecessary with the
   container configuration described above.
 
 - The :ref:`basic network access <remote-mkinitcpio-net>` and :ref:`dropbear <remote-mkinitcpio-dropbear>` instructions

--- a/docs/guides/general/mkinitcpio.rst
+++ b/docs/guides/general/mkinitcpio.rst
@@ -1,0 +1,44 @@
+Building with mkinitcpio
+========================
+
+ZFSBootMenu also supports the `mkinitcpio <https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/>`_ initramfs
+generator used by Arch Linux and available for Void Linux, but it must be configured first.
+
+Since `version 2.0.0 <https://github.com/zbm-dev/zfsbootmenu/releases/tag/v2.0.0>`_, ZFSBootMenu will install a standard
+:zbm:`mkinitcpio.conf <etc/zfsbootmenu/mkinitcpio.conf>` in the ``/etc/zfsbootmenu`` configuration directory. This file
+is generally the same as a standard ``mkinitcpio.conf``, except some additional declarations may be added to control
+aspects of the ``zfsbootmenu`` mkinitcpio module. The configuration file includes extensive inline documentation in the
+form of comments; configuration options specific to ZFSBootMenu are also described in the
+:ref:`zfsbootmenu(7) <zbm-mkinitcpio-options>` manual page.
+
+ZFSBootMenu still expects to use Dracut by default. To override this behavior and instead use mkinitcpio, edit
+``/etc/zfsbootmenu/config.yaml`` and add the following options:
+
+.. code-block:: yaml
+
+  Global:
+    InitCPIO: true
+    ## NOTE: The following three lines are OPTIONAL
+    InitCPIOHookDirs:
+      - /etc/zfsbootmenu/initcpio
+      - /usr/lib/initcpio
+
+.. note::
+
+  In some ZFSBootMenu guides, like :doc:`remote-access`, some mkinitcpio modules will be installed to
+  ``/etc/zfsbootmenu/initcpio`` to keep them isolated from system-installed modules. To accommodate this non-standard
+  installation, ``InitCPIOHookDirs`` must be defined in ``/etc/zfsbootmenu/config.yaml``. Furthermore, because
+  overriding the hook directory causes mkinitcpio to ignore its default module path, the default ``/usr/lib/initcpio``
+  must be manually specified. If all hooks are installed in ``/usr/lib/initcpio`` or ``/etc/initcpio``, the ZFSBootMenu
+  configuration does **not** need to specify ``InitCPIOHookDirs``.
+
+Without further changes, running ``generate-zbm`` should now produce a ZBM image based on mkinitcpio rather than Dracut.
+
+Whenever ``generate-zbm`` is run to generate images based on mkinitcpio, it forcefully adds the the required
+``zfsbootmenu`` hook after any hooks defined in the ``HOOKS`` array of ``/etc/zfsbootmenu/mkinitcpio.conf``. The default
+configuration file explicitly includes the ``zfsbootmenu`` hook in the array as a visual reminder that it will be
+included (strictly speaking, this will cause mkinitcpio to add the hook **twice**, but because the ``zfsbootmenu`` hook
+completely takes over execution of its initramfs image, it will only ever run once). If any custom configuration requires
+additional hooks be added to the ZFSBootMenu initramfs image, make sure that these hooks are included **before** any
+occurrence of ``zfsbootmenu`` in ``HOOKS``. Better still, just remove the ``zfsbootmenu`` hook from
+``/etc/zfsbootmenu/mkinitcpio.conf`` when making any edits to ``HOOKS`` to minimize the chance of configuration errors.

--- a/docs/guides/general/remote-access.rst
+++ b/docs/guides/general/remote-access.rst
@@ -11,47 +11,163 @@ your boot environments reside in encrypted filesystems, SSH access is necessary 
 when you are not physically present. Because ZFSBootMenu supports Dracut and mkinitcpio, any mechanism that can provide
 remote access to a Dracut or mkinitcpio initramfs will work.
 
-Dracut
-------
+Enabling Network Access
+-----------------------
 
-The `dracut-crypt-ssh <https://github.com/dracut-crypt-ssh/dracut-crypt-ssh>`_ provides a straightforward approach to
-configuring and launching an SSH server in Dracut images. The module is packaged in Void and does not rely on
-``systemd`` within the initramfs. If you run a distribution that does not package ``dracut-crypt-ssh``, you will need to
-track down its dependencies. The ``dracut-network`` module and ``dropbear`` are required to provide network access and
-an SSH server, respectively; other prerequisites are probably already installed on your system.
+.. tabs::
 
-Simplified Installation Instructions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  .. group-tab:: Dracut
 
-The ``dracut-crypt-ssh`` package comes with a few helper utilities in the ``module/60crypt-ssh/helper`` directory that
-are designed to simplify providing passwords and snooping console output so that you can interact with unlock processes
-that are already running in the initramfs. These components are not required for ZFSBootMenu and do not provide a lot of
-value. If you have no problems installing the package as intended, it is OK to leave the helpers installed. If your
-distribution has trouble compiling the helpers, just copy the contents of the ``60crypt-ssh`` directory, less the
-``helper`` directory and ``Makefile``, to the modules directory for Dracut. This will most likely be
-``/usr/lib/dracut/modules.d/60crypt-ssh``.
+    The `dracut-crypt-ssh <https://github.com/dracut-crypt-ssh/dracut-crypt-ssh>`_ module provides a straightforward
+    approach to configuring and launching an SSH server in Dracut images. This module is packaged on several distributions,
+    but if you run a distribution that does not package ``dracut-crypt-ssh``, you will need to track down its dependencies:
+    the ``dracut-network`` module for network access and ``dropbear`` for the SSH server; other prerequisites are probably
+    already installed on your system.
 
-If you do not install the contents of ``helper``, you may wish to edit the ``module-setup.sh`` script provided by the
-package to remove references to installing the helper. At the time of writing, these references consist of the last four
-lines (five, if you count the harmless comment) of the ``install()`` functioned. Removing these lines should not be
-critical, as Dracut should happily continue the initramfs creation process even if those installation commands fail.
+    .. note::
+      The ``dracut-crypt-ssh`` module comes with a few helper utilities in the ``module/60crypt-ssh/helper`` directory that
+      are designed to simplify providing passwords and snooping console output so that you can interact with unlock processes
+      that are already running in the initramfs. These components are not required for ZFSBootMenu and do not provide a lot of
+      value. If you have no problems installing the module as intended, it is okay to leave the helpers installed. If your
+      distribution has trouble compiling the helpers, just copy the contents of the ``60crypt-ssh`` directory, except for the
+      ``helper`` directory and ``Makefile``, to the modules directory for Dracut. This will most likely be
+      ``/usr/lib/dracut/modules.d/60crypt-ssh``.
 
-If you use Dracut to produce the initramfs images in your boot environment, you may wish to disable the ``crypt-ssh``
-module in those images. Just add
+      If you do not install the contents of ``helper``, you may wish to edit the ``module-setup.sh`` script provided by the
+      package to remove references to installing the helper. At the time of writing, these references consist of the last four
+      lines (five, if you count the harmless comment) of the ``install()`` functioned. Removing these lines should not be
+      critical, as Dracut should happily continue the initramfs creation process even if those installation commands fail.
 
-.. code-block::
+    If you use Dracut to produce the initramfs images in your boot environment, you may wish to disable the ``crypt-ssh``
+    module in those images. Just add::
 
-  omit_dracutmodules+=" crypt-ssh "
+      omit_dracutmodules+=" crypt-ssh "
 
-to a configuration file in ``/etc/dracut.conf.d``. The configuration file must have a ``.conf`` extension to be
-recognized; see `dracut.conf(5) <https://man.voidlinux.org/dracut.conf.5>`_ for more information.
+    to a configuration file in ``/etc/dracut.conf.d``. The configuration file must have a ``.conf`` extension to be
+    recognized; see :manpage:`dracut.conf(5)` for more information.
 
-Configuring Dropbear in ZFSBootMenu
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    To inform ``dracut-network`` that it must bring up a network interface, pass the kernel command-line parameters
+    ``ip=dhcp`` and ``rd.neednet=1`` to your ZFSBootMenu image. If you use another boot loader to start ZFSBootMenu, *e.g.*
+    rEFInd or syslinux, this can be accomplished by configuring that loader. However, it may be more convenient to add these
+    parameters directly to the ZFSBootMenu image::
 
-By default, ``dracut-crypt-ssh`` will generate random host keys for your ZFSBootMenu initramfs. This is undesirable
-because SSH will complain about unknown keys every time you reboot. If you wish, you can configure the module to copy
-your regular host keys into the image. However, there are two problems with this:
+      mkdir -p /etc/cmdline.d
+      echo "ip=dhcp rd.neednet=1" > /etc/cmdline.d/dracut-network.conf
+
+    It is possible to specify a static IP configuration by replacing ``dhcp`` with a properly formatted configuration
+    string. Consult the `dracut documentation <https://man.voidlinux.org/dracut.cmdline.7#Network>`_ for details about
+    static IP configuration.
+
+    There are methods besides writing to ``/etc/cmdline.d`` or configuring another boot loader to specify kernel
+    command-line arguments that will configure networking in Dracut. However, Dracut uses the ``/etc/cmdline.d`` directory
+    to store "fake" arguments, which it processes directly rather than handing to the kernel. Using other methods
+    (like adding these arguments to the ``kernel_cmdline`` Dracut option for a UEFI bundle) can cause the ``ip=dhcp``
+    argument to appear more than once on the kernel command-line, which may cause ``dracut-network`` to fail
+    catastrophically and refuse to boot. Writing a configuration file in ``/etc/cmdline.d`` is a reliable way to ensure
+    that ``ip=dhcp`` appears exactly once to ``dracut-network``.
+
+  .. group-tab:: mkinitcpio
+
+    .. _remote-mkinitcpio-net:
+
+    If using :doc:`mkinitcpio <mkinitcpio>` to generate the ZFSBootMenu image, network access can be realized in several ways.
+
+    On some distributions, the `mkinitcpio-nfs-utils <https://repology.org/project/mkinitcpio-nfs-utils>`_ package
+    provides a ``net`` module that allows the initramfs to parse ``ip=`` kernel command-line parameters.
+
+    If a static IP configuration is sufficient, the `mkinitcpio-rclocal <https://github.com/ahesford/mkinitcpio-rclocal>`_
+    module, which allows user scripts to be injected at several points in the initramfs boot process, provides a simple
+    mechanism for configuring a network interface.
+
+    .. tabs::
+
+      .. group-tab:: mkinitcpio-nfs-utils
+
+        First, install ``mkinitcpio-nfs-utils``.
+
+        Then, to ensure that the ``net`` module is installed and run in the ZBM image, either append ``net`` to the array
+        defined on the ``HOOKS`` line in ``/etc/zfsbootmenu/mkinitcpio.conf`` or run::
+
+          sed -e '/HOOKS=/a HOOKS+=(net)' -i /etc/zfsbootmenu/mkinitcpio.conf
+
+        Next, add an ``ip=`` parameter to ZFSBootMenu's kernel command-line. If you use another boot loader to start
+        ZFSBootMenu, *e.g.* rEFInd or syslinux, this can be accomplished by configuring that loader. If booting the EFI
+        bundle directly, this can be accomplished by configuring it in ``/etc/zfsbootmenu/config.yaml``, for example:
+
+        .. code-block:: yaml
+
+          Kernel:
+            CommandLine: "ro quiet loglevel=0 ip=:::::eth0:dhcp"
+
+        .. note::
+          For more details about the possible values for the ``ip=`` parameter, see the `net module documentation
+          <https://wiki.archlinux.org/title/Mkinitcpio#Using_net>`_.
+
+      .. group-tab:: mkinitcpio-rclocal
+
+        First, install ``mkinitcpio-rclocal``::
+
+          curl -L https://github.com/ahesford/mkinitcpio-rclocal/archive/master.tar.gz | tar -zxvf - -C /tmp
+          mkdir -p /etc/zfsbootmenu/initcpio/{install,hooks}
+          cp /tmp/mkinitcpio-rclocal-master/rclocal_hook /etc/zfsbootmenu/initcpio/hooks/rclocal
+          cp /tmp/mkinitcpio-rclocal-master/rclocal_install /etc/zfsbootmenu/initcpio/install/rclocal
+          rm -r /tmp/mkinitcpio-rclocal-master
+
+        Next, create an ``rc.local`` script that can be run within the mkinitcpio image to configure the ``eth0`` interface::
+
+          cat > /etc/zfsbootmenu/initcpio/rc.local <<RCEOF
+          #!/bin/sh
+
+          # Don't attempt to configure an interface that does not exist
+          ip link show dev eth0 >/dev/null 2>&1 || exit
+
+          # Bring up the interface
+          ip link set dev eth0 up
+
+          # Configure a static address for this host
+          ip addr add 192.168.1.2/24 brd + dev eth0
+          ip route add default via 192.168.1.1
+
+          # Add some name servers
+          cat > /etc/resolv.conf <<EOF
+          nameserver 1.1.1.1
+          nameserver 8.8.8.8
+          EOF
+          RCEOF
+
+        .. note::
+
+          If your Ethernet interface is called something other than ``eth0`` or your static IP configuration is different,
+          adjust the script as needed.
+
+        To ensure that the ``rclocal`` module is installed and run in the ZBM image, either append ``rclocal`` to the array
+        defined on the ``HOOKS`` line in ``/etc/zfsbootmenu/mkinitcpio.conf`` or run::
+
+          sed -e '/HOOKS=/a HOOKS+=(rclocal)' -i /etc/zfsbootmenu/mkinitcpio.conf
+
+        The ``rclocal`` module should be told where it can find the ``rc.local`` script to install and run by running::
+
+          echo 'rclocal_hook=/etc/zfsbootmenu/initcpio/rc.local' >> /etc/zfsbootmenu/mkinitcpio.conf
+
+        Finally, make sure to include the ``ip`` executable in your initramfs image by manually adding ``ip`` to the
+        ``BINARIES`` array in ``/etc/zfsbootmenu/mkinitcpio.conf`` or by running::
+
+          sed -e '/BINARIES=/a BINARIES+=(ip)' -i /etc/zfsbootmenu/mkinitcpio.conf
+
+
+Unless you've taken steps not described here, the network-enabled ZFSBootMenu image will not advertise itself via
+dynamic DNS or mDNS. You will need to know the IP address of the ZFSBootMenu host to connect. Thus, you should either
+configure a static IP address or configure your DHCP server to reserve a known address for the MAC address of the
+network interface you configured.
+
+Configuring Dropbear
+--------------------
+
+First, install ``dropbear``, if not already installed.
+
+By default, ``dropbear`` will generate random host keys for your ZFSBootMenu initramfs. This is undesirable because SSH
+will complain about unknown keys every time you reboot. If you wish, you can configure it to copy your regular host keys
+into the image. However, there are two problems with this:
 
 1. The ZFSBootMenu image will generally be installed on a filesystem with no access permissions, allowing anybody to
    read your private host keys; and
@@ -63,251 +179,94 @@ To create dedicated host keys in the proper format, decide on a location, for ex
 new keys::
 
   mkdir -p /etc/dropbear
-  ssh-keygen -t rsa -m PEM -f /etc/dropbear/ssh_host_rsa_key
-  ssh-keygen -t ecdsa -m PEM -f /etc/dropbear/ssh_host_ecdsa_key
-
-The module expects to install RSA and ECDSA keys, so both types are created here.
-
-.. note::
-
-  When prompted for a passphrase when creating each host key, leave it blank. A non-empty password will prevent dropbear
-  from reading a key.
-
-To inform ``dracut-network`` that it must bring up a network interface, pass the kernel command-line parameters
-``ip=dhcp`` and ``rd.neednet=1`` to your ZFSBootMenu image. If you use another boot loader to start ZFSBootMenu, *e.g.*
-rEFInd or syslinux, this can be accomplished by configuring that loader. However, it may be more convenient to add these
-parameters directly to the ZFSBootMenu image::
-
-  mkdir -p /etc/cmdline.d
-  echo "ip=dhcp rd.neednet=1" > /etc/cmdline.d/dracut-network.conf
-
-It is possible to specify a static IP configuration by replacing ``dhcp`` with a properly formatted configuration
-string. Consult the `dracut documentation <https://man.voidlinux.org/dracut.cmdline.7#Network>`_ for details about
-static IP configuration.
-
-There are methods besides writing to ``/etc/cmdline.d`` or configuring another boot loader to specify kernel
-command-line arguments that will configure networking in Dracut. However, Dracut uses the ``/etc/cmdline.d`` directory
-to store "fake" arguments, which it processes directly rather than handing to the kernel. In my tests, using other
-methods (like adding these arguments to the ``kernel_cmdline`` Dracut option for a UEFI bundle) can cause the
-``ip=dhcp`` argument to appear more than once on the kernel command-line, which may cause ``dracut-network`` to fail
-catastrophically and refuse to boot. Writing a configuration file in ``/etc/cmdline.d`` is a reliable way to ensure that
-``ip=dhcp`` appears exactly once to ``dracut-network``.
-
-With critical pieces in place, ZFSBootMenu can be configured to bundle ``dracut-crypt-ssh`` in its images. Create the
-Dracut configuration file ``/etc/zfsbootmenu/dracut.conf.d/dropbear.conf`` with the following contents::
-
-  # Enable dropbear ssh server and pull in network configuration args
-  add_dracutmodules+=" crypt-ssh "
-  install_optional_items+=" /etc/cmdline.d/dracut-network.conf "
-  # Copy system keys for consistent access
-  dropbear_rsa_key=/etc/dropbear/ssh_host_rsa_key
-  dropbear_ecdsa_key=/etc/dropbear/ssh_host_ecdsa_key
-  # User zbmuser is the authorized unlocker here
-  dropbear_acl=/home/zbmuser/.ssh/authorized_keys
-
-The last line is optional and assumes the user ``zbmuser`` should provide an ``authorized_keys`` file that will
-determine remote access to the ZFSBootMenu image. The ``dracut-crypt-ssh`` module does not allow for password
-authentication over SSH; instead, key-based authentication is forced. By default, the list of authorized keys is taken
-from ``/root/.ssh/authorized_keys`` on the host. If you would prefer to use the ``authorized_keys`` file from another
-user on your system, copy the above example and replace ``zbmuser`` with the name of the user whose ``authorized_keys``
-you wish to include.
-
-.. note::
-
-  The default configuration will start dropbear on TCP port 222. This can be overridden with the ``dropbear_port``
-  configuration option. Generally, you do not want the server listening on the default port 22. Clients that expect to
-  find your normal host keys when connecting to an SSH server on port 22 will refuse to connect when they find different
-  keys provided by dropbear.
-
-Unless you've taken steps not described here, the network-enabled ZFSBootMenu image will not advertise itself via
-dynamic DNS or mDNS. You will need to know the IP address of the ZFSBootMenu host to connect. Thus, you should either
-configure a static IP address in ``/etc/cmdline.d/dracut-network.conf`` or configure your DHCP server to reserve a known
-address for the MAC address of the network interface you configure for ``dracut-crypt-ssh``.
-
-mkinitcpio
-----------
-
-ZFSBootMenu also supports the `mkinitcpio <https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/>`_ initramfs
-generator used by Arch Linux.
-
-.. _remote-mkinitcpio-core:
-
-ZFSBootMenu Configuration Changes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Since `version 2.0.0 <https://github.com/zbm-dev/zfsbootmenu/releases/tag/v2.0.0>`_, ZFSBootMenu will install a standard
-:zbm:`mkinitcpio.conf <etc/zfsbootmenu/mkinitcpio.conf>` in the ``/etc/zfsbootmenu`` configuration directory. This file
-is generally the same as a standard ``mkinitcpio.conf``, except some additional declarations may be added to control
-aspects of the ``zfsbootmenu`` mkinitcpio module. The configuration file includes extensive inline documentation in the
-form of comments; configuration options specific to ZFSBootMenu are also described in the
-:ref:`zfsbootmenu(7) <zbm-mkinitcpio-options>` manual page.
-
-ZFSBootMenu still expects to use dracut by default. To override this behavior and instead use mkinitcpio, edit
-``/etc/zfsbootmenu/config.yaml`` and add the following options:
-
-.. code-block:: yaml
-
-  Global:
-    InitCPIO: true
-    ## NOTE: The following three lines are OPTIONAL
-    InitCPIOHookDirs:
-      - /etc/zfsbootmenu/initcpio
-      - /usr/lib/initcpio
-
-.. note::
-
-  In the examples below, a couple of mkinitcpio modules will be installed to ``/etc/zfsbootmenu/initcpio`` to keep them
-  isolated from system-installed modules. To accommodate this non-standard installation, ``InitCPIOHookDirs`` must be
-  defined in ``/etc/zfsbootmenu/config.yaml``. Furthermore, because overriding the hook directory causes mkinitcpio to
-  ignore its default module path, the default ``/usr/lib/initcpio`` must be manually specified. If all hooks are
-  installed in ``/usr/lib/initcpio`` or ``/etc/initcpio``, the ZFSBootMenu configuration does **not** need to specify
-  ``InitCPIOHookDirs``.
-
-Without further changes, running ``generate-zbm`` should now produce a ZBM image based on mkinitcpio rather than dracut,
-although it will lack networking and remote-access capabilities. (By default, ``generate-zbm`` instructs mkinitcpio to
-use the configuration at ``/etc/zfsbootmenu/config.yaml``, although this can be changed in the ``generate-zbm``
-configuration file.) For these features, some additional mkinitcpio modules and configuration changes are necessary.
-
-Because further configuration will require additional mkinitcpio modules, and these must be run before the
-``zfsbootmenu`` module in the initramfs, edit ``/etc/zfsbootmenu/mkinitcpio.conf`` and **remove** any ``zfsbootmenu``
-entry in the ``HOOKS`` definition. As the standard configuration file notes, the ``zfsbootmenu`` module is required for
-ZFSBootMenu to function, but ``generate-zbm`` will forcefully at this at the end of the module list. Thus, the simplest
-way to ensure that additions to the ``HOOKS`` array occur *before* the ``zfsbootmenu`` module is to omit the latter from
-the configuration. The standard ``HOOKS`` line in ``/etc/zfsbootmenu/mkinitcpio.conf`` should therefore be something
-like::
-
-  HOOKS=(base udev autodetect modconf block filesystems keyboard)
-
-.. _remote-mkinitcpio-net:
-
-Basic Network Access
-~~~~~~~~~~~~~~~~~~~~
-
-Network access in a mkinitcpio image can be realized in one of several ways. In Arch Linux, for example, the
-`mkinitcpio-nfs-utils <https://archlinux.org/packages/?name=mkinitcpio-nfs-utils>`_ package provides a
-`net module <https://wiki.archlinux.org/title/Mkinitcpio#Using_net>`_ that allows the initramfs to parse ``ip=``
-directives from the kernel command line. When a static IP configuration is sufficient, the
-`mkinitcpio-rclocal <https://github.com/ahesford/mkinitcpio-rclocal>`_ module allows user scripts to be injected at
-several points in the initramfs boot process and provides a simple mechanism for configuring a network interface.
-
-When installing mkinitcpio modules that are not provided by a system package manager, it may be preferable to keep them
-isolated from the ordinary module tree. Because this module will only be required in ZBM images, placing extra modules
-in ``/etc/zfsbootmenu/initcpio`` is convenient::
-
-  curl -L https://github.com/ahesford/mkinitcpio-rclocal/archive/master.tar.gz | tar -zxvf - -C /tmp
-  mkdir -p /etc/zfsbootmenu/initcpio/{install,hooks}
-  cp /tmp/mkinitcpio-rclocal-master/rclocal_hook /etc/zfsbootmenu/initcpio/hooks/rclocal
-  cp /tmp/mkinitcpio-rclocal-master/rclocal_install /etc/zfsbootmenu/initcpio/install/rclocal
-  rm -r /tmp/mkinitcpio-rclocal-master
-
-Next, create an ``rc.local`` script that can be run within the mkinitcpio image to configure the ``eth0`` interface::
-
-  cat > /etc/zfsbootmenu/initcpio/rc.local <<RCEOF
-  #!/bin/sh
-
-  # Don't attempt to configure an interface that does not exist
-  ip link show dev eth0 >/dev/null 2>&1 || exit
-
-  # Bring up the interface
-  ip link set dev eth0 up
-
-  # Configure a static address for this host
-  ip addr add 192.168.1.2/24 brd + dev eth0
-  ip route add default via 192.168.1.1
-
-  # Add some name servers
-  cat > /etc/resolv.conf <<-EOF
-    nameserver 1.1.1.1
-    nameserver 8.8.8.8
-    EOF
-  RCEOF
-
-.. note::
-
-  If your Ethernet interface is called something other than ``eth0`` or your static IP configuration is different,
-  adjust the script as needed.
-
-To ensure that the ``rclocal`` module is installed and run in the ZBM image, either append ``rclocal`` to the array
-defined on the ``HOOKS`` line in ``/etc/zfsbootmenu/mkinitcpio.conf`` or run
-
-.. code-block::
-
-  sed -e '/HOOKS=/a HOOKS+=(rclocal)' -i /etc/zfsbootmenu/mkinitcpio.conf
-
-The ``rclocal`` module should be told where it can find the ``rc.local`` script to install and run by running::
-
-  echo 'rclocal_hook=/etc/zfsbootmenu/initcpio/rc.local' >> /etc/zfsbootmenu/mkinitcpio.conf
-
-Finally, make sure to include the ``ip`` executable in your initramfs image by manually adding ``ip`` to the
-``BINARIES`` array in ``/etc/zfsbootmenu/mkinitcpio.conf`` or by running
-
-.. code-block::
-
-  sed -e '/BINARIES=/a BINARIES+=(ip)' -i /etc/zfsbootmenu/mkinitcpio.conf
-
-.. _remote-mkinitcpio-dropbear:
-
-Dropbear
-~~~~~~~~
-
-Arch Linux provides a `mkinitcpio-dropbear <https://archlinux.org/packages/community/any/mkinitcpio-dropbear/>`_ package
-that provides a straightforward method for installing, configuring and running the dropbear SSH server inside a
-mkinitcpio image. This package is based on a
-`project of the same name <https://github.com/grazzolini/mkinitcpio-dropbear>`_ by an Arch Linux developer. A
-`fork of the mkinitcpio-dropbear project <https://github.com/ahesford/mkinitcpio-dropbear>`_ contains a few minor
-improvements in runtime configuration and key management. If these improvements are not needed, using the upstream
-project is perfectly acceptable.
-
-Once again, the mkinitcpio module must first be downloaded and installed::
-
-  curl -L https://github.com/ahesford/mkinitcpio-dropbear/archive/master.tar.gz | tar -zxvf - -C /tmp
-  mkdir -p /etc/zfsbootmenu/initcpio/{install,hooks}
-  cp /tmp/mkinitcpio-dropbear-master/rclocal_hook /etc/zfsbootmenu/initcpio/hooks/dropbear
-  cp /tmp/mkinitcpio-dropbear-master/rclocal_install /etc/zfsbootmenu/initcpio/install/dropbear
-  rm -r /tmp/mkinitcpio-dropbear-master
-
-The upstream ``dropbear`` module will attempt to copy host OpenSSH keys into ``/etc/dropbear`` if possible; otherwise,
-it will generate random host keys. Both options are undesirable. Copying host keys will leave these protected files
-directly accessible to anybody able to read a ZFSBootMenu image, which is probably every user on the system. Generating
-unique keys with each run inhibits your ability to detect interlopers when you connect to your bootloader via SSH. My
-fork will, by default, respect any existing dropbear keys available as ``/etc/dropbear/dropbear_*_host_key``. Therefore,
-make some new host keys for use in your ZFSBootMenu image::
-
-  mkdir -p /etc/dropbear
   for keytype in rsa ecdsa ed25519; do
       dropbearkey -t "${keytype}" -f "/etc/dropbear/dropbear_${keytype}_host_key"
   done
 
-The module also requires, at ``/etc/dropbear/root_key``, a set of authorized SSH keys that will be given access to the
-``root`` account in the image. On a single-user system, it is sufficient to do::
+.. note::
+  The dracut module expects to install RSA and ECDSA keys, so at minimum those keys should be created.
+  The mkinitcpio module supports RSA, ECDSA, and ED25519 keys.
 
-  ln -s ${HOME}/.ssh/authorized_keys /etc/dropbear/root_key
+  Not all versions of ``dropbear`` support ED25519 keys, so it is fine if the ED25519 key fails to generate.
 
-assuming that ``${HOME}`` points to the home directory of the user who should be given access to ZFSBootMenu.
+The Dracut and mkinitcpio dropbear modules do not allow for password authentication over SSH; instead key-based
+authentication is forced. The authorized keys for dropbear can be configured by putting an `authorized_keys file
+<https://man.voidlinux.org/dropbear#Authorized>`_ at ``/etc/dropbear/root_key``. On a single-user machine, this can be
+realized by symlinking your user's ``authorized_keys`` file::
 
-Finally, enable the ``dropbear`` module in ``/etc/zfsbootmenu/mkinitcpio.conf`` by manually appending ``dropbear`` to
-the ``HOOKS`` array, or by running::
+  ln -s "${HOME}/.ssh/authorized_keys" /etc/dropbear/root_key
 
-  sed -e '/HOOKS.*rclocal/a HOOKS+=(dropbear)' -i /etc/zfsbootmenu/mkinitcpio.conf
+.. tabs::
+
+  .. group-tab:: Dracut
+
+    With critical pieces in place, ZFSBootMenu can be configured to bundle ``dracut-crypt-ssh`` in its images. Create
+    the Dracut configuration file ``/etc/zfsbootmenu/dracut.conf.d/dropbear.conf`` with the following contents::
+
+      # Enable dropbear ssh server and pull in network configuration args
+      add_dracutmodules+=" crypt-ssh "
+      install_optional_items+=" /etc/cmdline.d/dracut-network.conf "
+      # Copy system keys for consistent access
+      dropbear_rsa_key=/etc/dropbear/ssh_host_rsa_key
+      dropbear_ecdsa_key=/etc/dropbear/ssh_host_ecdsa_key
+      dropbear_acl=/etc/dropbear/root_key
+
+    .. note::
+
+      The default configuration will start dropbear on TCP port 222. This can be overridden with the ``dropbear_port``
+      configuration option. Generally, you do not want the server listening on the default port 22. Clients that expect
+      to find your normal host keys when connecting to an SSH server on port 22 will refuse to connect when they find
+      different keys provided by dropbear.
+
+  .. group-tab:: mkinitcpio
+
+    .. _remote-mkinitcpio-dropbear:
+
+    Arch Linux provides a `mkinitcpio-dropbear <https://archlinux.org/packages/community/any/mkinitcpio-dropbear/>`_
+    package that provides a straightforward method for installing, configuring and running the dropbear SSH server
+    inside a mkinitcpio image. This package is based on a `project of the same name
+    <https://github.com/grazzolini/mkinitcpio-dropbear>`_ by an Arch Linux developer. A `fork of the mkinitcpio-dropbear
+    project <https://github.com/ahesford/mkinitcpio-dropbear>`_ contains a few minor improvements in runtime
+    configuration and key management. If these improvements are not needed, using the upstream project is perfectly
+    acceptable.
+
+    First, download and install the mkinitcpio module::
+
+      curl -L https://github.com/ahesford/mkinitcpio-dropbear/archive/master.tar.gz | tar -zxvf - -C /tmp
+      mkdir -p /etc/zfsbootmenu/initcpio/{install,hooks}
+      cp /tmp/mkinitcpio-dropbear-master/dropbear_hook /etc/zfsbootmenu/initcpio/hooks/dropbear
+      cp /tmp/mkinitcpio-dropbear-master/dropbear_install /etc/zfsbootmenu/initcpio/install/dropbear
+      rm -r /tmp/mkinitcpio-dropbear-master
+
+    Then, enable the ``dropbear`` module in ``/etc/zfsbootmenu/mkinitcpio.conf`` by manually appending ``dropbear`` to
+    the ``HOOKS`` array, or by running::
+
+      sed -e '/HOOKS.*rclocal/a HOOKS+=(dropbear)' -i /etc/zfsbootmenu/mkinitcpio.conf
+
+    .. note::
+
+      The default configuration will start dropbear on TCP port 22. If using the ``ahesford/mkinitcpio-dropbear`` fork
+      recommended here, this can be overridden by defining ``dropbear_listen`` in ``/etc/dropbear/dropbear.conf``::
+
+        echo 'dropbear_listen=222' >> /etc/dropbear/dropbear.conf
+
+      Generally, you do not want the server listening on the default port 22. Clients that expect to find your normal
+      host keys when connecting to an SSH server on port 22 will refuse to connect when they find different keys
+      provided by dropbear.
 
 Final Steps
-~~~~~~~~~~~
+-----------
 
 With the above configuration complete, running ``generate-zbm`` should produce a ZFSBootMenu image that contains the
 necessary components to enable an SSH server in your bootloader. This can be verified with the ``lsinitrd`` tool
 provided by dracut or the ``lsinitcpio`` tool provided by mkinitcpio. (The ``lsinitcpio`` tool is not able to inspect
 UEFI bundles, but ``lsinitrd`` can.) In the file listing, you should see keys in ``/etc/dropbear``, the ``dropbear`` and
-``ip`` executables, and the file ``root/.ssh/authorized_keys``.
+``ip`` executables, and the file ``/root/.ssh/authorized_keys``.
 
 After rebooting, ZFSBootMenu should configure the network interface, launch an SSH server and accept connections on TCP
-port 22 by default. If your SSH client complains because it finds ZFSBootMenu keys when it expects to find your normal
-host keys, you may wish to reconfigure dropbear to listen on a non-standard port. My fork of ``mkinitcpio-dropbear``
-supports this by writing a ``dropbear_listen`` definition to ``/etc/dropbear/dropbear.conf``::
-
-  echo 'dropbear_listen=2222' > /etc/dropbear/dropbear.conf
-
-After writing this file (adjust ``2222`` to whatever port you prefer), re-run ``generate-zbm``, reboot and confirm that
-dropbear listens where expected.
+port 222 (for Dracut) or TCP port 22 (for mkinitcpio) by default, unless otherwise configured. If your SSH client
+complains because it finds ZFSBootMenu keys when it expects to find your normal host keys, you may wish to reconfigure
+dropbear to listen on a non-standard port and re-run ``generate-zbm``.
 
 Accessing ZFSBootMenu Remotely
 ------------------------------
@@ -321,7 +280,7 @@ You may then use the menu as if you were connected locally.
 
 .. note::
 
-  recent versions of ZFSBootMenu automatically set the ``TERM`` environment variable to ``linux``. If you are running an
+  Recent versions of ZFSBootMenu automatically set the ``TERM`` environment variable to ``linux``. If you are running an
   older version, your SSH client may have provided a more specific terminal definition that will not be recognized by
   the restricted environment provided by ZFSBootMenu. Under these circumstances, you may need to run::
 


### PR DESCRIPTION
- docs/guides/general: move mkinitcpio setup to its own guide
- docs/guides/general/remote-access: refactor for easier reading

hopefully this reads better than the old guide. made some stuff consistent between dracut and mkinitcpio to make organisation easier
