### PR TITLE
zfsbootmenu: fix fzf colors for old systems, round two

### DIFF
--- a/zfsbootmenu/install-helpers.sh
+++ b/zfsbootmenu/install-helpers.sh
@@ -99,9 +99,15 @@ create_zbm_conf() {
     has_border=1
   fi
 
+  # Check if fuzzy finder supports optional --color arguments
+  # Added in fzf 0.52.0
+  local has_colors
+  if echo "abc" | fzf -f "abc" --color='current-fg:red,selected-fg:magenta' --exit-0 >/dev/null 2>&1; then
+    has_colors=1
+  fi
+
   # Check if fuzzy finder supports --raw flag
   # Added in fzf 0.66.0
-
   local has_raw
   if echo "abc" | fzf -f "abc" --raw --exit-0 >/dev/null 2>&1; then
     has_raw=1
@@ -140,6 +146,7 @@ create_zbm_conf() {
 	export HAS_DISABLED="${has_disabled}"
 	export HAS_BORDER="${has_border}"
 	export HAS_COLUMN="${has_column}"
+	export HAS_COLORS="${has_colors}"
 	export HAS_RAW="${has_raw}"
 	export ZBM_BUILDSTYLE="${ZBM_BUILDSTYLE}"
 	export ZBM_RELEASE_BUILD="${zfsbootmenu_release_build}"

--- a/zfsbootmenu/lib/fzf-defaults.sh
+++ b/zfsbootmenu/lib/fzf-defaults.sh
@@ -7,9 +7,8 @@
 
 # shellcheck disable=SC2016
 fuzzy_default_options=(
-  "--ansi" "--no-clear" "--cycle"
+  "--ansi" "--no-clear" "--cycle" "--color=16"
   "--layout=reverse-list" "--inline-info" "--tac"
-  "--color='16,current-fg:red,selected-fg:magenta'"
   "--bind" '"alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} 1>/dev/null ]"'
   "--bind" '"ctrl-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} 1>/dev/null ]"'
   "--bind" '"ctrl-alt-h:execute[ /libexec/zfsbootmenu-help -L ${HELP_SECTION:-main-screen} 1>/dev/null ]"'
@@ -26,13 +25,9 @@ if [ -n "${HAS_BORDER}" ]; then
   )
 fi
 
-# shellcheck disable=SC2016,SC2086
-if [ ${loglevel:-4} -eq 7 ] ; then
+if [ -n "${HAS_COLORS}" ]; then
   fuzzy_default_options+=(
-    "--bind" '"alt-t:execute[ /sbin/ztrace > ${control_term} ]"'
-    "--bind" '"ctrl-t:execute[ /sbin/ztrace > ${control_term} ]"'
-    "--bind" '"ctrl-alt-t:execute[ /sbin/ztrace > ${control_term} ]"'
-    "--bind" '"f12:execute[ /libexec/zfunc emergency_shell \"debugging shell\" > ${control_term} ]"'
+    "--color='current-fg:red,selected-fg:magenta'"
   )
 fi
 
@@ -45,6 +40,16 @@ if [ -n "${HAS_RAW}" ] && is_efi_system ; then
     "--bind" '"result:best"'
     "--bind" '"up:up-match"'
     "--bind" '"down:down-match"'
+  )
+fi
+
+# shellcheck disable=SC2016,SC2086
+if [ ${loglevel:-4} -eq 7 ] ; then
+  fuzzy_default_options+=(
+    "--bind" '"alt-t:execute[ /sbin/ztrace > ${control_term} ]"'
+    "--bind" '"ctrl-t:execute[ /sbin/ztrace > ${control_term} ]"'
+    "--bind" '"ctrl-alt-t:execute[ /sbin/ztrace > ${control_term} ]"'
+    "--bind" '"f12:execute[ /libexec/zfunc emergency_shell \"debugging shell\" > ${control_term} ]"'
   )
 fi
 


### PR DESCRIPTION
Fixes `fzf` in our Ubuntu test bed and likely Debian. Diff is a bit messy because I reordered the `HAS` conditionals to be grouped together.