### PR TITLE
docs(typo): paramters -> paremeters

### DIFF
--- a/docs/man/zfsbootmenu.7.rst
+++ b/docs/man/zfsbootmenu.7.rst
@@ -65,7 +65,7 @@ These options are set on the kernel command line when booting the initramfs or U
 
     .. code-block::
 
-      echo 0 > /sys/module/spl/paramters/spl_hostid
+      echo 0 > /sys/module/spl/parameters/spl_hostid
 
 **zbm.sort_key**
 

--- a/zfsbootmenu/help-files/132/zfsbootmenu.7.ansi
+++ b/zfsbootmenu/help-files/132/zfsbootmenu.7.ansi
@@ -81,7 +81,7 @@
         Setting [33mspl.spl_hostid[0m to a non-zero value on the kernel commandline will make the ZFS kernel modules [1mignore[0m any value set
         in [33m/etc/hostid[0m. To restore standard ZFS behavior on a running system, execute
 
-        echo 0 > /sys/module/spl/paramters/spl_hostid
+        echo 0 > /sys/module/spl/parameters/spl_hostid
 
     [1mzbm.sort_key[0m
 

--- a/zfsbootmenu/help-files/52/zfsbootmenu.7.ansi
+++ b/zfsbootmenu/help-files/52/zfsbootmenu.7.ansi
@@ -143,7 +143,7 @@
         standard ZFS behavior on a running
         system, execute
 
-        echo 0 > /sys/module/spl/paramters/spl_hostid
+        echo 0 > /sys/module/spl/parameters/spl_hostid
 
     [1mzbm.sort_key[0m
 

--- a/zfsbootmenu/help-files/92/zfsbootmenu.7.ansi
+++ b/zfsbootmenu/help-files/92/zfsbootmenu.7.ansi
@@ -95,7 +95,7 @@
         ZFS kernel modules [1mignore[0m any value set in [33m/etc/hostid[0m. To restore standard
         ZFS behavior on a running system, execute
 
-        echo 0 > /sys/module/spl/paramters/spl_hostid
+        echo 0 > /sys/module/spl/parameters/spl_hostid
 
     [1mzbm.sort_key[0m
 


### PR DESCRIPTION
Typo: paramters -> parameters
`docs/man/zfsbootmenu.7.rst`

Regenerate:
`zfsbootmenu/help-files/132/zfsbootmenu.7.ansi`
`zfsbootmenu/help-files/52/zfsbootmenu.7.ansi`
`zfsbootmenu/help-files/92/zfsbootmenu.7.ansi`