### PR TITLE
zfsbootmenu-core: remove SIGINT trap when spawning e-shell

### DIFF
--- a/zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -1896,7 +1896,7 @@ emergency_shell() {
   command -v efibootmgr >/dev/null 2>&1 && mount_efivarfs "rw" 
 
   # -i (interactive) mode will source $HOME/.bashrc
-  /bin/bash -i
+  ( trap - SIGINT; exec /bin/bash -i )
 
   # shellcheck disable=SC2034
   while read -r skip mp fs skip ; do


### PR DESCRIPTION
After emergency_shell() is called, no commands can be interrupted (ctrl-c). 

reproduce:
1) go to e-shell
2) execute `sleep 5`
3) press ctrl-c
4) sleep is not interrupted

fix
untrap SIGINT before launching e-shell