### PR TITLE
zfsbootmenu: use fzf --raw when available

### DIFF
--- a/zfsbootmenu/install-helpers.sh
+++ b/zfsbootmenu/install-helpers.sh
@@ -99,6 +99,14 @@ create_zbm_conf() {
     has_border=1
   fi
 
+  # Check if fuzzy finder supports --raw flag
+  # Added in fzf 0.66.0
+
+  local has_raw
+  if echo "abc" | fzf -f "abc" --raw --exit-0 >/dev/null 2>&1; then
+    has_raw=1
+  fi
+
   local has_column
   if command -v column >/dev/null 2>&1 ; then
     has_column=1
@@ -132,6 +140,7 @@ create_zbm_conf() {
 	export HAS_DISABLED="${has_disabled}"
 	export HAS_BORDER="${has_border}"
 	export HAS_COLUMN="${has_column}"
+	export HAS_RAW="${has_raw}"
 	export ZBM_BUILDSTYLE="${ZBM_BUILDSTYLE}"
 	export ZBM_RELEASE_BUILD="${zfsbootmenu_release_build}"
 	EOF

--- a/zfsbootmenu/lib/fzf-defaults.sh
+++ b/zfsbootmenu/lib/fzf-defaults.sh
@@ -35,6 +35,15 @@ if [ ${loglevel:-4} -eq 7 ] ; then
   )
 fi
 
+if [ -n "${HAS_RAW}" ]; then
+  fuzzy_default_options+=(
+    "--raw"
+    "--bind" '"result:best"'
+    "--bind" '"up:up-match"'
+    "--bind" '"down:down-match"'
+  )
+fi
+
 export FUZZYSEL=fzf
 export PREVIEW_HEIGHT=2
 export FZF_DEFAULT_OPTS="${fuzzy_default_options[*]}"


### PR DESCRIPTION
Tested on an SDL/GTK EFI console in qemu, looks pretty decent. Might need the `gutter` character changed though, but that's fairly subjective.