### PR TITLE
.gitattributes: treat help files and manpages as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+zfsbootmenu/help-files/** linguist-generated=true
+docs/man/dist/** linguist-generated=true


### PR DESCRIPTION
this prevents them from showing in Github diffs by default

https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github

![image](https://github.com/zbm-dev/zfsbootmenu/assets/5366828/7cc19d89-ae5e-4853-aa90-7f8b86a69c4b)
