### PR TITLE
Fix InitCPIOHookDirs parent key in host contaner build documentation

### DIFF
--- a/docs/general/container-building/example.rst
+++ b/docs/general/container-building/example.rst
@@ -192,7 +192,7 @@ custom modules:
 
 .. code-block:: yaml
 
-  General:
+  Global:
     InitCPIOHookDirs:
       - /build/initcpio
       - /usr/lib/initcpio


### PR DESCRIPTION
Build script [expects](https://github.com/zbm-dev/zfsbootmenu/blob/dc755a87a2397383cb8a0304acf446df60530950/bin/generate-zbm#L172) the `InitCPIOHookDirs` to be in the "Global" section, but the docs say to put it "General" section, which makes hooks unavailable when building the image.