### PR TITLE
zreport: handle hooks that run once and are completed

### DIFF
--- a/zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -2029,13 +2029,20 @@ zreport() {
 
   colorize orange "\n>> Enabled hooks\n"
   for hook in /libexec/hooks/*.d/*; do
-    [ -x "${hook}" ] && echo "* $( colorize green "${hook}")"
+    ENABLED=
+    if [[ "${hook}" =~ \.completed$ ]] ; then
+      hook="${hook//.completed/ (run once, completed)}"
+      ENABLED=1
+    fi
+    [ -x "${hook}" ] && ENABLED=1
+    [ -n "${ENABLED}" ] && echo "* $( colorize green "${hook}")"
   done
 
   colorize orange "\n>> Disabled hooks\n"
   for hook in /libexec/hooks/*.d/*; do
     [ -f "${hook}" ] || continue
     [ -x "${hook}" ] && continue
+    [[ "${hook}" =~ \.completed$ ]] && continue
     echo "* $( colorize red "${hook}")"
   done
 

--- a/zfsbootmenu/libexec/zfsbootmenu-run-hooks
+++ b/zfsbootmenu/libexec/zfsbootmenu-run-hooks
@@ -42,6 +42,7 @@ for _hook in "/libexec/hooks/${hook_stage}"/*; do
   if [ "${ONE_SHOT_HOOKS}" -eq 1 ] >/dev/null 2>&1; then
     zinfo "Disabling hook after execution: ${_hook}"
     chmod 000 "${_hook}"
+    mv "${_hook}" "${_hook}.completed"
   fi
 done
 


### PR DESCRIPTION
The hook report section uses `+x` to know if a hook is enabled - run once hooks lose `+x` after completion. Append `.completed` to the hook file name, and then do some trickery based on that in `zreport`.