### PR TITLE
dracut: explicitly require the bash module

### DIFF
--- a/etc/zfsbootmenu/dracut.conf.d/zfsbootmenu.conf
+++ b/etc/zfsbootmenu/dracut.conf.d/zfsbootmenu.conf
@@ -1,3 +1,3 @@
 nofsck="yes"
-add_dracutmodules+=" zfsbootmenu "
+add_dracutmodules+=" zfsbootmenu bash "
 omit_dracutmodules+=" btrfs zfs resume systemd systemd-initrd dracut-systemd plymouth dash "


### PR DESCRIPTION
On Void, and possibly other distributions, /bin/sh points to /bin/dash. When no specific shell module (bash, dash, busybox) is requested, the system /bin/sh is used by default. Because ZFSBootMenu blacklists dash, shell-interpreter is unable to be installed, which then blocks multiple other key/core dracut modules.

Fixes #690