### PR TITLE
AlmaLinux 9

### DIFF
--- a/docs/guides/almalinux.rst
+++ b/docs/guides/almalinux.rst
@@ -1,0 +1,7 @@
+AlmaLinux
+======
+
+.. toctree::
+  :titlesonly:
+
+  almalinux/alma9

--- a/docs/guides/almalinux/_include/alma-config.rst
+++ b/docs/guides/almalinux/_include/alma-config.rst
@@ -1,0 +1,25 @@
+Configure Alma
+--------------------------
+
+Set hostname
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  hostname AlmaRocks
+  hostname > /etc/hostname
+
+Fix SELinux filesystem labels
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  fixfiles -F -f relabel
+
+Create initial admin user
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  adduser -G wheel fred
+  passwd fred

--- a/docs/guides/almalinux/_include/commandline.rst
+++ b/docs/guides/almalinux/_include/commandline.rst
@@ -1,0 +1,3 @@
+.. code-block::
+
+   zfs set org.zfsbootmenu:commandline="quiet rhgb" zroot/ROOT

--- a/docs/guides/almalinux/_include/configure-gen-zbm.rst
+++ b/docs/guides/almalinux/_include/configure-gen-zbm.rst
@@ -1,0 +1,17 @@
+Configure :doc:`generate-zbm(5) </man/generate-zbm.5>` by ensuring that the following keys appear in
+``/etc/zfsbootmenu/config.yaml``:
+
+.. code-block:: yaml
+
+  Global:
+    ManageImages: true
+    BootMountPoint: /boot/efi
+  Components:
+     Enabled: false
+     Versions: false
+  EFI:
+    ImageDir: /boot/efi/EFI/zbm
+    Enabled: true
+  Kernel:
+    CommandLine: quiet loglevel=0
+    Version: "*.x86_64"

--- a/docs/guides/almalinux/_include/distro-install.rst
+++ b/docs/guides/almalinux/_include/distro-install.rst
@@ -1,0 +1,38 @@
+Install Alma 
+--------------
+
+.. parsed-literal::
+
+  dnf --installroot=/mnt --releasever=\ |releasever| -y groupinstall "Minimal Install"
+
+Copy files into the new install
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+  .. group-tab:: Unencrypted
+
+    .. code-block:: bash
+
+      cp -L /etc/resolv.conf /mnt/etc
+      cp /etc/hostid /mnt/etc
+
+  .. group-tab:: Encrypted
+
+    .. code-block:: bash
+
+      cp -L /etc/resolv.conf /mnt/etc
+      cp /etc/hostid /mnt/etc
+      mkdir -p /mnt/etc/zfs
+      cp /etc/zfs/zroot.key /mnt/etc/zfs
+
+Chroot into the new OS
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  mount -t proc proc /mnt/proc
+  mount -t sysfs sys /mnt/sys
+  mount -B /dev /mnt/dev
+  mount -t devpts pts /mnt/dev/pts
+  chroot /mnt /bin/bash

--- a/docs/guides/almalinux/_include/efi-boot-method.rst
+++ b/docs/guides/almalinux/_include/efi-boot-method.rst
@@ -1,0 +1,22 @@
+Configure EFI boot entries
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+   mount -t efivarfs efivarfs /sys/firmware/efi/efivars
+
+.. tabs::
+
+  .. group-tab:: Direct
+
+    .. include:: ../_include/configure-efibootmgr.rst
+  
+  .. group-tab:: rEFInd
+
+    .. code-block::
+
+      dnf install -y refind 
+
+    .. include:: ../_include/configure-refind.rst
+
+.. include:: ../_include/efi-seealso.rst

--- a/docs/guides/almalinux/_include/live-environment.rst
+++ b/docs/guides/almalinux/_include/live-environment.rst
@@ -1,0 +1,24 @@
+Configure Live Environment
+--------------------------
+
+Switch to a root account
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  sudo -i
+
+.. include:: ../_include/os-release.rst
+
+Install updated ZFS packages
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+   dnf install -y https://zfsonlinux.org/epel/zfs-release-2-3$(rpm --eval "%{dist}").noarch.rpm
+   dnf install -y epel-release 
+   dnf install -y "kernel-devel-uname-r == $(uname -r)"
+   dnf install -y zfs gdisk
+   modprobe zfs
+
+.. include:: ../_include/zgenhostid.rst

--- a/docs/guides/almalinux/_include/zbm-install-deps.rst
+++ b/docs/guides/almalinux/_include/zbm-install-deps.rst
@@ -1,0 +1,14 @@
+Install all packages required to build a ZFSBootMenu image on Alma:
+
+.. code-block:: bash
+
+  dnf config-manager --set-enabled crb
+  dnf install -y \
+    systemd-boot-unsigned \
+    perl-YAML-PP \
+    perl-Sort-Versions \
+    perl-boolean \
+    git \
+    fzf \
+    mbuffer \
+    kexec-tools

