### PR TITLE
examples: modernize, install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ core:
 	install -m 0644 -t "$(DESTDIR)$(MANDIR)/man5" -D docs/man/dist/man5/*.5
 	install -m 0644 -t "$(DESTDIR)$(MANDIR)/man7" -D docs/man/dist/man7/*.7
 	install -m 0644 -t "$(DESTDIR)$(MANDIR)/man8" -D docs/man/dist/man8/*.8
-	install -m 0755 -t "$(DESTDIR)$(EXAMPLES)" -D contrib/*
+	install -m 0755 -t "$(DESTDIR)$(EXAMPLES)/hooks" -D contrib/*
+	install -m 0755 -t "$(DESTDIR)$(EXAMPLES)" -D examples/*
 
 dracut:
 	./install-tree.sh dracut "$(DESTDIR)$(DRACUTDIR)/90zfsbootmenu"

--- a/examples/kboot.conf
+++ b/examples/kboot.conf
@@ -1,1 +1,0 @@
-ZFSBootMenu-0.7.6='/boot/vmlinux-0.7.6 initrd=/boot/initramfs-0.7.6.img root=zfsbootmenu:POOL=zroot spl_hostid=68f7287a quiet loglevel=0 ro rd.driver.blacklist=usbcore rd.driver.blacklist=xhci_hcd rd.driver.blacklist=xhci_pci amdgpu.dc=1 radeon.cik_support=0 amdgpu.cik_support=1 amdgpu.dpm=1'

--- a/examples/syslinux.cfg
+++ b/examples/syslinux.cfg
@@ -1,7 +1,20 @@
-DEFAULT ZFSBootMenu-0.7.6
+UI menu.c32
+PROMPT 0
 
-LABEL ZFSBootMenu-0.7.6
-KERNEL /vmlinux-0.7.6
-INITRD /initramfs-0.7.6.img
-APPEND root=zfsbootmenu:POOL=zroot spl_hostid=68f7287a quiet loglevel=0 ro rd.driver.blacklist=usbcore rd.driver.blacklist=xhci_hcd rd.driver.blacklist=xhci_pci amdgpu.dc=1 radeon.cik_support=0 amdgpu.cik_support=1 amdgpu.dpm=1
+MENU TITLE ZFSBootMenu
+TIMEOUT 50
 
+DEFAULT zfsbootmenu
+
+LABEL zfsbootmenu
+  MENU LABEL ZFSBootMenu
+  KERNEL /zfsbootmenu/vmlinuz-bootmenu
+  INITRD /zfsbootmenu/initramfs-bootmenu.img
+  APPEND zfsbootmenu quiet loglevel=0
+
+LABEL zfsbootmenu-backup
+  MENU LABEL ZFSBootMenu (Backup)
+  KERNEL /zfsbootmenu/vmlinuz-bootmenu-backup
+  INITRD /zfsbootmenu/initramfs-bootmenu-backup.img
+  APPEND zfsbootmenu quiet loglevel=0
+EOF


### PR DESCRIPTION
Remove kboot.conf, this was primarily used when POWER9/petitboot was still being targeted. Update syslinux.cfg to demonstrate how to boot fixed name files. Install examples/ via Makefile.