### PR TITLE
releng/make-binary.sh: specify release tag in builder images by default

### DIFF
--- a/releng/make-binary.sh
+++ b/releng/make-binary.sh
@@ -26,11 +26,7 @@ esac
 
 buildtag="${2:-ghcr.io/zbm-dev/zbm-builder:$(date '+%Y%m%d')}"
 if ! podman inspect "${buildtag}" >/dev/null 2>&1; then
-  build_args=( "${buildtag}" )
-
-  if [ -n "${ZBM_COMMIT_HASH}" ]; then
-    build_args+=( "${ZBM_COMMIT_HASH}" )
-  fi
+  build_args=( "${buildtag}" "${ZBM_COMMIT_HASH:-"v${release}"}" )
 
   if ! ./releng/docker/image-build.sh "${build_args[@]}"; then
     error "failed to create builder image"


### PR DESCRIPTION
Needs testing and backporting to v2.3.x before another release is tagged, but this ensures that we create images during releng that will build the release that is being tagged.