### PR TITLE
docs: add link to a NixOS integration blog post

### DIFF
--- a/docs/guides/third-party.rst
+++ b/docs/guides/third-party.rst
@@ -15,3 +15,8 @@ Gentoo
 ------
 
 * `Gentoo Wiki: root on ZFS <https://wiki.gentoo.org/wiki/ZFS/rootfs>`_
+
+NixOS
+-----
+
+* `Sirn Thanabulpong: ZFSBootMenu on NixOS <https://grid.in.th/2024/12/zfsbootmenu_on_nixos/>`_


### PR DESCRIPTION
PR'ing this so that I can confirm the docs look good