### PR TITLE
docs/guides/alpine/: include nvme initramfs module by default

### DIFF
--- a/docs/guides/alpine/_include/zfs-config.rst
+++ b/docs/guides/alpine/_include/zfs-config.rst
@@ -20,7 +20,7 @@ Configure mkinitfs to load ZFS support
     .. code-block::
 
       echo "/etc/hostid" >> /etc/mkinitfs/features.d/zfshost.files
-      echo 'features="ata base keymap kms mmc scsi usb virtio zfs zfshost"' > /etc/mkinitfs/mkinitfs.conf
+      echo 'features="ata base keymap kms mmc scsi usb virtio nvme zfs zfshost"' > /etc/mkinitfs/mkinitfs.conf
 
   .. group-tab:: Encrypted
 


### PR DESCRIPTION
add nvme to unencrypted instructions as well.

ref: b238a357f4a9bba260ae97bfe5d5abd7b84668ed