### PR TITLE
zfsbootmenu-core: conditionally disable spl_hostid warnings

### DIFF
--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -124,7 +124,7 @@ install() {
 
   # vdev_id.conf and hostid files are host-specific
   # and do not belong in public release images
-  if [ -z "${release_build}" ]; then
+  if [ -z "${zfsbootmenu_release_build}" ]; then
     if [ -e /etc/zfs/vdev_id.conf ]; then
       inst /etc/zfs/vdev_id.conf
       type mark_hostonly >/dev/null 2>&1 && mark_hostonly /etc/zfs/vdev_id.conf
@@ -171,7 +171,7 @@ install() {
 
   # Force rd.hostonly=0 in the KCL for releases, this will purge itself after 99base/init.sh runs
   # shellcheck disable=SC2154
-  if [ -n "${release_build}" ]; then
+  if [ -n "${zfsbootmenu_release_build}" ]; then
     echo "rd.hostonly=0" > "${initdir}/etc/cmdline.d/hostonly.conf"
   fi
 

--- a/etc/zfsbootmenu/release.conf.d/common.conf
+++ b/etc/zfsbootmenu/release.conf.d/common.conf
@@ -14,4 +14,4 @@ omit_dracutmodules+=" qemu "
 omit_dracutmodules+=" nvdimm fs-lib rootfs-block dm dmraid crypt "
 
 embedded_kcl="rd.hostonly=0"
-release_build=1
+zfsbootmenu_release_build=1

--- a/zfsbootmenu/install-helpers.sh
+++ b/zfsbootmenu/install-helpers.sh
@@ -100,6 +100,15 @@ create_zbm_conf() {
     has_column=1
   fi
 
+  case "${zfsbootmenu_release_build,,}" in
+    yes|y|on|1)
+      zfsbootmenu_release_build=1
+      ;;
+    *)
+      zfsbootmenu_release_build=
+      ;;
+  esac
+
   # Normalize ZBM_BUILDSTYLE, if set
   case "${ZBM_BUILDSTYLE,,}" in
     mkinitcpio) ZBM_BUILDSTYLE="mkinitcpio" ;;
@@ -113,12 +122,14 @@ create_zbm_conf() {
 	readonly _ETC_ZFSBOOTMENU_CONF=1
 	EOF
 
+  # shellcheck disable=SC2154
   cat >> "${BUILDROOT}/etc/zfsbootmenu.conf" <<-EOF
 	export HAS_REFRESH="${has_refresh}"
 	export HAS_DISABLED="${has_disabled}"
 	export HAS_BORDER="${has_border}"
 	export HAS_COLUMN="${has_column}"
 	export ZBM_BUILDSTYLE="${ZBM_BUILDSTYLE}"
+	export ZBM_RELEASE_BUILD="${zfsbootmenu_release_build}"
 	EOF
 }
 

--- a/zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -184,8 +184,10 @@ match_hostid() {
     if read_write='' import_pool "${pool}"; then
       zdebug "successfully imported ${pool}"
 
-      zwarn "imported ${pool} with assumed hostid ${hostid}"
-      zwarn "set spl_hostid=${hostid} on ZBM KCL or regenerate with corrected /etc/hostid"
+      if [ -z "${ZBM_RELEASE_BUILD}" ]; then
+        zwarn "imported ${pool} with assumed hostid ${hostid}"
+        zwarn "set spl_hostid=${hostid} on ZBM KCL or regenerate with corrected /etc/hostid"
+      fi
 
       echo "${pool};${hostid}"
       return 0


### PR DESCRIPTION
The default behavior of hostid matching is useful to have on in binary releases. However, it generates a warning message that isn't really relevant for users of that build.

It's expected that the spl_hostid value in ZFSBootMenu.EFI won't match the local pool hostid - advising these users to manually set `spl_hostid` on the ZBM KCL runs counter to how we recommend ZBM should be used.