### PR TITLE
zfsbootmenu: look less bad on BIOS consoles

### DIFF
--- a/zfsbootmenu/lib/fzf-defaults.sh
+++ b/zfsbootmenu/lib/fzf-defaults.sh
@@ -7,8 +7,9 @@
 
 # shellcheck disable=SC2016
 fuzzy_default_options=(
-  "--ansi" "--no-clear" "--cycle" "--color=16"
+  "--ansi" "--no-clear" "--cycle"
   "--layout=reverse-list" "--inline-info" "--tac"
+  "--color='base16,current-fg:red,selected-fg:magenta'"
   "--bind" '"alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} 1>/dev/null ]"'
   "--bind" '"ctrl-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} 1>/dev/null ]"'
   "--bind" '"ctrl-alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} 1>/dev/null ]"'
@@ -35,7 +36,7 @@ if [ ${loglevel:-4} -eq 7 ] ; then
   )
 fi
 
-if [ -n "${HAS_RAW}" ]; then
+if [ -n "${HAS_RAW}" ] && is_efi_system ; then
   fuzzy_default_options+=(
     "--raw"
     "--gutter-raw"  '" "'


### PR DESCRIPTION
FZF doesn't seem to handle `bright-` colors on BIOS consoles; which `--raw` mode makes use of by setting non-matching lines to gray (dim) text. Since our color options are so limited and it would take revamping all of the colors just to make non-matching lines look reasonable in raw mode; lets just disable that for BIOS systems. If you're in the niche position where you access the ZBM over a serial console or SSH for a BIOS system, you don't get raw mode. Thems the breaks.

This also sets the text color to magenta for lines that have been selected via tab, mostly used when selecting snapshots to diff.