### PR TITLE
docs: Fix default UEFI Executable location

### DIFF
--- a/docs/general/native-encryption.rst
+++ b/docs/general/native-encryption.rst
@@ -3,7 +3,7 @@ Native Encryption
 
 ZFSBootMenu can import pools or filesystems with native encryption enabled. If your boot environments are not encrypted
 but, for example, ``/home`` is, you will not receive a decryption prompt during boot. To ensure that you can decrypt
-your pool to load the kernel and initramfs, you'll need to you have the filesystem parameters configured correctly.
+your pool to load the kernel and initramfs, you'll need to have the filesystem parameters configured correctly.
 
 It's critical that ``keyformat`` is set to ``passphrase``, otherwise you'll be unable to enter the correct value in the
 bootloader. OpenZFS currently supports only one key, but in a way which ZFSBootMenu can exploit: if you configure the

--- a/docs/general/uefi-booting.rst
+++ b/docs/general/uefi-booting.rst
@@ -109,9 +109,8 @@ governs the creation of bundled UEFI executables. The default configuration disa
 The remaining keys in the ``EFI`` section allow control over where and how UEFI bundles are created:
 
 * ``ImageDir`` is the location where the bundle will be written, and should generally be a subdirectory of the ``EFI``
-  subdirectory of your EFI system partition. The default, ``/boot/efi/EFI/void``, is fine if the ESP is mounted at
-  ``/boot/efi`` (and you are either running Void Linux or don't care if the directory name matches your distribution
-  name).
+  subdirectory of your EFI system partition. The default, ``/boot/efi/EFI/zbm``, is fine if the ESP is mounted at
+  ``/boot/efi``.
 * ``Versions`` controls whether UEFI bundles include a version and revision number in their name and, if so, how many
   prior versioned executables are retained. Because the firmware is not automatically reconfigured to boot the latest
   version after runs of ``generate-zbm``, it is probably best to disabling ``Versions`` by setting its value to ``false``


### PR DESCRIPTION
With Commit 9c91afa, the default UEFI executable should be located at `/boot/efi/EFI/zbm` instead of `/boot/efi/EFI/void`.

Also a minor grammatical fix for native encryption documentation.