### PR TITLE
zfsbootmenu: extend zbm.prefer to set bootfs

### DIFF
--- a/docs/man/zfsbootmenu.7.rst
+++ b/docs/man/zfsbootmenu.7.rst
@@ -20,17 +20,18 @@ These options are set on the kernel command line when booting the initramfs or U
 
 **zbm.prefer**
 
-  ZFSBootMenu will attempt to import as many pools as possible to identify boot environments and will, by default, look for the *bootfs* property on the first imported pool (sorted alphabetically) to select the default boot environment. This option controls this behavior.
+  ZFSBootMenu attempts to import all detected pools by default, with the *bootfs* property on the first pool (sorted alphabetically) used to select the default boot environment. Providing a *pool* name for this parameter will override the pool import order. Providing a *dataset* for this parameter will override both the pool import order and the default boot environment.
 
-  **zbm.prefer=<pool>**
 
-    The simplest form attempts to import **<pool>** before any other pool. The *bootfs* value from this pool will control the default boot environment.
+  **zbm.prefer=<pool|dataset>**
 
-  **zbm.prefer=<pool>!**
+    The simplest form attempts to import **<pool>** or the pool component of a **<dataset>** before any other pool. If a *dataset* is provided, that will be used as the boot environment if it exists.
+
+  **zbm.prefer=<pool|dataset>!**
 
     If a literal *!* has been appended to the pool name, ZFSBootMenu will insist on successfully importing the named pool before attempting to import any others.
 
-  **zbm.prefer=<pool>!!**
+  **zbm.prefer=<pool|dataset>!!**
 
     If a literal *!!* has been appended to the pool name, ZFSBootMenu will insist on successfully importing the named pool and no others.
 

--- a/zfsbootmenu/init.d/50-import-pools
+++ b/zfsbootmenu/init.d/50-import-pools
@@ -105,17 +105,25 @@ if [ "${unsupported}" -ne 0 ]; then
 fi
 unset unsupported
 
-# Attempt to find the bootfs property
-# shellcheck disable=SC2086
-while read -r _bootfs; do
-  if [ "${_bootfs}" = "-" ]; then
-    BOOTFS=
+if [ -n "${zbm_prefer_bootfs}" ]; then
+  if is_zfs_filesystem "${zbm_prefer_bootfs}" ; then
+    BOOTFS="${zbm_prefer_bootfs}"
   else
-    BOOTFS="${_bootfs}"
-    break
+    zerror "bootfs value '${zbm_prefer_bootfs}' not a ZFS dataset"
   fi
-done <<<"$( zpool list -H -o bootfs "${zbm_prefer_pool:---}" )"
-unset _bootfs
+else
+  # Attempt to find the bootfs property
+  # shellcheck disable=SC2086
+  while read -r _bootfs; do
+    if [ "${_bootfs}" = "-" ]; then
+      BOOTFS=
+    else
+      BOOTFS="${_bootfs}"
+      break
+    fi
+  done <<<"$( zpool list -H -o bootfs "${zbm_prefer_pool:---}" )"
+  unset _bootfs
+fi
 
 if [ -n "${BOOTFS}" ]; then
   export BOOTFS

--- a/zfsbootmenu/pre-init/zfsbootmenu-preinit.sh
+++ b/zfsbootmenu/pre-init/zfsbootmenu-preinit.sh
@@ -28,6 +28,7 @@ export menu_timeout='${menu_timeout}'
 export loglevel='${loglevel}'
 export zbm_prefer_pool='${zbm_prefer_pool}'
 export zbm_require_pool='${zbm_require_pool}'
+export zbm_prefer_bootfs='${zbm_prefer_bootfs}'
 export default_hostid=00bab10c
 export zbm_sort='${zbm_sort}'
 export zbm_set_hostid='${zbm_set_hostid}'


### PR DESCRIPTION
Other bootloaders, such as `rEFInd`, can now be used to drive the boot process by specifying a dataset from which to boot. `zbm.prefer` now accepts a full dataset path, with the previous `!` and `!!` modifiers still applying to the pool portion of the dataset.

This closes https://github.com/zbm-dev/zfsbootmenu/discussions/738