### PR TITLE
docs: copy dropbear keys and config instead of symlink

### DIFF
--- a/docs/general/container-building/example.rst
+++ b/docs/general/container-building/example.rst
@@ -241,24 +241,15 @@ Make sure that the build container installs the packages necessary to provide ``
 
   echo "BUILD_ARGS+=( -p dropbear -p psmisc )" >> /etc/zfsbootmenu/zbm-builder.conf
 
-Finally, add a "terraform" script to link the expected ``/etc/dropbear`` directory to that in the build directory::
+Finally, add a "terraform" script to copy contents to the expected ``/etc/dropbear`` directory from the build directory::
 
   cat > /etc/zfsbootmenu/rc.d/dropbear <<EOF
   #!/bin/sh
 
   [ -d /build/dropbear ] || exit 0
 
-  if [ -d /etc/dropbear ] && [ ! -L /etc/dropbear ]; then
-      if ! rmdir /etc/dropbear; then
-          echo "ERROR: failed to remove existing /etc/dropbear directory"
-          exit 1
-      fi
-  fi
-
-  if ! ln -Tsf /build/dropbear /etc/dropbear; then
-      echo "ERROR: failed to make /etc/dropbear symlink"
-      exit 1
-  fi
+  mkdir -p /etc/dropbear
+  cp -R /build/dropbear/* /etc/dropbear/
   EOF
 
   chmod 755 /etc/zfsbootmenu/rc.d/dropbear

--- a/docs/general/container-building/example.rst
+++ b/docs/general/container-building/example.rst
@@ -232,7 +232,7 @@ unavailble in the container. Instead, simply copy a desired ``authorized_keys`` 
 ``/etc/zfsbootmenu/dropbear/root_key``. Alternatively, dynamism can be preserved by relying on bind-mounting a specific
 ``authorized_keys`` file into the build container::
 
-  echo "RUNTIME_ARGS+=( -v /home/${dropbear_user}/.ssh/authorized_keys:/authorized_keys:ro ) >> /etc/zfsbootmenu/zbm-builder.conf
+  echo "RUNTIME_ARGS+=( -v /home/${dropbear_user}/.ssh/authorized_keys:/authorized_keys:ro )" >> /etc/zfsbootmenu/zbm-builder.conf
   ln -s /authorized_keys /etc/zfsbootmenu/dropbear/root_key
 
 Replace ``${dropbear_user}`` with the desired user whose ``authorized_keys`` file should govern access to ZFSBootMenu.


### PR DESCRIPTION
In the container build, copy the contents of the dropbear folder into the expected folder instead of symlinking as the mkinitcpio function `add_full_dir` does not handle symlinked folders properly

Full discussion in https://github.com/zbm-dev/zfsbootmenu/discussions/724

Also fix quick typo: missing quote