### PR TITLE
zfsbootmenu-core: disable zfs_dmu_offset_next_sync for R/W pools

### DIFF
--- a/zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -1438,6 +1438,11 @@ set_rw_pool() {
     echo 0 > /sys/module/zfs/parameters/zfs_bclone_enabled
   fi
 
+  if [ -w /sys/module/zfs/parameters/zfs_dmu_offset_next_sync ] ; then
+    zdebug "disabling zfs_dmu_offset_next_sync on writeable pools"
+    echo 0 > /sys/module/zfs/parameters/zfs_dmu_offset_next_sync
+  fi
+
   # If force_export is set, skip evaluating if the pool is already read-write
   # shellcheck disable=SC2154
   [ -n "${force_export}" ] || ! is_writable "${pool}" || return 0


### PR DESCRIPTION
this currently appears to mostly or fully mitigate the silent corruption bug that was originally thought to be caused by block cloning. Keeping bclone disabled for now as it is a common avenue for triggering the bug, despite not being the root cause.

see openzfs/zfs#15526
