### PR TITLE
bin/generate-zbm: fix globbing in versionedKernel

### DIFF
--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -527,8 +527,11 @@ sub versionedKernel {
     # Otherwise, try to glob
     my @kernels = sort versioncmp glob($pattern);
 
-    next unless @kernels;
-    return pop @kernels, false;
+    foreach my $candidate (@kernels) {
+      if ( -f $candidate ) {
+        return $candidate, false;
+      }
+    }
   }
 
   return;


### PR DESCRIPTION
If a specific kernel version is requested on aarch64, where the kernel is named `vmlinux` rather than `vmlinuz`, the `glob` function returns, *e.g.*,

    /boot/vmlinuz-6.18.43_1

even when that file doesn't exist. This shorts the loop over other potential prefixes and returns an invalid result. Rather than grabbing the first glob result blindly, it's better to verify that *some* valid result exists in this list, or move on to the next prefix.
    