### PR TITLE
zfsbootmenu: add zbm.waitfor argument handler

### DIFF
--- a/docs/man/zfsbootmenu.7.rst
+++ b/docs/man/zfsbootmenu.7.rst
@@ -143,6 +143,14 @@ These options are set on the kernel command line when booting the initramfs or U
 
   Enable automatic font resizing of the kernel console to normalize the apparent resolution for both low resolution and high resolution displays. This option is enabled by default.
 
+**zbm.waitfor=device,device,...**
+
+  Ensure that one or more devices are present before starting the pool import process. Devices may be specified as full paths to device nodes (*e.g.*, **/dev/sda** or **/dev/disk/by-id/wwn-0x500a07510ee65912**) or, for convenience, as a typed indicator of the form **TYPE=VALUE**, which will be expanded internally as
+  
+    **/dev/disk/by-TYPE/VALUE**
+
+  The use of full device paths other than descendants of **/dev/disk/** is fragile and should be avoided.
+
 Deprecated Parameters
 ---------------------
 

--- a/zfsbootmenu/libexec/zfsbootmenu-init
+++ b/zfsbootmenu/libexec/zfsbootmenu-init
@@ -78,6 +78,60 @@ elif [ ! -e /etc/hostid ]; then
   write_hostid "${default_hostid}"
 fi
 
+# Wait for devices to show up
+
+if [ -n "${zbm_waitfor_devices}" ]; then
+  IFS=',' read -r -a user_devices <<<"${zbm_waitfor_devices}"
+  while true; do
+    FOUND=0
+    EXPECTED=0
+    missing=()
+
+    for device in "${user_devices[@]}"; do
+      case "${device}" in
+        /dev/*)
+          ((EXPECTED=EXPECTED+1))
+          if [ -e "${device}" ] ; then
+           ((FOUND=FOUND+1))
+          else
+            missing+=( "$device" )
+          fi
+          ;;
+        *=*)
+          ((EXPECTED=EXPECTED+1))
+          path_prefix="/dev/disk/by-${device%=*}"
+          checkfor="${path_prefix,,}/${device##*=}"
+          if [ -e "${checkfor}" ] ; then
+            ((FOUND=FOUND+1))
+          else
+            missing+=( "$device" )
+          fi
+          ;;
+        *)
+          zerror "malformed device: '${device}'"
+          ;;
+      esac
+    done
+
+    if [ ${FOUND} -eq ${EXPECTED} ]; then
+      break
+    else
+      if ! timed_prompt -d 3 -e "to cancel" \
+          -m "" \
+          -m "$( colorize red "One or more required devices are missing" )" \
+          -p "retrying in $( colorize yellow "%0.2d" ) seconds" ; then
+        for dev in "${missing[@]}" ; do
+          zerror "required device '${dev}' not found"
+        done
+
+        break
+      fi
+    fi
+  done
+
+  unset FOUND EXPECTED device path_prefix checkfor
+fi
+
 # Import ZBM hooks from an external root, if they exist
 if [ -n "${zbm_hook_root}" ]; then
   import_zbm_hooks "${zbm_hook_root}"

--- a/zfsbootmenu/pre-init/zfsbootmenu-parse-commandline.sh
+++ b/zfsbootmenu/pre-init/zfsbootmenu-parse-commandline.sh
@@ -226,6 +226,11 @@ if zbm_prefer_pool=$( get_zbm_arg zbm.prefer ) ; then
   zinfo "preferring ${zbm_prefer_pool} for bootfs"
 fi
 
+zbm_waitfor_devices=
+if zbm_waitfor_devices=$( get_zbm_arg zbm.waitfor ) ; then
+  zinfo "system will wait for ${zbm_waitfor_devices}"
+fi
+
 # pool! : this pool must be imported before all others
 # pool!!: this pool, and no others, must be imported
 

--- a/zfsbootmenu/pre-init/zfsbootmenu-preinit.sh
+++ b/zfsbootmenu/pre-init/zfsbootmenu-preinit.sh
@@ -33,6 +33,7 @@ export zbm_sort='${zbm_sort}'
 export zbm_set_hostid='${zbm_set_hostid}'
 export zbm_import_delay='${zbm_import_delay}'
 export zbm_hook_root='${zbm_hook_root}'
+export zbm_waitfor_devices='${zbm_waitfor_devices}'
 export control_term='${control_term}'
 # END additions by zfsbootmenu-preinit.sh
 EOF


### PR DESCRIPTION
With keyfiles being stored on USB drives, the boot process can be non-deterministic due to intermittently missing /dev entries. Users can now provide one or more devices that must be present before the pool import process can start. Unlike dracut, you can simply hit the escape key to cancel this check.