### PR TITLE
Fix ZFSBootMenu initialization with systemd

### DIFF
--- a/zfsbootmenu/pre-init/zfsbootmenu-parse-commandline.sh
+++ b/zfsbootmenu/pre-init/zfsbootmenu-parse-commandline.sh
@@ -79,6 +79,9 @@ else
   zinfo "defaulting controlling terminal to: ${control_term}"
 fi
 
+# Make sure control_term is available for zfsbootmenu-preinit.sh
+export control_term
+
 # hostid - discover the hostid used to import a pool on failure, assume it
 # force  - append -f to zpool import
 # strict - legacy behavior, drop to an emergency shell on failure

--- a/zfsbootmenu/pre-init/zfsbootmenu-preinit.sh
+++ b/zfsbootmenu/pre-init/zfsbootmenu-preinit.sh
@@ -42,5 +42,5 @@ EOF
 echo "ZFSBootMenu" > /proc/sys/kernel/hostname
 
 # https://busybox.net/FAQ.html#job_control
-ZFSBOOTMENU_CONSOLE=yes exec setsid \
+ZFSBOOTMENU_CONSOLE=yes setsid \
     bash -c "exec /libexec/zfsbootmenu-init <${control_term} >${control_term} 2>&1"


### PR DESCRIPTION
Fixes most of issues I encountered in https://github.com/zbm-dev/zfsbootmenu/issues/614

I understand that this fix is probably not very good since it possibly breaks something else, but I would be glad to adjust it based on the feedback.