### PR TITLE
docs/guides/fedora: use DNF5 syntax and update ZFS RPM packages

### DIFF
--- a/docs/guides/fedora/_include/zfs-config.rst
+++ b/docs/guides/fedora/_include/zfs-config.rst
@@ -44,7 +44,7 @@ Finally, install the ``dracut`` module necessary for importing pools at boot tim
 
   dnf install -y zfs-dracut
 
-  dnf config-manager --enable updates
+  dnf config-manager setopt updates.enabled=1
 
 
 Regenerate initramfs

--- a/docs/guides/fedora/_include/zfs-packages.rst
+++ b/docs/guides/fedora/_include/zfs-packages.rst
@@ -8,14 +8,18 @@ Disable the ``updates`` repository to ensure that the correct kernel headers are
 
 .. code-block::
 
-  dnf config-manager --disable updates
+  dnf config-manager setopt updates.enabled=0
 
 Install kernel headers and the OpenZFS package.
+
+.. note::
+
+  Refer to the `list of available zfs-release RPMs <https://github.com/zfsonlinux/zfsonlinux.github.com/tree/master/fedora>`_.
 
 .. code-block::
 
   dnf --releasever=${VERSION_ID} install -y \
-    https://zfsonlinux.org/fedora/zfs-release-2-5$(rpm --eval "%{dist}").noarch.rpm
+    https://zfsonlinux.org/fedora/zfs-release-3-0$(rpm --eval "%{dist}").noarch.rpm
 
   dnf install -y https://dl.fedoraproject.org/pub/fedora/linux/releases/${VERSION_ID}/Everything/x86_64/os/Packages/k/kernel-devel-$(uname -r).rpm
 


### PR DESCRIPTION
- Update dnf config-manager command with new DNF5 syntax
- Update to URL to latest ZFS RPM packages

Refer DNF5 docs here, which include an example for enabling a repository:
https://dnf5.readthedocs.io/en/latest/dnf5_plugins/config-manager.8.html#examples