### PR TITLE
zfsbootmenu-core: show enabled/disabled hooks in zreport

### DIFF
--- a/zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -1924,6 +1924,8 @@ emergency_shell() {
 # returns: nothing
 
 zreport() {
+  local hook
+
   colorize white "System Report\n\n"
 
   (
@@ -1948,9 +1950,21 @@ zreport() {
   )
 
   colorize orange "\n>> ZFSBootMenu commandline\n"
-  get_zbm_kcl | kcl_assemble
+  get_zbm_kcl | kcl_assemble ; echo
 
-  colorize orange "\n\n>> ZFS/SPL module information\n"
+  colorize orange "\n>> Enabled hooks\n"
+  for hook in /libexec/hooks/*.d/*; do
+    [ -x "${hook}" ] && echo "* $( colorize green "${hook}")"
+  done
+
+  colorize orange "\n>> Disabled hooks\n"
+  for hook in /libexec/hooks/*.d/*; do
+    [ -f "${hook}" ] || continue
+    [ -x "${hook}" ] && continue
+    echo "* $( colorize red "${hook}")"
+  done
+
+  colorize orange "\n>> ZFS/SPL module information\n"
   echo "$( modinfo -F filename spl ): $( modinfo -F version spl )"
   echo "$( modinfo -F filename zfs ): $( modinfo -F version zfs )"
 


### PR DESCRIPTION
I realized tonight that the hooks in the pre-built initramfs might not be very discoverable. Showing them in zreport (now exposed in the Help system) might improve that a bit.

![Screenshot_20231205_220800](https://github.com/zbm-dev/zfsbootmenu/assets/13874853/63467c0e-0e0a-4bd5-b551-83e5e5cb1efd)
