### PR TITLE
Use zbm-release file, add some color to zreport

### DIFF
--- a/zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -1924,20 +1924,43 @@ emergency_shell() {
 # returns: nothing
 
 zreport() {
-  local ZBMTAG
-  if [ -r "/etc/zbm-commit-hash" ]; then
-    read -r ZBMTAG < /etc/zbm-commit-hash
-    echo -e "ZFSBootMenu version: ${ZBMTAG}\n"
-  fi
-  uname -a
-  echo -e "\n# modinfo"
+  colorize white "System Report\n\n"
+
+  (
+    VERSION="unknown"
+    PRETTY_NAME="ZFSBootMenu"
+    UNAME="$( uname -srm )"
+
+    # shellcheck disable=SC1091
+    [ -f /etc/zbm-release ] && source /etc/zbm-release
+
+    if [[ "${VERSION}" =~ dev$ ]]; then
+      VERSION="$( colorize red "${VERSION}" )"
+    else
+      VERSION="$( colorize green "${VERSION}" )"
+    fi
+
+    if [[ "${PRETTY_NAME}" == "ZFSBootMenu" ]]; then
+      PRETTY_NAME="$( colorize orange ZFS )$( colorize lightgray BootMenu )"
+    fi
+
+    echo -e "${PRETTY_NAME} ${VERSION} (${UNAME})"
+  )
+
+  colorize orange "\n>> ZFSBootMenu commandline\n"
+  get_zbm_kcl | kcl_assemble
+
+  colorize orange "\n\n>> ZFS/SPL module information\n"
   echo "$( modinfo -F filename spl ): $( modinfo -F version spl )"
   echo "$( modinfo -F filename zfs ): $( modinfo -F version zfs )"
-  echo -e "\n# zfs version"
+
+  colorize orange "\n>> ZFS version\n"
   zfs version
-  echo -e "\n# zpool list"
+
+  colorize orange "\n>> Imported zpools\n"
   zpool list
-  echo -e "\n# zfs list"
+
+  colorize orange "\n>> ZFS datasets\n"
   zfs list -o name,mountpoint,encroot,keystatus,keylocation,org.zfsbootmenu:keysource
 }
 

--- a/zfsbootmenu/libexec/zfsbootmenu-help
+++ b/zfsbootmenu/libexec/zfsbootmenu-help
@@ -80,6 +80,7 @@ fi
 for doc in "${doc_path}"/* ; do
   SECTIONS+=( "${doc} $( head -1 "${doc}" )" )
 done
+SECTIONS+=( "zreport $( colorize white 'System Report' )" )
 
 while getopts "lL:s:" opt; do
   case "${opt}" in
@@ -92,7 +93,11 @@ while getopts "lL:s:" opt; do
       exit
       ;;
     s)
-      cat "${OPTARG}"
+      if [ "${OPTARG}" == "zreport" ]; then
+        /libexec/zfunc zreport
+      else
+        cat "${OPTARG}"
+      fi
       exit
       ;;
     ?)


### PR DESCRIPTION
What it says on the tin. Make the system report easier to access, add some color/spice to the output. Since everything is generated live, there's no "clean" line wrapping. The fzf preview window does at least wrap long lines, however.