### PR TITLE
releng/docker, testing/helpers/chroot-void: update Linux kernel versions

### DIFF
--- a/releng/docker/Dockerfile
+++ b/releng/docker/Dockerfile
@@ -16,12 +16,11 @@ LABEL org.opencontainers.image.authors="ZFSBootMenu Team, https://zfsbootmenu.or
 
 ARG XBPS_REPOS="https://repo-fastly.voidlinux.org/current"
 
-# Include the specified Void Linux kernel series in the image; kernel
-# series take the form linux<major>.<minor>
+# Include the specified Void Linux kernel series in the image;
+# kernel series take the form linux<major>.<minor>
 #
-# Default: linux5.10 linux5.15 linux6.1
 # (multiple entries must be seperated by spaces)
-ARG KERNELS="linux5.10 linux5.15 linux6.1"
+ARG KERNELS="linux6.6 linux6.12 linux6.18"
 # Update repos and install kernels and base dependencies.
 
 # Run the following within an external cache (/var/cache/xbps) for the

--- a/releng/docker/image-build.sh
+++ b/releng/docker/image-build.sh
@@ -28,7 +28,7 @@ usage() {
 	   series take the form <major>.<minor> and correspond to Void packages
 	   linux<kver> and linux<kver>-headers
 	
-	   Default: install 6.1, 6.6 and 6.12
+	   Default: install 6.6, 6.12, 6.18
 	
 	   (One version per argument; may be repeated as needed)
 	
@@ -122,7 +122,7 @@ fi
 
 # Use default kernel series when nothing was specified
 if [ "${#kern_series[@]}" -lt 1 ]; then
-  kern_series=( "linux6.1" "linux6.6" "linux6.12" )
+  kern_series=( "linux6.6" "linux6.12" "linux6.18" )
 fi
 
 # Populate the correspoding headers list

--- a/testing/helpers/chroot-void.sh
+++ b/testing/helpers/chroot-void.sh
@@ -34,7 +34,7 @@ for keyfile in /etc/zfs/*.key; do
   echo "install_items+=\" ${keyfile} \"" >> /etc/dracut.conf.d/zol.conf
 done
 
-: "${KERNEL:=linux6.1}"
+: "${KERNEL:=linux6.12}"
 
 xbps-install -y "${KERNEL}" "${KERNEL}-headers" dracut zfs
 


### PR DESCRIPTION
I assume current ZFS won't build with 6.18, but expect that ZFS 2.4.0 will. We should confirm and merge this after the ZFS 2.4.0 release but before we tag new builder images and cut a release.