### PR TITLE
Add dm-crypt kernel module to recovery images

### DIFF
--- a/etc/zfsbootmenu/recovery.conf.d/recovery.conf
+++ b/etc/zfsbootmenu/recovery.conf.d/recovery.conf
@@ -9,6 +9,7 @@ install_optional_items+=" /bin/efibootmgr "
 
 # LUKS control
 install_optional_items+=" /bin/cryptsetup "
+add_drivers+=" dm-crypt "
 
 # Networking
 install_optional_items+=" /bin/ip /bin/curl /bin/dhclient /sbin/dhclient-script /bin/ssh "

--- a/releng/docker/Dockerfile
+++ b/releng/docker/Dockerfile
@@ -7,7 +7,7 @@
 # repository you want on /zbm inside the container.
 
 # Use the official Void Linux container
-FROM voidlinux/voidlinux:latest
+FROM ghcr.io/void-linux/void-glibc-full:latest
 ARG ZBM_COMMIT_HASH
 
 # Ensure everything is up-to-date

--- a/releng/docker/image-build.sh
+++ b/releng/docker/image-build.sh
@@ -102,7 +102,7 @@ if [ ! -r "${ZBM_BUILDER}" ]; then
 fi
 
 maintainer="ZFSBootMenu Team, https://zfsbootmenu.org"
-container="$(buildah from ghcr.io/void-linux/void-linux:latest-full-x86_64)"
+container="$(buildah from ghcr.io/void-linux/void-glibc-full:latest)"
 
 buildah config --label author="${maintainer}" "${container}"
 


### PR DESCRIPTION
Apparently `cryptsetup` is unusable without `dm-crypt` (#468), so it should be added.

While we're at it, it's time to migrate to a newer base image.