### PR TITLE
recovery shell: ESP mount helper and tab completion

### DIFF
--- a/docs/online/recovery-shell.rst
+++ b/docs/online/recovery-shell.rst
@@ -40,6 +40,10 @@ Common Commands
 
   Mount the filesystem at a unique location and print the mount point.
 
+**mount_esp** *device*
+
+  Mount an EFI System Partition at a unique location and print the mount point.
+
 **mount_efivarfs** *mode*
 
   Mount or remount *efivarfs* as read-write or read-only.

--- a/etc/zfsbootmenu/release.conf.d/common.conf
+++ b/etc/zfsbootmenu/release.conf.d/common.conf
@@ -5,6 +5,9 @@ install_optional_items+=" /etc/zbm-commit-hash "
 
 omit_dracutmodules+=" crypt-ssh nfs lunmask "
 
+# kernel modules to allow mounting an ESP
+add_drivers+=" fat vfat nls_iso8859_1 nls_cp437 "
+
 # qemu drivers
 omit_dracutmodules+=" qemu "
 

--- a/zfsbootmenu/bin/mount_esp
+++ b/zfsbootmenu/bin/mount_esp
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# shellcheck disable=SC1091
+sources=(
+  /lib/kmsg-log-lib.sh
+  /lib/zfsbootmenu-core.sh
+)
+
+for src in "${sources[@]}"; do
+  # shellcheck disable=SC1090
+  if ! source "${src}" >/dev/null 2>&1 ; then
+    echo "<3>ZFSBootMenu: unable to source '${src}' in $0" > /dev/kmsg
+    exit 1
+  fi
+done
+
+unset src sources
+
+mount_block "${1}"

--- a/zfsbootmenu/help-files/132/recovery-shell.ansi
+++ b/zfsbootmenu/help-files/132/recovery-shell.ansi
@@ -40,6 +40,10 @@
 
     Mount the filesystem at a unique location and print the mount point.
 
+  [1mmount_esp[0m [33mdevice[0m
+
+    Mount an EFI System Partition at a unique location and print the mount point.
+
   [1mmount_efivarfs[0m [33mmode[0m
 
     Mount or remount [33mefivarfs[0m as read-write or read-only.

--- a/zfsbootmenu/help-files/52/recovery-shell.ansi
+++ b/zfsbootmenu/help-files/52/recovery-shell.ansi
@@ -50,6 +50,11 @@
     Mount the filesystem at a unique location and
     print the mount point.
 
+  [1mmount_esp[0m [33mdevice[0m
+
+    Mount an EFI System Partition at a unique
+    location and print the mount point.
+
   [1mmount_efivarfs[0m [33mmode[0m
 
     Mount or remount [33mefivarfs[0m as read-write or

--- a/zfsbootmenu/help-files/92/recovery-shell.ansi
+++ b/zfsbootmenu/help-files/92/recovery-shell.ansi
@@ -41,6 +41,10 @@
 
     Mount the filesystem at a unique location and print the mount point.
 
+  [1mmount_esp[0m [33mdevice[0m
+
+    Mount an EFI System Partition at a unique location and print the mount point.
+
   [1mmount_efivarfs[0m [33mmode[0m
 
     Mount or remount [33mefivarfs[0m as read-write or read-only.

--- a/zfsbootmenu/install-helpers.sh
+++ b/zfsbootmenu/install-helpers.sh
@@ -69,6 +69,10 @@ zfsbootmenu_essential_modules=(
 zfsbootmenu_optional_modules=(
   "zlib_deflate"
   "zlib_inflate"
+  "fat"
+  "vfat"
+  "nls_iso8859_1"
+  "nls_cp437"
 )
 
 create_zbm_conf() {

--- a/zfsbootmenu/lib/zfsbootmenu-completions.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-completions.sh
@@ -71,6 +71,23 @@ _mount_zfs() {
 }
 complete -F _mount_zfs mount_zfs
 
+_mount_esp() {
+  local ESP dev uuid
+  COMPREPLY=()
+
+  [ "${#COMP_WORDS[@]}" != "2" ] && return
+  
+  while IFS=' ' read -r dev uuid; do
+    # magic uuid for an ESP
+    [ "${uuid,,}" == "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" ] || continue
+    is_mounted "${dev}" >/dev/null 2>&1 || ESP+=( "${dev}" )
+  done <<<"$( lsblk -ln -o PATH,PARTTYPE )"
+
+  COMPREPLY=( $( compgen -W "${ESP[*]}" -- "${COMP_WORDS[1]}" ) )
+}
+  
+complete -F _mount_esp mount_esp
+
 _zsnapshots() {
   local ZFS
   COMPREPLY=()


### PR DESCRIPTION
Add a `mount_esp` function that mounts `/dev/sdxY` at `/mnt/sdxY` if nothing else is mounted there. If the device is already mounted, return the mountpoint. The shell completion helper only completes unmounted ESP devices.

Unmounting the device is left as an exercise to the user.  I'm interested in a reasonable argument for handling this when exiting the recovery shell, like we do for ZFS datasets.

The mount operation is possibly going to be a problem. I'm trapping errors and dumping them to the console, but that's not super graceful.

Edit:

Thinking about this more, I should log all errors via `zerror` and then add something to the recovery shell prompt that evaluates if `has_errors` is set - if it is, dump the errors to the console and then clear the flag. This lets internal functions still Do The Right Thing if they're called by a program, but still have a mechanism for exposing their error text to a human operator if needed.