### PR TITLE
docs/guides/chimera/: initial Chimera guide

### DIFF
--- a/docs/guides/chimera.rst
+++ b/docs/guides/chimera.rst
@@ -1,0 +1,7 @@
+Chimera Linux
+=============
+
+.. toctree::
+  :titlesonly:
+
+  chimera/uefi

--- a/docs/guides/chimera/_include/cleanup.rst
+++ b/docs/guides/chimera/_include/cleanup.rst
@@ -1,0 +1,21 @@
+Prepare for first boot
+----------------------
+
+Exit the chroot, unmount everything
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  exit
+
+.. code-block::
+
+  umount -n -R /mnt
+
+Export the zpool and reboot
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  zpool export zroot
+  reboot

--- a/docs/guides/chimera/_include/commandline.rst
+++ b/docs/guides/chimera/_include/commandline.rst
@@ -1,0 +1,3 @@
+.. code-block::
+
+   zfs set org.zfsbootmenu:commandline="quiet loglevel=4" zroot/ROOT

--- a/docs/guides/chimera/_include/distro-install.rst
+++ b/docs/guides/chimera/_include/distro-install.rst
@@ -1,0 +1,39 @@
+Install Chimera 
+---------------
+
+.. code-block::
+
+  chimera-bootstrap /mnt
+
+Copy our files into the new install
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+  .. group-tab:: Unencrypted
+
+    .. code-block::
+
+      cp /etc/hostid /mnt/etc
+
+  .. group-tab:: Encrypted
+
+    .. code-block::
+
+      cp /etc/hostid /mnt/etc
+      mkdir /mnt/etc/zfs
+      cp /etc/zfs/zroot.key /mnt/etc/zfs
+
+Chroot into the new OS
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  chimera-chroot /mnt
+
+Set a root password
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  passwd

--- a/docs/guides/chimera/_include/efi-boot-check.rst
+++ b/docs/guides/chimera/_include/efi-boot-check.rst
@@ -1,0 +1,6 @@
+Confirm EFI support:
+
+.. parsed-literal::
+
+  # **mount | grep -i efivarfs**
+  efivarfs on /sys/firmware/efi/efivars type efivarfs (rw,nosuid,nodev,noexec,relatime)

--- a/docs/guides/chimera/_include/efi-boot-method.rst
+++ b/docs/guides/chimera/_include/efi-boot-method.rst
@@ -1,0 +1,14 @@
+Configure EFI boot entries
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+  .. group-tab:: Direct
+
+    .. code-block:: bash
+
+        apk add --no-interactive efibootmgr
+
+    .. include:: ../_include/configure-efibootmgr.rst
+  
+.. include:: ../_include/efi-seealso.rst

--- a/docs/guides/chimera/_include/live-environment.rst
+++ b/docs/guides/chimera/_include/live-environment.rst
@@ -1,0 +1,35 @@
+Configure Live Environment
+--------------------------
+
+Switch to a root account
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  doas -s
+
+.. note::
+
+   The default password for the ``root`` account is ``chimera``.
+
+.. include:: _include/os-release.rst
+
+Update package repositories
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  apk add --no-interactive chimera-repo-contrib chimera-repo-user
+  apk update
+
+Setup additional tools 
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  apk add --no-interactive gptfdisk
+
+.. include:: ../_include/zgenhostid.rst
+
+..
+  vim: softtabstop=2 shiftwidth=2 textwidth=120

--- a/docs/guides/chimera/_include/os-release.rst
+++ b/docs/guides/chimera/_include/os-release.rst
@@ -1,0 +1,13 @@
+Source ``/etc/os-release``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The file `/etc/os-release` defines variables that describe the running distribution. In particular, the `$ID` variable
+defined within can be used as a short name for the filesystem that will hold this installation.
+
+.. code-block::
+
+  . /etc/os-release
+  export ID
+
+..
+  vim: softtabstop=2 shiftwidth=2 textwidth=120

--- a/docs/guides/chimera/_include/post-installation.rst
+++ b/docs/guides/chimera/_include/post-installation.rst
@@ -1,0 +1,4 @@
+Post-installation steps
+-----------------------
+
+Refer to the `Chimera Post-installation guide <https://chimera-linux.org/docs/configuration/post-installation>`_ to finish configuring your system. Return to this guide once you've completed those steps.

