### PR TITLE
recovery shell: print zerrors since the last command was executed

### DIFF
--- a/zfsbootmenu/bin/logs
+++ b/zfsbootmenu/bin/logs
@@ -1,0 +1,1 @@
+zlogtail

--- a/zfsbootmenu/install-helpers.sh
+++ b/zfsbootmenu/install-helpers.sh
@@ -155,7 +155,8 @@ create_zbm_profiles() {
 	[ -f /etc/profile ] && source /etc/profile
 	[ -f /lib/zfsbootmenu-completions.sh ] && source /lib/zfsbootmenu-completions.sh
 
-	export PS1="\[\033[0;33m\]zfsbootmenu\[\033[0m\] \w > "
+	export PROMPT_COMMAND="/libexec/recovery-error-printer"
+	export PS1='\[\033[0;33m\]zfsbootmenu\[\033[0m\] \w > '
 
 	alias clear="tput clear"
 	alias reset="tput reset"

--- a/zfsbootmenu/libexec/recovery-error-printer
+++ b/zfsbootmenu/libexec/recovery-error-printer
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+PROMPT_TS_FILE="${BASE}/.errors_since"
+
+[ -f "${PROMPT_TS_FILE}" ] && read -r prompt_ts < "${PROMPT_TS_FILE}"
+
+# shellcheck disable=SC1091
+source /lib/kmsg-log-lib.sh || exit 0
+
+if [ -f "${BASE}/have_errors" ]; then 
+  echo
+  print_kmsg_logs "err" ${prompt_ts:+${prompt_ts}}
+  echo
+  rm "/zfsbootmenu/have_errors" 
+fi
+
+printf '%(%Y-%m-%dT%H:%M:%S)T' > "${PROMPT_TS_FILE}"


### PR DESCRIPTION
I'm not super happy with how `print_kmsg_logs` is shaking out, but there's only so much time I'm willing to spend chasing elegance.

This is modestly tested, and could likely use further refinement after people play with it.