### PR TITLE
zfsbootmenu: log errors for unimportable pools

### DIFF
--- a/zfsbootmenu/bin/zlogtail
+++ b/zfsbootmenu/bin/zlogtail
@@ -2,6 +2,7 @@
 
 # shellcheck disable=SC1091
 source /lib/zfsbootmenu-lib.sh >/dev/null 2>&1 || exit 1
+source /lib/kmsg-log-lib.sh >/dev/null 2>&1 || exit 1
 
 [ -f "${BASE}/have_errors" ] && rm "${BASE}/have_errors"
 [ -f "${BASE}/have_warnings" ] && rm "${BASE}/have_warnings"
@@ -29,10 +30,4 @@ fi
 
 export FZF_DEFAULT_OPTS="${fuzzy_default_options[*]}"
 
-# Try to use feature flags found on dmesg from util-linux
-if output="$( dmesg --notime -f user -l err,warn 2>/dev/null )" ; then
-  echo "${output}" | ${FUZZYSEL}
-else
-  # fall back to manually parsing dmesg output; will show all ZBM generated logs up to zinfo level
-  dmesg | awk '/ZFSBootMenu:/{ for (i=3; i<=NF; i++){ printf("%s ", $i)}; printf "\n" }' | ${FUZZYSEL}
-fi
+print_kmsg_logs "err,warn" | ${FUZZYSEL}

--- a/zfsbootmenu/libexec/zfsbootmenu-init
+++ b/zfsbootmenu/libexec/zfsbootmenu-init
@@ -116,6 +116,7 @@ fi
 # If a boot pool is specified, that will be tried first
 try_pool="${boot_pool}"
 zbm_import_attempt=0
+
 while true; do
   if [ -n "${try_pool}" ]; then
     zdebug "attempting to import preferred pool ${try_pool}"
@@ -173,6 +174,7 @@ while true; do
       continue
   fi
 
+  log_unimportable
   # Allow the user to attempt recovery
   emergency_shell "unable to successfully import a pool"
 done


### PR DESCRIPTION
Before landing at the emergency_shell in the main import loop, log the output of a failed zpool import for every pool that's marked UNAVAIL .

In the emergency_shell function, write any log messages at the 'err' level directly to the active console.

https://asciinema.org/a/5QLE1dKHyeMDdmGQNmjM29yU0