--- a/docs/guides/chimera/_include/zbm-install.rst
+++ b/docs/guides/chimera/_include/zbm-install.rst
@@ -1,0 +1,12 @@
+Install ZFSBootMenu
+~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+  .. group-tab:: Prebuilt
+
+    .. code-block:: bash
+
+      apk add --no-interactive curl
+
+    .. include:: ../_include/zbm-install-prebuilt.rst

--- a/docs/guides/chimera/_include/zfs-config.rst
+++ b/docs/guides/chimera/_include/zfs-config.rst
@@ -1,0 +1,44 @@
+ZFS Configuration
+-----------------
+
+Install ZFS and kernel
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  apk add --no-interactive linux-lts-zfs-bin
+
+Configure initramfs-tools
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+  .. group-tab:: Unencrypted
+
+    .. code-block::
+
+      No required steps
+
+  .. group-tab:: Encrypted
+
+    .. code-block::
+
+      cat << 'EOF' > /usr/share/initramfs-tools/hooks/zfsencryption
+      if [ "$1" = "prereqs" ]; then
+        exit 0
+      fi
+
+      . /usr/share/initramfs-tools/hook-functions
+
+      [ -d "${DESTDIR}/etc/zfs" ] || mkdir "${DESTDIR}/etc/zfs"
+
+      for keyfile in /etc/zfs/*.key; do
+        [ -e "${keyfile}" ] || continue
+        cp "${keyfile}" "${DESTDIR}/etc/zfs/"
+      done
+      EOF
+
+      chmod +x /usr/share/initramfs-tools/hooks/zfsencryption
+      echo "UMASK=0077" > /etc/initramfs-tools/conf.d/umask.conf
+  
+      update-initramfs -c -k all

--- a/docs/guides/chimera/uefi.rst
+++ b/docs/guides/chimera/uefi.rst
@@ -1,0 +1,49 @@
+UEFI
+====
+
+.. |distribution| replace:: Chimera
+
+.. contents:: Contents
+  :depth: 2
+  :local:
+  :backlinks: none
+
+This guide can be used to install Chimera onto a single disk with with or without ZFS encryption. 
+
+It assumes the following:
+
+* Your system uses UEFI to boot
+* Your system is x86_64
+* You're mildly comfortable with ZFS, EFI and discovering system facts on your own (``lsblk``, ``dmesg``, ``gdisk``,
+  ...)
+
+Download the latest `Chimera Live Gnome ISO <https://repo.chimera-linux.org/live/latest/>`_, write it to USB drive and boot your
+system in EFI mode.
+
+.. include:: _include/efi-boot-check.rst
+
+.. include:: _include/live-environment.rst
+
+.. include:: ../_include/define-env.rst
+
+.. include:: ../_include/disk-preparation.rst
+
+.. include:: ../_include/pool-creation.rst
+
+.. include:: ../_include/create-filesystems.rst
+
+.. include:: _include/distro-install.rst
+
+.. include:: _include/zfs-config.rst
+
+.. include:: ../_include/zbm-setup.rst
+
+.. include:: ../_include/setup-esp.rst
+
+.. include:: _include/zbm-install.rst
+
+.. include:: _include/efi-boot-method.rst
+
+.. include:: _include/post-installation.rst
+
+.. include:: _include/cleanup.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,10 +66,11 @@
 
   guides/void-linux
   guides/alpine
+  guides/chimera
   guides/debian
-  guides/ubuntu
   guides/fedora
   guides/opensuse
+  guides/ubuntu
   guides/third-party
 
 .. toctree::


### PR DESCRIPTION
What it says on the tin. A basic root-on-ZFS for Chimera, using an LTS kernel and a prebuilt release asset.  There's no `initramfs-tools` hook to copy key files into an initramfs, so the one used in the `testing/` framework was dropped in.

Both the unencrypted / encrypted choose your own adventure were followed via copy-pasting into a terminal. In both cases, I was able to boot the system.