### PR TITLE
zbm-builder.sh: Fix links to documentation

### DIFF
--- a/zbm-builder.sh
+++ b/zbm-builder.sh
@@ -86,8 +86,7 @@ OPTIONS:
 
 For more information, see documentation at
 
-  https://github.com/zbm-dev/zfsbootmenu/blob/master/README.md
-  https://github.com/zbm-dev/zfsbootmenu/blob/master/docs/BUILD.md
+  https://docs.zfsbootmenu.org/
 EOF
 }
 


### PR DESCRIPTION
The output of `./zbm-builder.sh -h` includes a link to <https://github.com/zbm-dev/zfsbootmenu/blob/master/docs/BUILD.md>, which hasn't existed since 31fc472.

This PR replaces both documentation links with a single link to <https://docs.zfsbootmenu.org/>.