### PR TITLE
Update zfs-config.rst

### DIFF
--- a/docs/guides/alpine/_include/zfs-config.rst
+++ b/docs/guides/alpine/_include/zfs-config.rst
@@ -6,7 +6,7 @@ Install ZFS
 
 .. code-block::
 
-  apk add zfs zfs-lts 
+  apk add zfs zfs-lts zfs-scripts
   rc-update add zfs-import sysinit
   rc-update add zfs-mount sysinit
 


### PR DESCRIPTION
Add zfs-scripts to packages installed. It is listed when setting up live environment but missing here. This leads to zpool errors after installation because /usr/share/zfs/compatibility.d is missing.