### PR TITLE
zbm-builder.sh: Use -d for custom container CLI

### DIFF
--- a/docs/general/container-building.rst
+++ b/docs/general/container-building.rst
@@ -37,8 +37,8 @@ Dependencies
 ------------
 
 To build ZFSBootMenu images from a build container, either `podman <https://podman.io>`_ or
-`docker <https://www.docker.com>`_ is required. The development team prefers ``podman``, but ``docker`` may generally be
-substituted without consequence.
+`docker <https://www.docker.com>`_ is required. The development team prefers ``podman``, but ``docker`` or a
+compatible container utility may generally be substituted without consequence.
 
 If a custom build container is desired, `buildah <https://buildah.io>`_ and ``podman`` are generally required. A
 :zbm:`Dockerfile <releng/docker/Dockerfile>` is provided for convenience, but feature parity with the ``buildah``

--- a/zbm-builder.sh
+++ b/zbm-builder.sh
@@ -38,7 +38,9 @@ OPTIONS:
      Specify the path to a configuration file that will be sourced
      (Default: \${BUILD_DIRECTORY}/zbm-builder.conf, if it exists)
 
-  -d Force use of docker instead of podman
+  -d <container-frontend>
+     Use the specified front-end utility to launch the build container
+     (Default: podman if available, docker otherwise)
 
   -M <argument>
      Provide a comma-separated list of options to use for volume
@@ -119,7 +121,7 @@ else
   PODMAN="docker"
 fi
 
-CMDOPTS="b:dhi:l:L:c:M:O:HR"
+CMDOPTS="b:d:hi:l:L:c:M:O:HR"
 
 # First pass to get build directory and configuration file
 while getopts "${CMDOPTS}" opt; do
@@ -166,7 +168,7 @@ while getopts "${CMDOPTS}" opt; do
     b|c|h)
       ;;
     d)
-      PODMAN=docker
+      PODMAN="${OPTARG}"
       ;;
     i)
       BUILD_IMG="${OPTARG}"
@@ -202,7 +204,7 @@ done
 shift $((OPTIND-1))
 
 if ! command -v "${PODMAN}" >/dev/null 2>&1; then
-  echo "ERROR: this script requires podman or docker"
+  echo "ERROR: ${PODMAN} not found; use '-d' to specify a container front-end"
   exit 1
 fi
 


### PR DESCRIPTION
This PR changes the `-d` argument of `zbm-builder.sh` to accept an executable argument, which will be used in place of `podman` or `docker`. The container-building docs have been updated to mention the ability to use a `docker`-compatible CLI.

For example, to run the script using [nerdctl][0]:

```shell
./zbm-builder.sh -d nerdctl
```

The choice of container CLI follows this priority list:

1. `-d` argument
2. `PODMAN` variable in `zbm-builder.conf`
3. `podman`
4. `docker`

Specifying the `PODMAN` variable with `env` isn't supported, because the value would be overwritten by the value from `zbm-builder.conf` when it gets sourced.

[0]: https://github.com/containerd/nerdctl