### PR TITLE
zfsbootmenu: fix fzf color spec for the ancient ones

### DIFF
--- a/zfsbootmenu/lib/fzf-defaults.sh
+++ b/zfsbootmenu/lib/fzf-defaults.sh
@@ -9,7 +9,7 @@
 fuzzy_default_options=(
   "--ansi" "--no-clear" "--cycle"
   "--layout=reverse-list" "--inline-info" "--tac"
-  "--color='base16,current-fg:red,selected-fg:magenta'"
+  "--color='16,current-fg:red,selected-fg:magenta'"
   "--bind" '"alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} 1>/dev/null ]"'
   "--bind" '"ctrl-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} 1>/dev/null ]"'
   "--bind" '"ctrl-alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} 1>/dev/null ]"'


### PR DESCRIPTION
This color spec seems to work in an Ubuntu 25.10 container. I assume, but have not tested, that using 16 (documented as an alias for base16 in newer fzf) will work just fine for more current versions with or without --raw.

Fixes: #791.