### PR TITLE
shellcheck: fix warnings from 0.11.0

### DIFF
--- a/testing/run.sh
+++ b/testing/run.sh
@@ -302,7 +302,7 @@ if ((FLAME)) ; then
   [ -e "${FIFO}.out" ] || mkfifo "${FIFO}.out"
   [ -e "${FIFO}.in" ] || mkfifo "${FIFO}.in"
 
-  #shellcheck disable=SC2034
+  #shellcheck disable=SC1064,SC1065,SC2034
   coproc perf_data ( sed 's,^.*\(trapdebug*\),\1,g' < "${FIFO}.out" > "${TESTDIR}/perfdata.log" )
   trap cleanup EXIT INT TERM
 

--- a/zfsbootmenu/libexec/zfsbootmenu-diff
+++ b/zfsbootmenu/libexec/zfsbootmenu-diff
@@ -66,6 +66,8 @@ if ! mnt="$( mount_zfs "${base_fs}" )" ; then
 fi
 
 zdebug "executing: zfs diff -F -H ${snapshot} ${diff_target}"
+
+# shellcheck disable=SC1064,SC1065
 coproc zfs_diff ( zfs diff -F -H "${snapshot}" "${diff_target}" )
 
 # Bash won't use an FD referenced in a variable on the left side of a pipe


### PR DESCRIPTION
CI/CD uses 0.11.0, Void is still on 0.10.0. Shellcheck doesn't seem to understand coprocs.