### PR TITLE
aarch64 support: efi stub and devicetree selection

### DIFF
--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -15,6 +15,7 @@ use File::stat;
 use File::Path qw(make_path remove_tree);
 use File::Glob qw(:globally :nocase);
 use Sort::Versions;
+use Config;
 use bigint qw(hex);
 
 use Pod::Usage qw(pod2usage);
@@ -684,10 +685,12 @@ sub createUEFIBundle {
     }
   } else {
 
-    # For now, default stub locations are x86_64 only
-    my @uefi_stub_defaults = qw(
-      /usr/lib/systemd/boot/efi/linuxx64.efi.stub
-    );
+    my @uefi_stub_defaults;
+    if ( $Config{archname} =~ m/x86_64/ ) {
+      push( @uefi_stub_defaults, '/usr/lib/systemd/boot/efi/linuxx64.efi.stub' );
+    } elsif ( $Config{archname} =~ m/aarch64/ ) {
+      push( @uefi_stub_defaults, '/usr/lib/systemd/boot/efi/linuxaa64.efi.stub' );
+    }
 
     foreach my $stubloc (@uefi_stub_defaults) {
       if ( -f $stubloc ) {
@@ -769,6 +772,39 @@ sub createUEFIBundle {
     # only supported with systemd-boot's efistub,
     # but gummiboot doesn't care if the section exists
     $uki_offset = addBundleSection( \@cmd, ".splash", $config{EFI}{SplashImage}, $uki_offset, $uki_alignment );
+  }
+
+  if ( has_value $config{EFI}{DeviceTree} ) {
+    my $dtb_try;
+
+    if ( $config{EFI}{DeviceTree} =~ m,^/, ) {
+      if ( $config{EFI}{DeviceTree} =~ m/\Q%{kernel}/ ) {
+
+        # Possibly a templated file path
+        $dtb_try = $config{EFI}{DeviceTree};
+        $dtb_try =~ s/\Q%{kernel}/$runConf{kernel_version}/;
+      } else {
+
+        # Possibly an absolute path to a file
+        $dtb_try = $config{EFI}{DeviceTree};
+      }
+    } else {
+
+      # Possibly a partial path
+      $dtb_try = sprintf( "/boot/dtbs/dtbs-%s/%s", $runConf{kernel_version}, $config{EFI}{DeviceTree} );
+    }
+
+    if ( has_value $dtb_try ) {
+      if ( -f $dtb_try ) {
+        $uki_offset = addBundleSection( \@cmd, ".dtb", $dtb_try, $uki_offset, $uki_alignment );
+      } else {
+        printf "EFI.DeviceTree key set to '%s', file not found at '%s'\n", $config{EFI}{DeviceTree}, $dtb_try;
+        exit 1;
+      }
+    } else {
+      printf "EFI.DeviceTree key set to '%s', but no DeviceTree file could be found\n", $config{EFI}{DeviceTree};
+      exit 1;
+    }
   }
 
   $uki_offset = addBundleSection( \@cmd, ".initrd", $initramfs, $uki_offset, $uki_alignment );

--- a/docs/man/generate-zbm.5.rst
+++ b/docs/man/generate-zbm.5.rst
@@ -126,6 +126,14 @@ EFI
 
   The path to a bitmap image file (BMP) to use as a splash image before ZFSBootMenu loads. Only works if using systemd-boot's EFI stub loader. The ZFSBootMenu logo is available in BMP format at ``/usr/share/examples/zfsbootmenu/splash.bmp``.
 
+**DeviceTree**
+
+  The path to a device-tree file that, when specified, will be embedded in the EFI bundle. The path may be relative or absolute.
+
+  Absolute paths may contain a template placeholder, *%{kernel}*, that will be replaced with the kernel version that *generate-zbm* builds into the EFI bundle.
+
+  Relative paths are interpreted as children of the path */boot/dtbs/dtbs-%{kernel}/*, a well-known location used by Void Linux (and possibly other distributions) to store device-tree files for installed kernels. The placeholder *%{kernel}* in the implicit prefix behaves as the template placeholder in an absolute path. An explicit template placeholder is not supported in relative paths.
+
 EXAMPLE
 =======
 

--- a/docs/man/zfsbootmenu.7.rst
+++ b/docs/man/zfsbootmenu.7.rst
@@ -248,6 +248,28 @@ By default, ZFSBootMenu only shows boot environments with the property *mountpoi
 
   When **org.zfsbootmenu:keysource** is a mountable ZFS filesystem, before prompting for a passphrase when *keylocation* is not set to *prompt*, ZFSBootMenu will attempt to mount **<filesystem>** (unlocking that, if necessary) and search for the key file within **<filesystem>**. When **<filesystem>** specifies a *mountpoint* property that is not *none* or *legacy*, the specified mount point will be stripped (if possible) from the beginning of any *keylocation* property to attempt to identify a key at the point where it would normally be mounted. If no file exists at the stripped path (or the *mountpoint* specifies *none* or *legacy*), keys will be sought at the full path of *keylocation* relative to **<filesystem>**. If a key is found at either location, it will be copied to the initramfs. The copy in the initramfs will be used to decrypt the original boot environment. Copied keys are retained until ZFSBootMenu boots an environment, so a single password prompt can be sufficient to unlock several pools with the same *keysource* or prevent prompts from reappearing when the pool must be exported and reimported (for example, to alter boot parameters from within ZFSBootMenu).
 
+**org.zfsbootmenu:devicetree=<devicetree file definition>**
+
+  If specified, this provides the path to a device-tree file that will be loaded when ZFSBootMenu loads and boots an environment. The path may be relative or absolute.
+
+  Absolute paths may contain a template placeholder, *%{kernel}*, that will be replaced with the version of the kernel that will be booted.
+
+  Relative paths are interpreted as children of the path */boot/dtbs/dtbs-%{kernel}/*, a well-known location used by Void Linux (and possibly other distributions) to store device-tree files for installed kernels. The placeholder *%{kernel}* in the implicit prefix behaves as the template placeholder in an absolute path. An explicit template placeholder is not supported in relative paths.
+
+  Whether relative or absolute, the device-tree path is always interpreted within the environment to be booted.
+
+  **/templated/path/to/%{kernel}/platform.dtb**
+
+    The value *%{kernel}* in the property will be replaced with the kernel version that is to be launched from the boot environment.
+
+  **short/path/platform.dtb**
+
+    This value is appended to */boot/dtbs/dtbs-%{kernel}/*, a well-known path used by Void Linux and possibly other distributions.
+
+  **/absolute/path/to/platform.dtb**
+
+    This is the absolute path to a device tree file, regardless of the kernel that is to be launched.
+
 .. _zbm-dracut-options:
 .. _zbm-mkinitcpio-options:
 


### PR DESCRIPTION
generate-zbm now understands the `EFI.DeviceTree` key. This key can contain one of three possible values:

1) /absolute/path/%{kernel}/to/device-tree-file.dtb 
2) /absolute/path/to/device-tree-file.dtb
3) partial/path/device-tree-file.dtb

If found, %{kernel} is replaced with the kernel version being built in to the EFI asset. Partial paths are appended to `/boot/dtbs/dtb-$kernel/`, a well-known path for device tree files used by Void Linux.

Inside ZFSBootMenu, the `org.zfsbootmenu:devicetree` property is read. The values of this property are handled in the same order/priority as `EFI.DeviceTree`.

Documentation will be written and appended to this PR once the overall design of this support is accepted.