### PR TITLE
zfsbootmenu-core.sh: do not cache unencrypted keysources

### DIFF
--- a/zfsbootmenu/lib/zfsbootmenu-core.sh
+++ b/zfsbootmenu/lib/zfsbootmenu-core.sh
@@ -1706,6 +1706,12 @@ be_keysource() {
     return 1;
   fi
 
+  if ! be_has_encroot "${keysrc}" >/dev/null 2>&1; then
+    zwarn "keysource ${keysrc} for ${fs} is not encrypted; ignoring"
+    echo ""
+    return 1;
+  fi
+
   echo "${keysrc}"
   return 0
 }


### PR DESCRIPTION
This needs testing.

I can't think of a single legitimate use for storing ZFS encryption keys on an unencrypted ZFS filesystem. People can do it if they want, but we don't need to help them make bad choices by copying their unencrypted keys via our caching mechanism.