--- a/docs/guides/almalinux/_include/zbm-install.rst
+++ b/docs/guides/almalinux/_include/zbm-install.rst
@@ -1,0 +1,35 @@
+Install ZFSBootMenu
+~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+  .. group-tab:: Prebuilt
+
+    .. include:: ../_include/zbm-install-prebuilt.rst
+
+  .. group-tab:: Source
+
+    .. include:: _include/zbm-install-deps.rst
+
+    .. include:: ../_include/zbm-install-source.rst
+
+    Configure :doc:`generate-zbm(5) </man/generate-zbm.5>` by ensuring that the following keys appear in
+    ``/etc/zfsbootmenu/config.yaml``:
+
+    .. code-block:: yaml
+
+        Global:
+            ManageImages: true
+            BootMountPoint: /boot/efi
+        Components:
+            Enabled: false
+            Versions: false
+        EFI:
+            ImageDir: /boot/efi/EFI/ZBM
+            Enabled: true
+        Kernel:
+            CommandLine: quiet loglevel=0
+            Version: "*.x86_64"
+
+
+    .. include:: ../_include/gen-initramfs.rst

--- a/docs/guides/almalinux/_include/zfs-config.rst
+++ b/docs/guides/almalinux/_include/zfs-config.rst
@@ -1,0 +1,58 @@
+ZFS Configuration
+-----------------
+
+Configure Dracut to load ZFS support
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+  .. group-tab:: Unencrypted
+
+    .. code-block::
+
+      cat << EOF > /etc/dracut.conf.d/zol.conf
+      nofsck="yes"
+      add_dracutmodules+=" zfs "
+      omit_dracutmodules+=" btrfs "
+      EOF
+
+  .. group-tab:: Encrypted
+
+    .. code-block::
+
+      cat << EOF > /etc/dracut.conf.d/zol.conf
+      nofsck="yes"
+      add_dracutmodules+=" zfs "
+      omit_dracutmodules+=" btrfs "
+      install_items+=" /etc/zfs/zroot.key "
+      EOF
+
+Install required packages
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  source /etc/os-release
+
+  dnf install -y https://zfsonlinux.org/epel/zfs-release-2-3$(rpm --eval "%{dist}").noarch.rpm
+  dnf install -y epel-release
+  dnf install -y zfs zfs-dracut sudo console-setup efibootmgr langpacks-en dosfstools
+  dnf install -y kernel kernel-devel
+
+
+.. note::
+
+  Ignore missing kernel messages, we haven't installed the kernel yet, when we do install the kernel after ZFS, dkms will install the module as it should.
+
+Regenerate initramfs
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block::
+
+  rpm -q kernel
+  dracut --force --kver 5.14.0-570.25.1.el9_6.x86_64
+
+.. note::
+
+  Find the newly installed kernel version using rpm, and then tell dracut to regenerate it's initramfs,
+  ignore any messages about "findmnt".

--- a/docs/guides/almalinux/alma9.rst
+++ b/docs/guides/almalinux/alma9.rst
@@ -1,0 +1,51 @@
+AlmaLinux 9 UEFI
+===================
+
+.. |distribution| replace:: almalinux
+.. |releasever| replace:: 9
+
+.. contents:: Contents
+  :depth: 2
+  :local:
+  :backlinks: none
+
+This guide can be used to install AlmaLinux onto a single disk with or without ZFS encryption.
+
+It assumes the following:
+
+* Your system uses UEFI to boot
+* Your system is x86_64
+* You're mildly comfortable with ZFS, EFI and discovering system facts on your own (``lsblk``, ``dmesg``, ``gdisk``, ...)
+
+Download `AlmaLinux 9 Live <https://repo.almalinux.org/almalinux/9/live/x86_64/AlmaLinux-9-latest-x86_64-Live-XFCE.iso>`_
+, write it to a USB drive and boot your system in EFI mode.
+
+.. include:: ../_include/efi-boot-check.rst
+
+.. include:: _include/live-environment.rst
+
+.. include:: ../_include/define-env.rst
+
+.. include:: ../_include/disk-preparation.rst
+
+.. include:: ../_include/pool-creation.rst
+
+.. include:: ../_include/create-filesystems.rst
+
+.. include:: ../_include/update-devices.rst
+
+.. include:: _include/distro-install.rst
+
+.. include:: _include/zfs-config.rst
+
+.. include:: _include/alma-config.rst
+
+.. include:: ../_include/zbm-setup.rst
+
+.. include:: ../_include/setup-esp.rst
+
+.. include:: _include/zbm-install.rst
+
+.. include:: _include/efi-boot-method.rst
+
+.. include:: ../_include/cleanup.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,6 +67,7 @@
   :hidden:
 
   guides/void-linux
+  guides/almalinux
   guides/alpine
   guides/chimera
   guides/debian


### PR DESCRIPTION
I've gone through and made a copy of the fedora guide but for AlmaLinux 9, I would also added AlmaLinux 10 but the ZFS RPMs aren't ready yet, but I think the process will effectively the same.

I've tested
 - Unencrypted
 - Encrypted
 - Prebuilt ZFSBootMenu
 - Compiled ZFSBootMenu