### PR TITLE
zfsbootmenu: rename UI library, normalize imports

### DIFF
--- a/contrib/keycache.sh
+++ b/contrib/keycache.sh
@@ -40,7 +40,7 @@
 ##    If you use different keys, just give them unique paths.)
 
 # shellcheck disable=SC1091
-[ -r /lib/zfsbootmenu-lib.sh ] && . /lib/zfsbootmenu-lib.sh
+[ -r /lib/zfsbootmenu-core.sh ] && . /lib/zfsbootmenu-core.sh
 
 # Make sure key environment variables are defined
 [ -n "${BOOTFS}" ] || exit 0

--- a/zfsbootmenu/bin/zfsbootmenu
+++ b/zfsbootmenu/bin/zfsbootmenu
@@ -6,7 +6,7 @@ sources=(
   /lib/profiling-lib.sh
   /etc/zfsbootmenu.conf
   /lib/zfsbootmenu-core.sh
-  /lib/zfsbootmenu-lib.sh
+  /lib/zfsbootmenu-ui.sh
   /lib/kmsg-log-lib.sh
   /etc/profile
   /lib/fzf-defaults.sh

--- a/zfsbootmenu/bin/zlogtail
+++ b/zfsbootmenu/bin/zlogtail
@@ -1,8 +1,20 @@
 #!/bin/bash
 
 # shellcheck disable=SC1091
-source /lib/zfsbootmenu-lib.sh >/dev/null 2>&1 || exit 1
-source /lib/kmsg-log-lib.sh >/dev/null 2>&1 || exit 1
+sources=(
+  /lib/kmsg-log-lib.sh
+  /lib/zfsbootmenu-ui.sh
+)
+
+for src in "${sources[@]}"; do
+  # shellcheck disable=SC1090
+  if ! source "${src}" >/dev/null 2>&1 ; then
+    echo "<3>ZFSBootMenu: unable to source '${src}' in $0" > /dev/kmsg
+    exit 1
+  fi
+done
+
+unset src sources
 
 [ -f "${BASE}/have_errors" ] && rm "${BASE}/have_errors"
 [ -f "${BASE}/have_warnings" ] && rm "${BASE}/have_warnings"

--- a/zfsbootmenu/bin/zsnapshots
+++ b/zfsbootmenu/bin/zsnapshots
@@ -5,7 +5,7 @@ sources=(
   /etc/zfsbootmenu.conf
   /lib/kmsg-log-lib.sh
   /lib/zfsbootmenu-core.sh
-  /lib/zfsbootmenu-lib.sh
+  /lib/zfsbootmenu-ui.sh
   /lib/fzf-defaults.sh
 )
 
@@ -13,9 +13,11 @@ for src in "${sources[@]}"; do
   # shellcheck disable=SC1090
   if ! source "${src}" >/dev/null 2>&1 ; then
     echo -e "\033[0;31mWARNING: ${src} was not sourced; unable to proceed\033[0m"
-    exit
+    exit 1
   fi
 done
+
+unset src sources
 
 # Replace the global_header function with a stub
 global_header() {

--- a/zfsbootmenu/lib/zfsbootmenu-ui.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-ui.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # vim: softtabstop=2 shiftwidth=2 expandtab
 
-[ -n "${_ZFSBOOTMENU_LIB}" ] && return
-readonly _ZFSBOOTMENU_LIB=1
+[ -n "${_ZFSBOOTMENU_UI}" ] && return
+readonly _ZFSBOOTMENU_UI=1
 
 # shellcheck disable=SC1091
 source /lib/zfsbootmenu-core.sh >/dev/null 2>&1 || exit 1

--- a/zfsbootmenu/libexec/zfsbootmenu-diff
+++ b/zfsbootmenu/libexec/zfsbootmenu-diff
@@ -2,11 +2,23 @@
 # vim: softtabstop=2 shiftwidth=2 expandtab
 
 # shellcheck disable=SC1091
-source /lib/profiling-lib.sh >/dev/null 2>&1 || true
-source /etc/zfsbootmenu.conf >/dev/null 2>&1 || exit 1
-source /lib/kmsg-log-lib.sh >/dev/null 2>&1 || exit 1
-source /lib/zfsbootmenu-core.sh >/dev/null 2>&1 || exit 1
-source /lib/zfsbootmenu-lib.sh >/dev/null 2>&1 || exit 1
+sources=(
+  /lib/profiling-lib.sh
+  /etc/zfsbootmenu.conf
+  /lib/kmsg-log-lib.sh
+  /lib/zfsbootmenu-core.sh
+  /lib/zfsbootmenu-ui.sh
+)
+
+for src in "${sources[@]}"; do
+  # shellcheck disable=SC1090
+  if ! source "${src}" >/dev/null 2>&1 ; then
+    echo "<3>ZFSBootMenu: unable to source '${src}' in $0" > /dev/kmsg
+    exit 1
+  fi
+done
+
+unset src sources
 
 # prevent ctrl-c from killing us, so that zfs diff can exit cleanly
 trap '' SIGINT

--- a/zfsbootmenu/libexec/zfsbootmenu-help
+++ b/zfsbootmenu/libexec/zfsbootmenu-help
@@ -2,11 +2,23 @@
 # vim: softtabstop=2 shiftwidth=2 expandtab
 
 # shellcheck disable=SC1091
-source /lib/profiling-lib.sh >/dev/null 2>&1
-source /etc/zfsbootmenu.conf 2>&1 || exit 1
-source /lib/kmsg-log-lib.sh >/dev/null 2>&1 || exit 1
-source /lib/zfsbootmenu-core.sh >/dev/null 2>&1 || exit 1
-source /lib/zfsbootmenu-lib.sh >/dev/null 2>&1 || exit 1
+sources=(
+  /lib/profiling-lib.sh
+  /etc/zfsbootmenu.conf
+  /lib/kmsg-log-lib.sh
+  /lib/zfsbootmenu-core.sh
+  /lib/zfsbootmenu-ui.sh
+)
+
+for src in "${sources[@]}"; do
+  # shellcheck disable=SC1090
+  if ! source "${src}" >/dev/null 2>&1 ; then
+    echo "<3>ZFSBootMenu: unable to source '${src}' in $0" > /dev/kmsg
+    exit
+  fi
+done
+
+unset src sources
 
 # zfsbootmenu-help invokes itself, so the value of $WIDTH depends
 # on if $0 is launching fzf (-L) or is being launched inside

--- a/zfsbootmenu/libexec/zfunc
+++ b/zfsbootmenu/libexec/zfunc
@@ -2,11 +2,23 @@
 # vim: softtabstop=2 shiftwidth=2 expandtab
 
 # shellcheck disable=SC1091
-source /lib/profiling-lib.sh >/dev/null 2>&1
-source /etc/zfsbootmenu.conf 2>&1 || exit 1
-source /lib/kmsg-log-lib.sh >/dev/null 2>&1 || exit 1
-source /lib/zfsbootmenu-lib.sh >/dev/null 2>&1 || exit 1
-source /lib/zfsbootmenu-core.sh >/dev/null 2>&1 || exit 1
+sources=(
+  /lib/profiling-lib.sh
+  /etc/zfsbootmenu.conf
+  /lib/kmsg-log-lib.sh
+  /lib/zfsbootmenu-core.sh
+  /lib/zfsbootmenu-ui.sh
+)
+
+for src in "${sources[@]}"; do
+  # shellcheck disable=SC1090
+  if ! source "${src}" >/dev/null 2>&1 ; then
+    echo "<3>ZFSBootMenu: unable to source '${src}' in $0" > /dev/kmsg
+    exit 1
+  fi
+done
+
+unset src sources
 
 # First argument is the function name
 # the rest are positional params


### PR DESCRIPTION
Rename zfsbootmenu-lib to zfsbootmenu-ui-lib to more accurately represent which functions are contained therein.

Additionally, normalize how libraries are sourced.