### PR TITLE
dracut: exclude clevis due to missing systemd module

### DIFF
--- a/etc/zfsbootmenu/dracut.conf.d/zfsbootmenu.conf
+++ b/etc/zfsbootmenu/dracut.conf.d/zfsbootmenu.conf
@@ -1,3 +1,3 @@
 nofsck="yes"
 add_dracutmodules+=" zfsbootmenu bash "
-omit_dracutmodules+=" btrfs zfs resume systemd systemd-initrd dracut-systemd plymouth dash "
+omit_dracutmodules+=" btrfs zfs resume systemd systemd-initrd dracut-systemd plymouth dash clevis "


### PR DESCRIPTION
If clevis is available, dracut will add it to the image. However, as dracut-systemd is already omitted, clevis will crash complaining of a missing environment variable.