### PR TITLE
docs: list OpenWrt Clevis integration

### DIFF
--- a/docs/guides/third-party.rst
+++ b/docs/guides/third-party.rst
@@ -18,3 +18,10 @@ NixOS
 -----
 
 * `Sirn Thanabulpong: ZFSBootMenu on NixOS <https://grid.in.th/2024/12/zfsbootmenu_on_nixos/>`_
+
+OpenWrt
+-------
+
+* `zbm-openwrt-clevis <https://github.com/rdmitry0911/zbm-openwrt-clevis>`_ - an OpenWrt-based boot runtime that gates
+  unattended boot with TPM2/Clevis PCR policy, uses ZFSBootMenu to select and kexec a boot environment, and falls back
+  to authenticated OpenWrt login for manual reseal when measurements change.


### PR DESCRIPTION
## Summary

- Add `zbm-openwrt-clevis` to the third-party resources guide under an OpenWrt section.
- Describe it as an external OpenWrt-based boot runtime that gates unattended boot with TPM2/Clevis PCR policy, hands off through ZFSBootMenu, and falls back to authenticated OpenWrt login for manual reseal.

## Validation

- `git diff --check`
- `PATH=/tmp/zbm-docs-venv/bin:$PATH make -C docs html SPHINXOPTS='-W --keep-going'`
