### PR TITLE
Run zgenhostid without a static value

### DIFF
--- a/docs/guides/_include/zgenhostid.rst
+++ b/docs/guides/_include/zgenhostid.rst
@@ -3,4 +3,4 @@ Generate ``/etc/hostid``
 
 .. code-block::
 
-  zgenhostid -f 0x00bab10c
+  zgenhostid -f


### PR DESCRIPTION
When generating a new host id, a specific value should not be provided so that each host has a different unique host id.

https://openzfs.github.io/openzfs-docs/man/master/8/zgenhostid.8.html