### PR TITLE
zfsbootmenu-core.sh: fix instant timed prompts

### DIFF
--- a/zfsbootmenu/bin/zfsbootmenu
+++ b/zfsbootmenu/bin/zfsbootmenu
@@ -28,7 +28,7 @@ unset src sources
 mkdir -p "${BASE:=/zfsbootmenu}"
 
 while [ ! -e "${BASE}/initialized" ]; do
-  if ! timed_prompt -d 0 \
+  if ! timed_prompt -d -1 \
       -m "$( colorize red "ZFSBootMenu must be initialized to continue" )" \
       -r "initialize" \
       -e "abort     "; then

--- a/zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -1263,7 +1263,7 @@ has_resume_device() {
 }
 
 # getopts arguments:
-# -d  prompt countdown/delay; non-positive values will wait forever
+# -d  prompt countdown/delay; negative values will wait forever
 # -p  prompt with countdown timer (use %0.Xd as a placeholder for time)
 # -m+ message to be printed above the prompt, usable multiple times
 # -r  message to be prefixed with [RETURN] (accept)
@@ -1284,6 +1284,8 @@ timed_prompt() {
         elif [ "${delay}" -lt 0 ] >/dev/null 2>&1; then
           delay="30"
           infinite="yes"
+        elif [ "${delay}" -eq 0 ] >/dev/null 2>&1; then
+          return 0
         else
           zdebug "delay argument for timed_prompt is not numeric"
           return 0

--- a/zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -1281,7 +1281,7 @@ timed_prompt() {
         delay="${OPTARG:-0}"
         if [ "${delay}" -gt 0 ] >/dev/null 2>&1; then
           :
-        elif [ "${delay}" -le 0 ] >/dev/null 2>&1; then
+        elif [ "${delay}" -lt 0 ] >/dev/null 2>&1; then
           delay="30"
           infinite="yes"
         else


### PR DESCRIPTION
bin/zfsbootmenu cheats and passes a timeout of 0 seconds, which is an instant timeout / success. Protect that value and restrict infinite timeouts to negative numbers entirely.

This fixes `zbm.skip`.