### PR TITLE
docs: Fix nested list syntax in container-building

### DIFF
--- a/docs/general/container-building.rst
+++ b/docs/general/container-building.rst
@@ -114,9 +114,9 @@ The default behavior of ``zbm-builder.sh`` will:
 2. If ``./hostid`` does not exist, copy ``/etc/hostid`` (if it exists) to ``./hostid``.
 3. Spawn an ephemeral container from the builder image and run its build process:
 
-  1. Bind-mount the working directory into the container to expose local configurations to the builder
-  2. If ``./config.yaml`` exists, inform the builder to use that custom configuration instead of the default
-  3. Run the internal build script to produce output in the ``./build`` subdirectory
+   1. Bind-mount the working directory into the container to expose local configurations to the builder
+   2. If ``./config.yaml`` exists, inform the builder to use that custom configuration instead of the default
+   3. Run the internal build script to produce output in the ``./build`` subdirectory
 
 .. note::
 


### PR DESCRIPTION
In reStructuredText markup, nested lists are created by aligning the bullet/enumerator with the left edge of the text in the list item above it. For [enumerated lists][0], that means an indent of at least **3 spaces** is required, otherwise the indent is treated as a [block quote][1].

This PR fixes the indentation of emphemeral container steps in the `zbm-builder.sh` behavior description in
`docs/general/container-building.rst`, which removes the (presumably) unintended block quote.

[0]: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#enumerated-lists
[1]: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#block-quotes