### PR TITLE
docs/guides/third-party: remove install scripts

### DIFF
--- a/docs/guides/third-party.rst
+++ b/docs/guides/third-party.rst
@@ -5,24 +5,12 @@ The `ZFSBootMenu Wiki <https://github.com/zbm-dev/zfsbootmenu/wiki>`_ hosts seve
 
 The following links are not hosted by ZFSBootMenu, but may provide useful information.
 
-Void Linux
-----------
-
-* `Void Linux ZFSBootMenu install scripts <https://github.com/eoli3n/void-config/tree/master/scripts/install>`_
-
-Ubuntu
-------
-
-* `Ubuntu server ZFSBootMenu install script <https://github.com/edifus/ubuntu-server-zfsbootmenu>`_
-* `Ubuntu ZFSBootMenu install script - desktop and server <https://github.com/Sithuk/ubuntu-server-zfsbootmenu>`_
-
 Arch Linux
 ----------
 
 * `Arch Wiki: Using ZFSBootMenu for UEFI <https://wiki.archlinux.org/title/Install_Arch_Linux_on_ZFS#Using_ZFSBootMenu_for_UEFI>`_
 * `Arch User Repository: ZFSBootMenu <https://aur.archlinux.org/packages/zfsbootmenu>`_
 * `Arch User Repository: ZFSBootMenu EFI binaries <https://aur.archlinux.org/packages/zfsbootmenu-efi-bin>`_
-* `Arch Linux ZFSBootMenu install scripts <https://github.com/eoli3n/arch-config/tree/master/scripts/zfs/install>`_
 
 Gentoo
 ------


### PR DESCRIPTION
Install scripts are liable to become outdated w/r/t our recommended practices, especially when they aren't written by us and the author lets them sit.

It's not hard to install ZBM from a guide, and users can create their own script based on those guides by just copying/adapting the codeblocks.

Not much is lost from removing these, as Void and Ubuntu have official install guides, and Arch has proper documentation linked on the Arch wiki.
