### PR TITLE
zfsbootmenu-core: disable block cloning for R/W pools

### DIFF
--- a/zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -1433,6 +1433,11 @@ set_rw_pool() {
   fi
   zdebug "pool set to ${pool}"
 
+  if [ -w /sys/module/zfs/parameters/zfs_bclone_enabled ] ; then
+    zdebug "disabling block cloning on writeable pools"
+    echo 0 > /sys/module/zfs/parameters/zfs_bclone_enabled
+  fi
+
   # If force_export is set, skip evaluating if the pool is already read-write
   # shellcheck disable=SC2154
   [ -n "${force_export}" ] || ! is_writable "${pool}" || return 0


### PR DESCRIPTION
Block cloning in ZFS 2.2.0 is dangerous. Until it stabilizes, we should disable it if the tuneable to do so is available when a pool is set read/write.

See https://github.com/openzfs/zfs/pull/15529 for more details.

I don't think we need to expose this as a toggleable option. This feature should be simple and not plumbed very deeply, on the hope that it's just a short-term patch for an unlikely source of problems for people. If users really care, they can turn it back on before doing whatever it is they're going to do in the recovery shell. 