### PR TITLE
zfsbootmenu-core: run boot environment hooks after environment mount

### DIFF
--- a/zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -290,6 +290,14 @@ kexec_kernel() {
 
   CLEAR_SCREEN=1 load_key "${fs}"
 
+  tput cnorm
+  tput clear
+
+  if ! mnt=$( mount_zfs "${fs}" ); then
+    emergency_shell "unable to mount $( colorize cyan "${fs}" )"
+    return 1
+  fi
+
   # Variables to tell user hooks what BE has been selected
   hook_envs=(
     ZBM_SELECTED_BE="${fs}"
@@ -299,14 +307,6 @@ kexec_kernel() {
 
   # Run boot-environment hooks, if they exist
   env "${hook_envs[@]}" /libexec/zfsbootmenu-run-hooks "boot-sel.d"
-
-  tput cnorm
-  tput clear
-
-  if ! mnt=$( mount_zfs "${fs}" ); then
-    emergency_shell "unable to mount $( colorize cyan "${fs}" )"
-    return 1
-  fi
 
   cli_args="$( load_be_cmdline "${fs}" )"
   root_prefix="$( find_root_prefix "${fs}" "${mnt}" )"


### PR DESCRIPTION
Moving boot environment hooks after environment mount will increase the usefulness of the new `boot-sel.d` hooks.
The hooks will not only be able to interact with the newly mounted environment but also shadow files (like the initramfs) in it using bind mounts, thus allowing techniques like the one described in #432 to be implemented.