### PR TITLE
zfsbootmenu: add org.zfsbootmenu:readonly gate

### DIFF
--- a/docs/man/zfsbootmenu.7.rst
+++ b/docs/man/zfsbootmenu.7.rst
@@ -190,6 +190,10 @@ The following properties can be set at the pool level to control boot behavior.
 
   This must be set for automatic booting to function. When no **bootfs** property is detected, ZFSBootMenu will always display a selection menu.
 
+**org.zfsbootmenu:readonly**
+
+  When set to any value other than *-* or *off*, ZFSBootMenu operations which require the pool to be imported read-write will fail.
+
 ZFS Dataset Properties
 ======================
 


### PR DESCRIPTION
Pretty basic change. Add a pool property that, when set, will inhibit ZFSBootMenu from importing that pool read-write. This is intended to be used as a backup protection in the event that a hibernation image can't be detected on a hibernated system.