### PR TITLE
bin/generate-zbm: remove gummiboot from default stub list

### DIFF
--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -687,7 +687,6 @@ sub createUEFIBundle {
     # For now, default stub locations are x86_64 only
     my @uefi_stub_defaults = qw(
       /usr/lib/systemd/boot/efi/linuxx64.efi.stub
-      /usr/lib/gummiboot/linuxx64.efi.stub
     );
 
     foreach my $stubloc (@uefi_stub_defaults) {

--- a/docs/general/uefi-booting.rst
+++ b/docs/general/uefi-booting.rst
@@ -118,11 +118,8 @@ The remaining keys in the ``EFI`` section allow control over where and how UEFI 
   or ``0``. See the :ref:`description of this key in manual page <config-components>` for more details about its
   behavior. Even when versioning is disabled, ``generate-zbm`` still makes a backup of your existing boot image by
   replacing its ``.EFI`` extension with ``-backup.EFI`` to provide a fallback.
-* ``Stub`` specifies the location of the UEFI stub loader required when creating a bundled executable. Both ``gummiboot``
-  and its descendant ``systemd-boot`` provide stub loaders; ``gummiboot``, for example, tends to store the loader at
-  ``/usr/lib/gummiboot/linuxx64.efi.stub``. If this key is omitted (as it is by default), ``dracut`` will attempt to
-  find either the ``systemd-boot`` or ``gummiboot`` version at their expected locations. This key is useful when
-  automatic detection fails.
+* ``Stub`` specifies the location of the UEFI stub loader required while creating a bundled executable when the default
+  location of the ``systemd-boot`` needs to be changed.
 
 In addition, two options in the ``Kernel`` section of the configuration file are used during bundle creation:
 

--- a/docs/man/generate-zbm.5.rst
+++ b/docs/man/generate-zbm.5.rst
@@ -120,7 +120,7 @@ EFI
 
 **Stub**
 
-  The path to the EFI stub loader used to boot the unified bundle. If not set, a default of either ``/usr/lib/systemd/boot/efi/linuxx64.efi.stub`` or ``/usr/lib/gummiboot/linuxx64.efi.stub`` is assumed.
+  The path to the EFI stub loader used to boot the unified bundle. If not set, a default of ``/usr/lib/systemd/boot/efi/linuxx64.efi.stub`` is assumed.
 
 **SplashImage**
 


### PR DESCRIPTION
gummiboot doesn't work with newer (6.6+?) kernels, so lets stop recommending it as a default. If you still want to use it, set EFI.Stub in your configuration file.

The testing scripts still reference the old gummiboot location as a fall back, but that's not unreasonable that we leave that in our testing infra.