### PR TITLE
init.d/50-import-pools: tailor text if using a binary release

### DIFF
--- a/zfsbootmenu/init.d/50-import-pools
+++ b/zfsbootmenu/init.d/50-import-pools
@@ -93,9 +93,15 @@ while IFS=$'\t' read -r _pool _property; do
 done <<<"$( zpool get all -H -o name,property )"
 
 if [ "${unsupported}" -ne 0 ]; then
-  zerror "Unsupported features detected, Upgrade ZFS modules in ZFSBootMenu with generate-zbm"
+  if [ -n "${ZBM_RELEASE_BUILD}" ]; then
+    upgrade="Check for a new binary release of ZFSBootMenu"
+  else
+    upgrade="Upgrade ZFS modules in ZFSBootMenu with generate-zbm"
+  fi
+
+  zerror "Unsupported features detected, ${upgrade}"
   timed_prompt -m "$( colorize red 'Unsupported features detected')" \
-    -m "$( colorize red 'Upgrade ZFS modules in ZFSBootMenu with generate-zbm')"
+    -m "$( colorize red "${upgrade}" )"
 fi
 unset unsupported
 


### PR DESCRIPTION
Binary release users shouldn't be told to generate a new ZBM image.