### PR TITLE
docs: fix error on host-specific container build dropbear path

### DIFF
--- a/docs/general/container-building/example.rst
+++ b/docs/general/container-building/example.rst
@@ -214,7 +214,7 @@ Rather than creating keys (and optional configuration) in ``/etc/dropbear``, cre
 
   ## Not strictly required; see note below
   for keytype in rsa ecdsa ed25519; do
-      dropbearkey -t "${keytype}" -f "/etc/dropbear/dropbear_${keytype}_host_key"
+      dropbearkey -t "${keytype}" -f "/etc/zfsbootmenu/dropbear/dropbear_${keytype}_host_key"
   done
 
   ## If desired


### PR DESCRIPTION
[The Container Build docs](https://docs.zfsbootmenu.org/en/latest/general/container-building/example.html#configuring-dropbear) page probably copied some code snippet from [this other page](https://docs.zfsbootmenu.org/en/latest/general/remote-access.html#configuring-dropbear) without updating the path for the container build.

The containerized build uses a slightly different directory. This makes a minor update to fix the code snippet that works on my machine.